### PR TITLE
Make MAC addresses build-time configurable,

### DIFF
--- a/examples/echo_server/lwip.c
+++ b/examples/echo_server/lwip.c
@@ -32,6 +32,9 @@
 #define LWIP_TICK_MS 100
 
 #define _unused(x) ((void)(x))
+#ifndef MAC_ADDRESS
+#  define MAC_ADDRESS (0x525401000000ULL)
+#endif
 
 /* Memory regions. These all have to be here to keep compiler happy */
 uintptr_t rx_free;
@@ -449,15 +452,13 @@ static void netif_status_callback(struct netif *netif)
 static void get_mac(void)
 {
     /* For now just use a dummy hardcoded mac address.*/
-    state.mac[0] = 0x52;
-    state.mac[1] = 0x54;
-    state.mac[2] = 0x1;
-    state.mac[3] = 0;
-    state.mac[4] = 0;
-    if (!strcmp(microkit_name, "client0")) {
-        state.mac[5] = 0;
-    } else {
-        state.mac[5] = 0x1;
+    int i;
+    for (i = 5; i >= 0; --i) {
+        state.mac[5 - i] = 0xff & (MAC_ADDRESS >> (i*8));
+    }
+
+    if (strcmp(microkit_name, "client0")) {
+        state.mac[5] += 0x1;
     }
     /* microkit_ppcall(RX_CH, microkit_msginfo_new(0, 0));
     uint32_t palr = microkit_mr_get(0);

--- a/network/components/arp.c
+++ b/network/components/arp.c
@@ -32,6 +32,11 @@ uintptr_t uart_base;
 ring_handle_t rx_ring;
 ring_handle_t tx_ring;
 
+#ifndef MAC_BASE_ADDRESS
+#  define MAC_BASE_ADDRESS (0x525401000000ULL)
+#endif
+#define MAC_OFFSET (1)
+
 uint8_t mac_addrs[NUM_CLIENTS][ETH_HWADDR_LEN];
 // TODO: Expand this to support multiple ip addresses for a single client.
 uint32_t ipv4_addrs[NUM_CLIENTS];

--- a/network/components/arp.c
+++ b/network/components/arp.c
@@ -19,7 +19,6 @@
 #define SHARED_DMA_SIZE (BUF_SIZE * NUM_BUFFERS)
 
 #define _unused(x) ((void)(x))
-
 uintptr_t rx_free;
 uintptr_t rx_used;
 
@@ -286,6 +285,8 @@ protected(microkit_channel ch, microkit_msginfo msginfo)
 void
 init(void)
 {
+    int i;
+
     /* Set up shared memory regions */
     ring_init(&rx_ring, (ring_buffer_t *)rx_free, (ring_buffer_t *)rx_used, 0, NUM_BUFFERS, NUM_BUFFERS);
     ring_init(&tx_ring, (ring_buffer_t *)tx_free, (ring_buffer_t *)tx_used, 0, NUM_BUFFERS, NUM_BUFFERS);
@@ -294,19 +295,9 @@ init(void)
     tx_ring.free_ring->notify_reader = true;
 
     /* Set up hardcoded mac addresses */
-    mac_addrs[0][0] = 0x52;
-    mac_addrs[0][1] = 0x54;
-    mac_addrs[0][2] = 0x1;
-    mac_addrs[0][3] = 0;
-    mac_addrs[0][4] = 0;
-    mac_addrs[0][5] = 0;
-
-    mac_addrs[1][0] = 0x52;
-    mac_addrs[1][1] = 0x54;
-    mac_addrs[1][2] = 0x1;
-    mac_addrs[1][3] = 0;
-    mac_addrs[1][4] = 0;
-    mac_addrs[1][5] = 1;
-
-    return;
+    for (i = 5; i >= 0; --i) {
+        mac_addrs[0][5 - i] = 0xff & (MAC_BASE_ADDRESS >> (i * 8));
+        mac_addrs[1][5 - i] = 0xff & (MAC_BASE_ADDRESS >> (i * 8));
+    }
+    mac_addrs[1][5] += MAC_OFFSET;
 }

--- a/network/components/mux_rx.c
+++ b/network/components/mux_rx.c
@@ -30,6 +30,11 @@ uintptr_t uart_base;
 
 #define BUF_SIZE 2048
 #define NUM_BUFFERS 512
+/*
+#ifndef MAC_BASE_ADDRESS
+#  define MAC_BASE_ADDRESS (0x525401000000ULL)
+#endif
+*/
 
 #define _unused(x) ((void)(x))
 
@@ -250,21 +255,15 @@ void notified(microkit_channel ch)
 
 void init(void)
 {
-    // set up client macs 
-    state.mac_addrs[0][0] = 0x52;
-    state.mac_addrs[0][1] = 0x54;
-    state.mac_addrs[0][2] = 0x1;
-    state.mac_addrs[0][3] = 0;
-    state.mac_addrs[0][4] = 0;
-    state.mac_addrs[0][5] = 10;
-
-    state.mac_addrs[1][0] = 0x52;
-    state.mac_addrs[1][1] = 0x54;
-    state.mac_addrs[1][2] = 0x1;
-    state.mac_addrs[1][3] = 0;
-    state.mac_addrs[1][4] = 0;
-    state.mac_addrs[1][5] = 11;
-
+    // set up client macs FIXME this should be done by the clients
+    int i;
+    int j;
+    for (j = 0; j < 2; j++) {
+        for (i = 5; i >= 0; --i) {
+            state.mac_addrs[j][5 - i] = 0xff & (MAC_BASE_ADDRESS >> (i*8));
+        }
+        state.mac_addrs[j][5] += 10 + j;
+    }
     // and for broadcast. 
     state.mac_addrs[2][0] = 0xff;
     state.mac_addrs[2][1] = 0xff;

--- a/network/components/mux_rx.c
+++ b/network/components/mux_rx.c
@@ -30,11 +30,9 @@ uintptr_t uart_base;
 
 #define BUF_SIZE 2048
 #define NUM_BUFFERS 512
-/*
 #ifndef MAC_BASE_ADDRESS
 #  define MAC_BASE_ADDRESS (0x525401000000ULL)
 #endif
-*/
 
 #define _unused(x) ((void)(x))
 


### PR DESCRIPTION
It used to be that MAC addresses were hardcoded to 52:54:01:00:00, 52:54:01:00:0A, etc.
Now you can specify -DMAC_BASE_ADDRESS=0x5254010000 to the C compiler to get the same effect.

You must use the same MAC_BASE_ADDRESS for all components.

This is referenced by https://github.com/au-ts/LionsOS/pull/10