### PR TITLE
Add initial CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build_linux_x86_64:
+    name: Build examples (Linux x86-64)
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout VMM repository
+        uses: actions/checkout@v3
+      - name: Download Microkit SDK
+        run: wget https://trustworthy.systems/Downloads/microkit/microkit-sdk-dev-4f717f2-linux-x86-64.tar.gz
+        shell: bash
+      - name: Extract Microkit SDK
+        run: tar -xf microkit-sdk-dev-4f717f2-linux-x86-64.tar.gz
+      - name: Install dependencies (via apt)
+        run: sudo apt update && sudo apt install -y make clang lld
+      - name: Download and install AArch64 GCC toolchain
+        run: |
+          wget -O aarch64-toolchain.tar.gz https://trustworthy.systems/Downloads/microkit/arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-elf.tar.xz%3Frev%3D73ff9780c12348b1b6772a1f54ab4bb3
+          tar xf aarch64-toolchain.tar.gz
+          echo "$(pwd)/arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+      - name: Build and run examples
+        run: ./ci/examples.sh ${PWD}/microkit-sdk-1.2.6
+        shell: bash
+  build_macos_x86_64:
+    name: Build examples (macOS x86-64)
+    runs-on: macos-12
+    steps:
+      - name: Checkout VMM repository
+        uses: actions/checkout@v3
+      - name: Download Microkit SDK
+        run: wget https://trustworthy.systems/Downloads/microkit/microkit-sdk-dev-4f717f2-macos-x86-64.tar.gz
+        shell: bash
+      - name: Extract Microkit SDK
+        run: tar -xf microkit-sdk-dev-4f717f2-macos-x86-64.tar.gz
+      - name: Install dependencies (via Homebrew)
+        run: |
+          brew install llvm make
+          echo "/usr/local/opt/llvm/bin:$PATH" >> $GITHUB_PATH
+      - name: Download and install AArch64 GCC toolchain
+        run: |
+          wget -O aarch64-toolchain.tar.gz https://trustworthy.systems/Downloads/microkit/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf.tar.xz%3Frev%3D51c39c753f8c4a54875b7c5dccfb84ef
+          tar xf aarch64-toolchain.tar.gz
+          echo "$(pwd)/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+      - name: Build and run examples
+        run: ./ci/examples.sh ${PWD}/microkit-sdk-1.2.6
+        shell: bash

--- a/ci/examples.sh
+++ b/ci/examples.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -e
+
+SDK_PATH=$1
+CI_BUILD_DIR="ci_build"
+
+[[ -z $SDK_PATH ]] && echo "usage: examples.sh [PATH TO SDK]" && exit 1
+[[ ! -d $SDK_PATH ]] && echo "The path to the SDK provided does not exist: '$SDK_PATH'" && exit 1
+
+build_network_echo_server() {
+    CONFIG=$1
+    echo "CI|INFO: building echo server example with config: $CONFIG"
+    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/echo_server/${CONFIG}"
+    rm -rf ${BUILD_DIR}
+    mkdir -p ${BUILD_DIR}
+    make -C examples/echo_server \
+        BUILD_DIR=${BUILD_DIR} \
+        MICROKIT_CONFIG=${CONFIG} \
+        MICROKIT_SDK=${SDK_PATH}
+}
+
+build_i2c() {
+    CONFIG=$1
+    echo "CI|INFO: building I2C example with config: $CONFIG"
+    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/i2c/${CONFIG}"
+    rm -rf ${BUILD_DIR}
+    mkdir -p ${BUILD_DIR}
+    make -C examples/i2c \
+        BUILD_DIR=${BUILD_DIR} \
+        MICROKIT_CONFIG=${CONFIG} \
+        MICROKIT_SDK=${SDK_PATH}
+}
+
+build_timer() {
+    CONFIG=$1
+    echo "CI|INFO: building timer example with config: $CONFIG"
+    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/timer/${CONFIG}"
+    rm -rf ${BUILD_DIR}
+    mkdir -p ${BUILD_DIR}
+    make -C examples/timer \
+        BUILD_DIR=${BUILD_DIR} \
+        MICROKIT_CONFIG=${CONFIG} \
+        MICROKIT_SDK=${SDK_PATH}
+}
+
+build_serial() {
+    CONFIG=$1
+    echo "CI|INFO: building serial example with config: $CONFIG"
+    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/serial/${CONFIG}"
+    rm -rf ${BUILD_DIR}
+    mkdir -p ${BUILD_DIR}
+    make -C examples/serial_two_client \
+        BUILD_DIR=${BUILD_DIR} \
+        MICROKIT_CONFIG=${CONFIG} \
+        MICROKIT_SDK=${SDK_PATH}
+}
+
+build_network_echo_server "debug"
+build_network_echo_server "release"
+build_network_echo_server "benchmark"
+
+build_i2c "debug"
+build_i2c "release"
+
+build_timer "debug"
+build_timer "release"
+
+build_serial "debug"
+build_serial "release"
+
+echo ""
+echo "CI|INFO: Passed all sDDF tests"

--- a/examples/echo_server/Makefile
+++ b/examples/echo_server/Makefile
@@ -6,20 +6,13 @@
 
 # @ivanv: Changes any of the params given e.g MICROKIT_CONFIG,
 # doesn't actually cause a re-compile. We should fix this.
-ifeq ($(strip $(BUILD_DIR)),)
-$(error BUILD_DIR must be specified)
-endif
+
+BUILD_DIR ?= build
+MICROKIT_BOARD := imx8mm_evk
+MICROKIT_CONFIG ?= debug
 
 ifeq ($(strip $(MICROKIT_SDK)),)
 $(error MICROKIT_SDK must be specified)
-endif
-
-ifeq ($(strip $(MICROKIT_BOARD)),)
-$(error MICROKIT_BOARD must be specified)
-endif
-
-ifeq ($(strip $(MICROKIT_CONFIG)),)
-$(error MICROKIT_CONFIG must be specified)
 endif
 
 ifeq ($(strip $(TOOLCHAIN)),)

--- a/examples/timer/Makefile
+++ b/examples/timer/Makefile
@@ -7,7 +7,7 @@ BUILD_DIR ?= build
 MICROKIT_CONFIG ?= debug
 
 MICROKIT_BOARD := odroidc4
-CPU := cortex-a53
+CPU := cortex-a55
 
 CC := clang
 LD := ld.lld


### PR DESCRIPTION
Lots of people developing now, and things are easily breaking.

We obviously need run-time tests as well but there's still lots of pieces moving around in the sDDF so this will catch the build failures at least.