### PR TITLE
Remove debug prints from LWIP

### DIFF
--- a/network/ipstacks/lwip/src/core/inet_chksum.c
+++ b/network/ipstacks/lwip/src/core/inet_chksum.c
@@ -51,8 +51,6 @@
 #include "lwip/def.h"
 #include "lwip/ip_addr.h"
 
-#include "util.h"
-
 #include <string.h>
 
 #ifndef LWIP_CHKSUM

--- a/network/ipstacks/lwip/src/core/ipv4/etharp.c
+++ b/network/ipstacks/lwip/src/core/ipv4/etharp.c
@@ -56,7 +56,6 @@
 #include "netif/ethernet.h"
 
 #include <string.h>
-#include "util.h"
 
 #ifdef LWIP_HOOK_FILENAME
 #include LWIP_HOOK_FILENAME
@@ -660,7 +659,6 @@ etharp_input(struct pbuf *p, struct netif *netif)
     LWIP_DEBUGF(ETHARP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_WARNING,
                 ("etharp_input: packet dropped, wrong hw type, hwlen, proto, protolen or ethernet type (%"U16_F"/%"U16_F"/%"U16_F"/%"U16_F")\n",
                  hdr->hwtype, (u16_t)hdr->hwlen, hdr->proto, (u16_t)hdr->protolen));
-    print("etharp_input: packet dropped, wrong hw type, hwlen, proto, protolen or ethernet type")
     ETHARP_STATS_INC(etharp.proterr);
     ETHARP_STATS_INC(etharp.drop);
     pbuf_free(p);

--- a/network/ipstacks/lwip/src/core/ipv4/ip4.c
+++ b/network/ipstacks/lwip/src/core/ipv4/ip4.c
@@ -445,7 +445,6 @@ ip4_input(struct pbuf *p, struct netif *inp)
   iphdr = (struct ip_hdr *)p->payload;
   if (IPH_V(iphdr) != 4) {
     LWIP_DEBUGF(IP_DEBUG | LWIP_DBG_LEVEL_WARNING, ("IP packet dropped due to bad version number %"U16_F"\n", (u16_t)IPH_V(iphdr)));
-    print("Bad version number");
     ip4_debug_print(p);
     pbuf_free(p);
     IP_STATS_INC(ip.err);
@@ -476,19 +475,16 @@ ip4_input(struct pbuf *p, struct netif *inp)
     if (iphdr_hlen < IP_HLEN) {
       LWIP_DEBUGF(IP_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
                   ("ip4_input: short IP header (%"U16_F" bytes) received, IP packet dropped\n", iphdr_hlen));
-      print("short IP header");
     }
     if (iphdr_hlen > p->len) {
       LWIP_DEBUGF(IP_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
                   ("IP header (len %"U16_F") does not fit in first pbuf (len %"U16_F"), IP packet dropped.\n",
                    iphdr_hlen, p->len));
-      print("Long IP header");
     }
     if (iphdr_len > p->tot_len) {
       LWIP_DEBUGF(IP_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
                   ("IP (len %"U16_F") is longer than pbuf (len %"U16_F"), IP packet dropped.\n",
                    iphdr_len, p->tot_len));
-      print("Long IP header");
     }
     /* free (drop) packet pbufs */
     pbuf_free(p);
@@ -611,7 +607,6 @@ ip4_input(struct pbuf *p, struct netif *inp)
       /* packet source is not valid */
       LWIP_DEBUGF(IP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_WARNING, ("ip4_input: packet source is not valid.\n"));
       /* free (drop) packet pbufs */
-      print("invalid packet source");
       pbuf_free(p);
       IP_STATS_INC(ip.drop);
       MIB2_STATS_INC(mib2.ipinaddrerrors);

--- a/network/ipstacks/lwip/src/core/pbuf.c
+++ b/network/ipstacks/lwip/src/core/pbuf.c
@@ -243,7 +243,6 @@ pbuf_alloc(pbuf_layer layer, u16_t length, pbuf_type type)
         u16_t qlen;
         q = (struct pbuf *)memp_malloc(MEMP_PBUF_POOL);
         if (q == NULL) {
-          print("Pbuf pool is empty!\n");
           PBUF_POOL_IS_EMPTY();
           /* free chain so far allocated */
           if (p) {
@@ -279,14 +278,12 @@ pbuf_alloc(pbuf_layer layer, u16_t length, pbuf_type type)
       /* bug #50040: Check for integer overflow when calculating alloc_len */
       if ((payload_len < LWIP_MEM_ALIGN_SIZE(length)) ||
           (alloc_len < LWIP_MEM_ALIGN_SIZE(length))) {
-        print("payload_len < length || alloc_len < length\n");
         return NULL;
       }
 
       /* If pbuf is to be allocated in RAM, allocate memory for it. */
       p = (struct pbuf *)mem_malloc(alloc_len);
       if (p == NULL) {
-        print("pbuf_alloc PBUF_RAM: mem_malloc failed\n");
         return NULL;
       }
       pbuf_init_alloced_pbuf(p, LWIP_MEM_ALIGN((void *)((u8_t *)p + SIZEOF_STRUCT_PBUF + offset)),
@@ -335,7 +332,6 @@ pbuf_alloc_reference(void *payload, u16_t length, pbuf_type type)
   /* only allocate memory for the pbuf structure */
   p = (struct pbuf *)memp_malloc(MEMP_PBUF);
   if (p == NULL) {
-    print("pbuf_alloc_reference: Could not allocate MEMP_PBUF\n");
     LWIP_DEBUGF(PBUF_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
                 ("pbuf_alloc_reference: Could not allocate MEMP_PBUF for PBUF_%s.\n",
                  (type == PBUF_ROM) ? "ROM" : "REF"));

--- a/network/ipstacks/lwip/src/core/tcp_in.c
+++ b/network/ipstacks/lwip/src/core/tcp_in.c
@@ -145,7 +145,6 @@ tcp_input(struct pbuf *p, struct netif *inp)
   if (p->len < TCP_HLEN) {
     /* drop short packets */
     LWIP_DEBUGF(TCP_INPUT_DEBUG, ("tcp_input: short packet (%"U16_F" bytes) discarded\n", p->tot_len));
-    print("TCP Short packet");
     TCP_STATS_INC(tcp.lenerr);
     goto dropped;
   }
@@ -177,7 +176,6 @@ tcp_input(struct pbuf *p, struct netif *inp)
   hdrlen_bytes = TCPH_HDRLEN_BYTES(tcphdr);
   if ((hdrlen_bytes < TCP_HLEN) || (hdrlen_bytes > p->tot_len)) {
     LWIP_DEBUGF(TCP_INPUT_DEBUG, ("tcp_input: invalid header length (%"U16_F")\n", (u16_t)hdrlen_bytes));
-    print("TCP invalid header length");
     TCP_STATS_INC(tcp.lenerr);
     goto dropped;
   }
@@ -211,7 +209,6 @@ tcp_input(struct pbuf *p, struct netif *inp)
     if (opt2len > p->next->len) {
       /* drop short packets */
       LWIP_DEBUGF(TCP_INPUT_DEBUG, ("tcp_input: options overflow second pbuf (%"U16_F" bytes)\n", p->next->len));
-      print("TCP options overflow second pbuf");
       TCP_STATS_INC(tcp.lenerr);
       goto dropped;
     }
@@ -242,7 +239,6 @@ tcp_input(struct pbuf *p, struct netif *inp)
     if (tcplen < p->tot_len) {
       /* u16_t overflow, cannot handle this */
       LWIP_DEBUGF(TCP_INPUT_DEBUG, ("tcp_input: length u16_t overflow, cannot handle this\n"));
-      print("TCP length u16_t overflow");
       TCP_STATS_INC(tcp.lenerr);
       goto dropped;
     }

--- a/network/ipstacks/lwip/src/core/udp.c
+++ b/network/ipstacks/lwip/src/core/udp.c
@@ -62,7 +62,6 @@
 #include "lwip/stats.h"
 #include "lwip/snmp.h"
 #include "lwip/dhcp.h"
-#include "util.h"
 #include <string.h>
 
 #ifndef UDP_LOCAL_PORT_RANGE_START
@@ -216,7 +215,6 @@ udp_input(struct pbuf *p, struct netif *inp)
     /* drop short packets */
     LWIP_DEBUGF(UDP_DEBUG,
                 ("udp_input: short UDP datagram (%"U16_F" bytes) discarded\n", p->tot_len));
-    print("udp_input: short UDP datagram\n")
     UDP_STATS_INC(udp.lenerr);
     UDP_STATS_INC(udp.drop);
     MIB2_STATS_INC(mib2.udpinerrors);
@@ -756,7 +754,6 @@ udp_sendto_if_src_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *d
 
   /* packet too large to add a UDP header without causing an overflow? */
   if ((u16_t)(p->tot_len + UDP_HLEN) < p->tot_len) {
-    print("p->tot_len + UDP_HLEN < p->tot_len\n");
     return ERR_MEM;
   }
   /* not enough space to add an UDP header to first pbuf in given p chain? */
@@ -765,7 +762,6 @@ udp_sendto_if_src_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *d
     q = pbuf_alloc(PBUF_IP, UDP_HLEN, PBUF_RAM);
     /* new header pbuf could not be allocated? */
     if (q == NULL) {
-      print("udp_send could not allocate header\n");
       LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_SERIOUS, ("udp_send: could not allocate header\n"));
       return ERR_MEM;
     }

--- a/network/ipstacks/lwip/src/netif/ethernet.c
+++ b/network/ipstacks/lwip/src/netif/ethernet.c
@@ -48,7 +48,6 @@
 #include "lwip/etharp.h"
 #include "lwip/ip.h"
 #include "lwip/snmp.h"
-#include "util.h"
 #include <string.h>
 
 #include "netif/ppp/ppp_opts.h"
@@ -180,7 +179,6 @@ ethernet_input(struct pbuf *p, struct netif *netif)
                     ("ethernet_input: IPv4 packet dropped, too short (%"U16_F"/%"U16_F")\n",
                      p->tot_len, next_hdr_offset));
         LWIP_DEBUGF(ETHARP_DEBUG | LWIP_DBG_TRACE, ("Can't move over header in packet"));
-        print("ethernet_input ipv4 packet too short\n");
         goto free_and_return;
       } else {
         /* pass to IP layer */


### PR DESCRIPTION
Most of these are just duplicates of existing LWIP debug prints so if they are needed it would be better to fix the originals.

This also removes a dependency on util.h which is desirable because util.h is a grab-bag of echo server stuff we should be trying to reorganise.