### PR TITLE
Add explicit channel argument to timer client library

### DIFF
--- a/examples/timer/Makefile
+++ b/examples/timer/Makefile
@@ -50,7 +50,7 @@ $(BUILD_DIR)/timer_driver.o: $(TIMER_DRIVER)/timer.c
 	$(CC) -c $(CFLAGS) $(TIMER_DRIVER)/timer.c -o $(BUILD_DIR)/timer_driver.o
 
 $(BUILD_DIR)/sddf_timer_client.o:
-	BUILD_DIR=$(abspath $(BUILD_DIR)) MICROKIT_INCLUDE=$(BOARD_DIR)/include TIMER_CHANNEL=1 make -C $(SDDF)/timer/client
+	BUILD_DIR=$(abspath $(BUILD_DIR)) MICROKIT_INCLUDE=$(BOARD_DIR)/include make -C $(SDDF)/timer/client
 
 $(BUILD_DIR)/timer.elf: $(BUILD_DIR)/timer_driver.o
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@

--- a/examples/timer/client.c
+++ b/examples/timer/client.c
@@ -2,6 +2,8 @@
 #include <microkit.h>
 #include <sddf/timer/client.h>
 
+#define TIMER_CHANNEL 1
+
 static void
 put64(uint64_t val) {
     char buffer[20];
@@ -25,24 +27,24 @@ notified(microkit_channel ch)
      */
     microkit_dbg_puts("CLIENT|INFO: Got a timeout!\n");
     /* Get the current time */
-    uint64_t time = sddf_timer_time_now();
+    uint64_t time = sddf_timer_time_now(TIMER_CHANNEL);
     microkit_dbg_puts("CLIENT|INFO: Now the time (in nanoseconds) is: ");
     put64(time);
     microkit_dbg_puts("\n");
     /* Set another timeout */
-    sddf_timer_set_timeout(NS_IN_S);
+    sddf_timer_set_timeout(TIMER_CHANNEL, NS_IN_S);
 }
 
 void
 init(void)
 {
     // lets get the time!
-    uint64_t time = sddf_timer_time_now();
+    uint64_t time = sddf_timer_time_now(TIMER_CHANNEL);
     microkit_dbg_puts("CLIENT|INFO: The time now is: ");
     put64(time);
     microkit_dbg_puts("\n");
 
     // lets set a timeout
     microkit_dbg_puts("CLIENT|INFO: Setting a time out for 1 second\n");
-    sddf_timer_set_timeout(NS_IN_S);
+    sddf_timer_set_timeout(TIMER_CHANNEL, NS_IN_S);
 }

--- a/include/sddf/timer/client.h
+++ b/include/sddf/timer/client.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <microkit.h>
 #include <stdint.h>
 
 #define NS_IN_MS 1000000ULL
@@ -10,13 +11,15 @@
 /**
  * Request a timeout via PPC into the passive timer driver.
  * Use the label to indicate this request.
+ * @param microkit channel of timer driver.
  * @param timeout relative timeout in nanoseconds.
  */
-void sddf_timer_set_timeout(uint64_t timeout);
+void sddf_timer_set_timeout(microkit_channel channel, uint64_t timeout);
 
 /**
  * Request the time since start up via PPC into the passive timer driver.
  * Use the label to indicate this request.
+ * @param microkit channel of timer driver.
  * @return the time in nanoseconds since start up.
  */
-uint64_t sddf_timer_time_now(void);
+uint64_t sddf_timer_time_now(microkit_channel channel);

--- a/timer/client/Makefile
+++ b/timer/client/Makefile
@@ -8,10 +8,6 @@ ifeq ($(strip $(MICROKIT_INCLUDE)),)
 $(error MICROKIT_INCLUDE must be specified)
 endif
 
-ifeq ($(strip $(TIMER_CHANNEL)),)
-$(error TIMER_CHANNEL must be specified)
-endif
-
 BUILD_DIR ?= .
 
 CC := clang

--- a/timer/client/client.c
+++ b/timer/client/client.c
@@ -2,24 +2,20 @@
 #include <microkit.h>
 #include <sddf/timer/client.h>
 
-#ifndef TIMER_CHANNEL
-#error "TIMER_CHANNEL must be provided"
-#endif
-
 #define GET_TIME 0
 #define SET_TIMEOUT 1
 
 void
-sddf_timer_set_timeout(uint64_t timeout)
+sddf_timer_set_timeout(microkit_channel channel, uint64_t timeout)
 {
     microkit_mr_set(0, timeout);
-    microkit_ppcall(TIMER_CHANNEL, microkit_msginfo_new(SET_TIMEOUT, 1));
+    microkit_ppcall(channel, microkit_msginfo_new(SET_TIMEOUT, 1));
 }
 
 uint64_t
-sddf_timer_time_now(void)
+sddf_timer_time_now(microkit_channel channel)
 {
-    microkit_ppcall(TIMER_CHANNEL, microkit_msginfo_new(GET_TIME, 0));
+    microkit_ppcall(channel, microkit_msginfo_new(GET_TIME, 0));
     uint64_t time_now = seL4_GetMR(0);
     return time_now;
 }


### PR DESCRIPTION
Having the timer driver's channel as a preprecessor macro means that for systems that contain multiple programs using the timer, either every program must have the same channel number for the timer driver, or the client library needs to be built independently for different programs. This may be too constricting until we develop an ergonomic way to specify and build Microkit systems.

This commit modifies the API of the timer client library to accept the timer's channel as a parameter.

This also has the side effect that a program could use multiple timer devices simultaneously. Not sure how much value there is there.