### PR TITLE
Remove lwIP dependency from ethernet RX multiplexer and ARP components

### DIFF
--- a/examples/echo_server/Makefile
+++ b/examples/echo_server/Makefile
@@ -98,7 +98,7 @@ MUX_TX_OBJS := $(NETWORK_COMPONENTS)/mux_tx_bandwidth_limited.o sddf_network_sha
 COPY_OBJS := $(NETWORK_COMPONENTS)/copy.o sddf_network_sharedringbuffer.o
 BENCH_OBJS := $(BENCHMARK)/benchmark.o
 IDLE_OBJS := $(BENCHMARK)/idle.o
-ARP_OBJS := $(UTIL)/cache.o $(LWIP)/core/inet_chksum.o $(LWIP)/core/def.o $(NETWORK_COMPONENTS)/arp.o sddf_network_sharedringbuffer.o
+ARP_OBJS := $(UTIL)/cache.o $(NETWORK_COMPONENTS)/arp.o sddf_network_sharedringbuffer.o
 TIMER_OBJS := $(TIMER_DRIVER)/timer.o
 
 OBJS := $(sort $(addprefix $(BUILD_DIR)/, $(ETH_OBJS) $(MUX_RX_OBJS) $(MUX_TX_OBJS)\

--- a/include/sddf/network/constants.h
+++ b/include/sddf/network/constants.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdint.h>
+
+#define ETH_TYPE_ARP 0x0806U
+#define ETH_TYPE_IP 0x0800U
+#define ETHARP_OPCODE_REQUEST 1
+#define ETHARP_OPCODE_REPLY 2
+
+struct ethernet_address {
+  uint8_t addr[6];
+} __attribute__((packed));
+
+struct ethernet_header {
+  struct ethernet_address dest;
+  struct ethernet_address src;
+  uint16_t type;
+} __attribute__((packed));

--- a/include/sddf/network/util.h
+++ b/include/sddf/network/util.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <sddf/util/util.h>
+
+#if BYTE_ORDER == BIG_ENDIAN
+#define HTONS(x) ((uint16_t)(x))
+#else
+#define HTONS(x) ((uint16_t)((((x) & (uint16_t)0x00ffU) << 8) | (((x) & (uint16_t)0xff00U) >> 8)))
+#endif

--- a/include/sddf/util/util.h
+++ b/include/sddf/util/util.h
@@ -24,6 +24,18 @@
 #define unlikely(x) (!!(x))
 #endif
 
+#ifndef BYTE_ORDER
+#if defined(__BYTE_ORDER__)
+#  define BYTE_ORDER __BYTE_ORDER__
+#elif defined(__BIG_ENDIAN)
+#  define BYTE_ORDER BIG_ENDIAN
+#elif defined(__LITTLE_ENDIAN)
+#  define BYTE_ORDER LITTLE_ENDIAN
+#else
+#  error Unable to determine system endianness
+#endif
+#endif
+
 static void
 putC(uint8_t ch)
 {

--- a/network/components/mux_rx.c
+++ b/network/components/mux_rx.c
@@ -6,8 +6,7 @@
 #include <sddf/network/shared_ringbuffer.h>
 #include <sddf/util/util.h>
 #include <sddf/util/fence.h>
-#include "lwip/ip_addr.h"
-#include "netif/etharp.h"
+#include <sddf/network/constants.h>
 
 uintptr_t rx_free_drv;
 uintptr_t rx_used_drv;
@@ -101,7 +100,7 @@ int compare_mac(uint8_t *mac1, uint8_t *mac2)
 
 /* Return the client ID if the Mac address is a match. */
 int get_client(uintptr_t dma_vaddr) {
-    struct eth_hdr *ethhdr = (struct eth_hdr *)dma_vaddr;
+    struct ethernet_header *ethhdr = (struct ethernet_header *)dma_vaddr;
     for (int client = 0; client < NUM_CLIENTS; client++) {
         if (compare_mac(ethhdr->dest.addr, state.mac_addrs[client]) == 0) {
             return client;


### PR DESCRIPTION
This commit changes the mux_rx and arp ethernet components to no longer depend on lwIP. lwIP was only used lightly in these components to parse ethernet headers, so the relevant constants (which are defined by standards) were duplicated into new files in include/sddf/network/constants.h. Additionally, a macro BYTE_ORDER was added to include/sddf/util/util.h and an implementation of htons was duplicated into include/sddf/network/util.h. New names were given to duplicated identifiers so that they will not clash with lwIP if included by a component which also uses lwIP.