### PR TITLE
Update ethernet components and OdroidC4 driver to latest protocol

### DIFF
--- a/network/components/copy.c
+++ b/network/components/copy.c
@@ -1,6 +1,7 @@
 #include <microkit.h>
 #include <sddf/network/shared_ringbuffer.h>
 #include "util.h"
+#include "fence.h"
 #include <string.h>
 #include <stdbool.h>
 
@@ -21,23 +22,27 @@ uintptr_t uart_base;
 #define NUM_BUFFERS 512
 #define SHARED_DMA_SIZE (BUF_SIZE * NUM_BUFFERS)
 
+#define _unused(x) ((void)(x))
+
 ring_handle_t rx_ring_mux;
 ring_handle_t rx_ring_cli;
 
 void process_rx_complete(void)
 {
-    uint64_t enqueued = 0;
+    bool enqueued = false;
+    process_rx_complete_:
     // We only want to copy buffers if all the dequeues and enqueues will be successful
     while (!ring_empty(rx_ring_mux.used_ring) &&
             !ring_empty(rx_ring_cli.free_ring) &&
             !ring_full(rx_ring_mux.free_ring) &&
             !ring_full(rx_ring_cli.used_ring)) {
 
-        uintptr_t m_addr, c_addr = 0;
-        unsigned int m_len, c_len = 0;
+        uintptr_t m_addr = 0, c_addr = 0;
+        unsigned int m_len = 0, c_len = 0;
         void *cookie = NULL;
         void *cookie2 = NULL;
         int err;
+        _unused(err);
 
         err = dequeue_used(&rx_ring_mux, &m_addr, &m_len, &cookie);
         assert(!err);
@@ -75,48 +80,40 @@ void process_rx_complete(void)
         err = enqueue_free(&rx_ring_mux, m_addr, BUF_SIZE, cookie);
         assert(!err);
 
-        enqueued += 1;
+        enqueued = true;
     }
+    
+    rx_ring_mux.used_ring->notify_reader = true;
+
+    if (!ring_empty(rx_ring_mux.used_ring)) rx_ring_cli.free_ring->notify_reader = true;
+    else rx_ring_cli.free_ring->notify_reader = false;
+
+
+    THREAD_MEMORY_FENCE();
+    if (!ring_empty(rx_ring_mux.used_ring) && !ring_empty(rx_ring_cli.free_ring) &&
+        !ring_full(rx_ring_mux.free_ring) && !ring_full(rx_ring_cli.used_ring)) {
+        rx_ring_mux.used_ring->notify_reader = false;
+        rx_ring_cli.free_ring->notify_reader = false;
+        goto process_rx_complete_;
+    }
+
 
     if (rx_ring_cli.used_ring->notify_reader && enqueued) {
-        microkit_notify_delayed(CLIENT_CH);
+        rx_ring_cli.used_ring->notify_reader = false;
+        microkit_notify(CLIENT_CH);
     }
 
-    /* We want to inform the mux that more free buffers are available or the 
-        used ring can now be refilled */
-    if (enqueued && (rx_ring_mux.free_ring->notify_reader || rx_ring_mux.used_ring->notify_writer)) {
-        if (have_signal && signal == BASE_OUTPUT_NOTIFICATION_CAP + CLIENT_CH) {
-            // We need to notify the client, but this should
-            // happen first. 
-            microkit_notify(CLIENT_CH);
-        }
-
+    /* We want to inform the mux that more free buffers are available */
+    if (enqueued && rx_ring_mux.free_ring->notify_reader) {
+        rx_ring_mux.free_ring->notify_reader = false;
         microkit_notify_delayed(MUX_RX_CH);
-    }
-
-    if (!ring_empty(rx_ring_mux.used_ring) || rx_ring_mux.free_ring->notify_reader) {
-        // we want to be notified when this changes so we can continue
-        // enqueuing packets to the client.
-        rx_ring_cli.free_ring->notify_reader = true;
-        // we don't need a notification from the multiplexer now. 
-        // rx_ring_mux.used_ring->notify_reader = false;
-    } else {
-        rx_ring_cli.free_ring->notify_reader = false;
-        // rx_ring_mux.used_ring->notify_reader = true;
     }
 }
 
 void notified(microkit_channel ch)
 {
-    if (ch == CLIENT_CH || ch == MUX_RX_CH) {
-        /* We have one job. */
-        process_rx_complete();
-    } else {
-        print("COPY|ERROR: unexpected notification from channel: ");
-        puthex64(ch);
-        print("\n");
-        assert(0);
-    }
+    /* We have one job. */
+    process_rx_complete();
 }
 
 void init(void)

--- a/network/ipstacks/lwip/src/core/ipv4/ip4.c
+++ b/network/ipstacks/lwip/src/core/ipv4/ip4.c
@@ -501,7 +501,6 @@ ip4_input(struct pbuf *p, struct netif *inp)
 
       LWIP_DEBUGF(IP_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
                   ("Checksum (0x%"X16_F") failed, IP packet dropped.\n", inet_chksum(iphdr, iphdr_hlen)));
-      print("Checksum failed");
       ip4_debug_print(p);
       pbuf_free(p);
       IP_STATS_INC(ip.chkerr);

--- a/network/ipstacks/lwip/src/core/tcp_in.c
+++ b/network/ipstacks/lwip/src/core/tcp_in.c
@@ -164,7 +164,6 @@ tcp_input(struct pbuf *p, struct netif *inp)
     if (chksum != 0) {
       LWIP_DEBUGF(TCP_INPUT_DEBUG, ("tcp_input: packet discarded due to failing checksum 0x%04"X16_F"\n",
                                     chksum));
-      print("TCP failed checksum");                            
       tcp_debug_print(tcphdr);
       TCP_STATS_INC(tcp.chkerr);
       goto dropped;

--- a/network/ipstacks/lwip/src/core/udp.c
+++ b/network/ipstacks/lwip/src/core/udp.c
@@ -433,7 +433,6 @@ end:
 chkerr:
   LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
               ("udp_input: UDP (or UDP Lite) datagram discarded due to failing checksum\n"));
-  print("udp_input: failing checksum\n");
   UDP_STATS_INC(udp.chkerr);
   UDP_STATS_INC(udp.drop);
   MIB2_STATS_INC(mib2.udpinerrors);

--- a/util/include/util.h
+++ b/util/include/util.h
@@ -27,19 +27,13 @@
 static void
 putC(uint8_t ch)
 {
-    while (!(*UART_REG(STAT) & STAT_TDRE)) { }
-    *UART_REG(TRANSMIT) = ch;
+    microkit_dbg_putc(ch);
 }
 
 static void
 print(const char *s)
 {
-#ifndef NO_PRINTING
-    while (*s) {
-        putC(*s);
-        s++;
-    }
-#endif
+    microkit_dbg_puts(s);
 }
 
 static char
@@ -113,4 +107,3 @@ static void _assert_fail(
     } while(0)
 
 #endif
-


### PR DESCRIPTION
This PR: 
- updates the multiplexers, copier and ARP components to the latest protocol;
- updates the OdroidC4 ethernet driver to be compatible with the aforementioned components.

But it has some issues:
- The hardcoded MAC addresses in the mux_rx component have been changed to accomodate running OdroidC4 on the same network as the imx8 running the echo benchmarking, but this will break the echo server. The hardcoded MACs are a broken design in the first place so the solution here is to get rid of them when time permits.
- I've duplicated some cache management code to get around build issues. That needs to be fixed in the future.
- Some of the guards on signalling are disabled and need to be re-enabled and tested.