### PR TITLE
fix: changed to unsigned int

### DIFF
--- a/echo_server/libsharedringbuffer/include/shared_ringbuffer.h
+++ b/echo_server/libsharedringbuffer/include/shared_ringbuffer.h
@@ -74,7 +74,7 @@ static inline int ring_full(ring_buffer_t *ring)
     return !((ring->write_idx - ring->read_idx + 1) % SIZE);
 }
 
-static inline int ring_size(ring_buffer_t *ring)
+static inline uint32_t ring_size(ring_buffer_t *ring)
 {
     return (ring->write_idx - ring->read_idx);
 }


### PR DESCRIPTION
Not a bug in practice but something verifast picked up when I tried verifast a few months ago. 
Everything else looks good (in the ringbufffer)