### PR TITLE
fix: overflow in ringbuffer

### DIFF
--- a/drivers/i2c/meson/include/sw_shared_ringbuffer.h
+++ b/drivers/i2c/meson/include/sw_shared_ringbuffer.h
@@ -71,7 +71,7 @@ static inline int ring_full(ring_buffer_t *ring)
     return !((ring->write_idx - ring->read_idx + 1) % SIZE);
 }
 
-static inline int ring_size(ring_buffer_t *ring)
+static inline uint32_t ring_size(ring_buffer_t *ring)
 {
     return (ring->write_idx - ring->read_idx);
 }

--- a/include/sddf/network/shared_ringbuffer.h
+++ b/include/sddf/network/shared_ringbuffer.h
@@ -64,7 +64,7 @@ int ring_empty(ring_buffer_t *ring);
  */
 int ring_full(ring_buffer_t *ring);
 
-int ring_size(ring_buffer_t *ring);
+uint32_t ring_size(ring_buffer_t *ring);
 
 /**
  * Enqueue an element to a ring buffer

--- a/network/libethsharedringbuffer/shared_ringbuffer.c
+++ b/network/libethsharedringbuffer/shared_ringbuffer.c
@@ -37,7 +37,7 @@ int ring_full(ring_buffer_t *ring)
     return !((ring->write_idx - ring->read_idx + 1) % ring->size);
 }
 
-int ring_size(ring_buffer_t *ring)
+uint32_t ring_size(ring_buffer_t *ring)
 {
     assert((ring->write_idx - ring->read_idx) >= 0);
     return (ring->write_idx - ring->read_idx);

--- a/serial/libserialsharedringbuffer/include/shared_ringbuffer.h
+++ b/serial/libserialsharedringbuffer/include/shared_ringbuffer.h
@@ -77,7 +77,7 @@ static inline int ring_full(ring_buffer_t *ring)
     return !((ring->write_idx - ring->read_idx + 1) % ring->size);
 }
 
-static inline int ring_size(ring_buffer_t *ring)
+static inline uint32_t ring_size(ring_buffer_t *ring)
 {
     // assert((ring->write_idx - ring->read_idx) >= 0);
     return (ring->write_idx - ring->read_idx);


### PR DESCRIPTION
Overflow in ringbuffer picked up by verifast, probably never going to be an issue in practice. 