### PR TITLE
Fix printf to not clash with other printfs

### DIFF
--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -100,21 +100,21 @@ static void microkit_benchmark_stop_tcb(uint64_t pd_id, uint64_t *total, uint64_
 
 static void print_benchmark_details(uint64_t pd_id, uint64_t kernel_util, uint64_t kernel_entries, uint64_t number_schedules, uint64_t total_util)
 {
-    if (pd_id == PD_TOTAL) printf("Total utilisation details: ");
-    else printf("Utilisation details for PD: ");
+    if (pd_id == PD_TOTAL) sddf_printf("Total utilisation details: ");
+    else sddf_printf("Utilisation details for PD: ");
     switch (pd_id) {
-        case PD_ETH_ID: printf("ETH DRIVER"); break;
-        case PD_MUX_RX_ID: printf("MUX RX"); break;
-        case PD_MUX_TX_ID: printf("MUX TX"); break;
-        case PD_COPY_ID: printf("COPIER0"); break;
-        case PD_COPY1_ID: printf("COPIER1"); break;
-        case PD_LWIP_ID: printf("LWIP CLIENT0"); break;
-        case PD_LWIP1_ID: printf("LWIP CLIENT1"); break;
-        case PD_ARP_ID: printf("ARP"); break;
-        case PD_TIMER_ID: printf("TIMER"); break;
+        case PD_ETH_ID: sddf_printf("ETH DRIVER"); break;
+        case PD_MUX_RX_ID: sddf_printf("MUX RX"); break;
+        case PD_MUX_TX_ID: sddf_printf("MUX TX"); break;
+        case PD_COPY_ID: sddf_printf("COPIER0"); break;
+        case PD_COPY1_ID: sddf_printf("COPIER1"); break;
+        case PD_LWIP_ID: sddf_printf("LWIP CLIENT0"); break;
+        case PD_LWIP1_ID: sddf_printf("LWIP CLIENT1"); break;
+        case PD_ARP_ID: sddf_printf("ARP"); break;
+        case PD_TIMER_ID: sddf_printf("TIMER"); break;
     }
-    if (pd_id != PD_TOTAL) printf(" ( %llx)", pd_id);
-    printf("\n{\nKernelUtilisation:  %llx\nKernelEntries:  %llx\nNumberSchedules:  %llx\nTotalUtilisation:  %llx\n}\n", 
+    if (pd_id != PD_TOTAL) sddf_printf(" ( %llx)", pd_id);
+    sddf_printf("\n{\nKernelUtilisation:  %llx\nKernelEntries:  %llx\nNumberSchedules:  %llx\nTotalUtilisation:  %llx\n}\n", 
             kernel_util, kernel_entries, number_schedules, total_util);
 }
 #endif
@@ -144,12 +144,12 @@ static inline void seL4_BenchmarkTrackDumpSummary(benchmark_track_kernel_entry_t
         index++;
     }
 
-    printf("Number of system call invocations  %llx and fastpaths  %llx\n", syscall_entries, fastpaths);
-    printf("Number of interrupt invocations  %llx\n", interrupt_entries);
-    printf("Number of user-level faults  %llx\n", userlevelfault_entries);
-    printf("Number of VM faults  %llx\n", vmfault_entries);
-    printf("Number of debug faults  %llx\n", debug_fault);
-    printf("Number of others  %llx\n", other);
+    sddf_printf("Number of system call invocations  %llx and fastpaths  %llx\n", syscall_entries, fastpaths);
+    sddf_printf("Number of interrupt invocations  %llx\n", interrupt_entries);
+    sddf_printf("Number of user-level faults  %llx\n", userlevelfault_entries);
+    sddf_printf("Number of VM faults  %llx\n", vmfault_entries);
+    sddf_printf("Number of debug faults  %llx\n", debug_fault);
+    sddf_printf("Number of others  %llx\n", other);
 }
 #endif
 
@@ -175,9 +175,11 @@ void notified(microkit_channel ch)
             sel4bench_get_counters(benchmark_bf, &counter_values[0]);
             sel4bench_stop_counters(benchmark_bf);
 
-            printf("{\n");
-            for (int i = 0; i < ARRAY_SIZE(benchmarking_events); i++) printf("%s: %llX\n", counter_names[i], counter_values[i]);
-            printf("}\n");
+            sddf_printf("{\n");
+            for (int i = 0; i < ARRAY_SIZE(benchmarking_events); i++) {
+                sddf_printf("%s: %llX\n", counter_names[i], counter_values[i]);
+            }
+            sddf_printf("}\n");
 
             #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
             uint64_t total;
@@ -217,13 +219,13 @@ void notified(microkit_channel ch)
 
             #ifdef CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES
             entries = seL4_BenchmarkFinalizeLog();
-            printf("KernelEntries:  %llx\n", entries);
+            sddf_printf("KernelEntries:  %llx\n", entries);
             seL4_BenchmarkTrackDumpSummary(log_buffer, entries);
             #endif
 
             break;
         default:
-            printf("Bench thread notified on unexpected channel\n");
+            sddf_printf("Bench thread notified on unexpected channel\n");
     }
 }
 
@@ -249,7 +251,7 @@ void init(void)
 
 #ifdef CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES
     int res_buf = seL4_BenchmarkSetLogBuffer(LOG_BUFFER_CAP);
-    if (res_buf) printf("Could not set log buffer:  %llx\n", res_buf);
-    else printf("Log buffer set\n");
+    if (res_buf) sddf_printf("Could not set log buffer:  %llx\n", res_buf);
+    else sddf_printf("Log buffer set\n");
 #endif
 }

--- a/benchmark/idle.c
+++ b/benchmark/idle.c
@@ -57,7 +57,7 @@ void notified(microkit_channel ch)
             count_idle();
             break;
         default:
-            dprintf("Idle thread notified on unexpected channel: %llu\n", ch);
+            sddf_dprintf("Idle thread notified on unexpected channel: %llu\n", ch);
     }
 }
 

--- a/drivers/clock/imx/timer.c
+++ b/drivers/clock/imx/timer.c
@@ -154,7 +154,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
             }
             break;
         default:
-            dprintf("TIMER DRIVER|LOG: Unknown request %llu to timer from channel %llu\n", microkit_msginfo_get_label(msginfo), ch);
+            sddf_dprintf("TIMER DRIVER|LOG: Unknown request %llu to timer from channel %llu\n", microkit_msginfo_get_label(msginfo), ch);
             break;
     }
 

--- a/drivers/clock/meson/timer.c
+++ b/drivers/clock/meson/timer.c
@@ -131,7 +131,7 @@ notified(microkit_channel ch)
         handle_irq(ch);
         microkit_irq_ack_delayed(ch);
     } else {
-        dprintf("TIMER DRIVER|LOG: unexpected notification %llu\n", ch);
+        sddf_dprintf("TIMER DRIVER|LOG: unexpected notification %llu\n", ch);
     }
 }
 
@@ -169,7 +169,7 @@ protected(microkit_channel ch, microkit_msginfo msginfo)
             }
             break;
         default:
-            dprintf("TIMER DRIVER|LOG: Unknown request %llu to timer from channel %llu\n", microkit_msginfo_get_label(msginfo), ch);
+            sddf_dprintf("TIMER DRIVER|LOG: Unknown request %llu to timer from channel %llu\n", microkit_msginfo_get_label(msginfo), ch);
             break;
     }
 

--- a/drivers/i2c/meson/i2c.c
+++ b/drivers/i2c/meson/i2c.c
@@ -25,12 +25,12 @@
 // #define DEBUG_DRIVER
 
 #ifdef DEBUG_DRIVER
-#define LOG_DRIVER(...) do{ printf("I2C DRIVER|INFO: "); printf(__VA_ARGS__); }while(0)
+#define LOG_DRIVER(...) do{ sddf_dprintf("I2C DRIVER|INFO: "); sddf_dprintf(__VA_ARGS__); }while(0)
 #else
 #define LOG_DRIVER(...) do{}while(0)
 #endif
 
-#define LOG_DRIVER_ERR(...) do{ printf("I2C DRIVER|ERROR: "); printf(__VA_ARGS__); }while(0)
+#define LOG_DRIVER_ERR(...) do{ sddf_printf("I2C DRIVER|ERROR: "); sddf_printf(__VA_ARGS__); }while(0)
 
 struct i2c_regs {
     uint32_t ctl;
@@ -146,7 +146,7 @@ static inline void i2c_dump(volatile struct i2c_regs *regs) {
  * Initialise the i2c master interfaces.
 */
 static inline void i2c_setup() {
-    printf("driver: initialising i2c master interfaces...\n");
+    LOG_DRIVER("initialising i2c master interfaces...\n");
 
     volatile struct i2c_regs *regs = (volatile struct i2c_regs *) i2c_regs;
 
@@ -180,7 +180,7 @@ static inline void i2c_setup() {
 
     // Check that registers actually changed
     if (!(*pinmux5_ptr & (GPIO_PM5_X18 | GPIO_PM5_X17))) {
-        printf("driver: failed to set pinmux5!\n");
+        LOG_DRIVER_ERR("failed to set pinmux5!\n");
     }
 
     // Set GPIO drive strength
@@ -191,7 +191,7 @@ static inline void i2c_setup() {
     // Check register updated
     if ((*pad_ds2b_ptr & (GPIO_DS_2B_X17 | GPIO_DS_2B_X18)) != ((ds << GPIO_DS_2B_X17_SHIFT) |
                     (ds << GPIO_DS_2B_X18_SHIFT))) {
-        printf("driver: failed to set drive strength for m2!\n");
+        LOG_DRIVER_ERR("failed to set drive strength for m2!\n");
     }
 
     // Disable bias, because the odroid i2c hardware has undocumented internal ones
@@ -199,7 +199,7 @@ static inline void i2c_setup() {
 
     // Check registers updated
     if ((*pad_bias2_ptr & ((1 << 18) | (1 << 17))) != 0) {
-        printf("driver: failed to disable bias for m2!\n");
+        LOG_DRIVER_ERR("failed to disable bias for m2!\n");
     }
 #elif I2C_BUS_NUM == 3
     // Enable i2cm3 -> pinmux E
@@ -209,7 +209,7 @@ static inline void i2c_setup() {
 
     // Check registers actually changed
     if (!(*pinmuxE_ptr & (GPIO_PE_A15 | GPIO_PE_A14))) {
-        printf("driver: failed to set pinmuxE!\n");
+        LOG_DRIVER_ERR("failed to set pinmuxE!\n");
     }
 
     // Set GPIO drive strength
@@ -220,7 +220,7 @@ static inline void i2c_setup() {
     // Check register updated
     if ((*pad_ds5a_ptr & (GPIO_DS_5A_A14 | GPIO_DS_5A_A15)) != ((ds << GPIO_DS_5A_A14_SHIFT) |
                     (ds << GPIO_DS_5A_A15_SHIFT))) {
-        printf("driver: failed to set drive strength for m3!\n");
+        LOG_DRIVER_ERR("failed to set drive strength for m3!\n");
     }
 
     // Disable bias, because the odroid i2c hardware has undocumented internal ones
@@ -228,7 +228,7 @@ static inline void i2c_setup() {
 
     // Check registers updated
     if ((*pad_bias5_ptr & ((1 << 14) | (1 << 15))) != 0) {
-        printf("driver: failed to disable bias for m3!\n");
+        LOG_DRIVER_ERR("failed to disable bias for m3!\n");
     }
 #endif /* I2C_BUS_NUM */
 
@@ -238,7 +238,7 @@ static inline void i2c_setup() {
 
     // Check that registers actually changed
     if (!(*clk81_ptr & I2C_CLK81_BIT)) {
-        printf("driver: failed to toggle clock!\n");
+        LOG_DRIVER_ERR("failed to toggle clock!\n");
     }
 
     // Initialise fields
@@ -511,7 +511,7 @@ static inline void handle_request(void) {
         LOG_DRIVER("Loading request from client %u to address 0x%x of sz %zu\n", req[0], req[1], size);
 
         if (size > I2C_MAX_DATA_SIZE) {
-            printf("Invalid request size: %zu!\n", size);
+            LOG_DRIVER_ERR("Invalid request size: %zu!\n", size);
             return;
         }
         i2c_ifState.curr_request_data = (i2c_token_t *) DATA_REGIONS_START + offset;

--- a/drivers/network/imx/ethernet.c
+++ b/drivers/network/imx/ethernet.c
@@ -210,7 +210,7 @@ static void handle_irq(void)
             rx_return();
             rx_provide();
         }
-        if (e & NETIRQ_EBERR) dprintf("ETH|ERROR: System bus/uDMA\n");
+        if (e & NETIRQ_EBERR) sddf_dprintf("ETH|ERROR: System bus/uDMA\n");
         e = eth->eir & irq_mask;
         eth->eir = e;
     }
@@ -325,7 +325,7 @@ void notified(microkit_channel ch)
             tx_provide();
             break;
         default:
-            dprintf("ETH|LOG: received notification on unexpected channel: %lu\n", ch);
+            sddf_dprintf("ETH|LOG: received notification on unexpected channel: %lu\n", ch);
             break;
     }
 }

--- a/drivers/network/meson/ethernet.c
+++ b/drivers/network/meson/ethernet.c
@@ -119,7 +119,7 @@ static void rx_return(void)
         THREAD_MEMORY_ACQUIRE();
 
         if (d->status & DESC_RXSTS_ERROR) {
-            dprintf("ETH|ERROR: RX descriptor returned with error status %x\n", d->status);
+            sddf_dprintf("ETH|ERROR: RX descriptor returned with error status %x\n", d->status);
             uint32_t cntl = (MAX_RX_FRAME_SZ << DESC_RXCTRL_SIZE1SHFT) & DESC_RXCTRL_SIZE1MASK;
             if (rx.tail + 1 == RX_COUNT) cntl |= DESC_RXCTRL_RXRINGEND;
 
@@ -203,7 +203,7 @@ static void handle_irq()
         tx_return();
     }
     if (e & DMA_INTR_ABNORMAL) {
-        if (e & DMA_INTR_FBE) dprintf("Ethernet device fatal bus error\n");
+        if (e & DMA_INTR_FBE) sddf_dprintf("Ethernet device fatal bus error\n");
     }
     eth_dma->status &= e;
 }
@@ -277,7 +277,7 @@ void notified(microkit_channel ch)
             tx_provide();
             break;
         default:
-            dprintf("ETH|LOG: received notification on unexpected channel %llu\n", ch);
+            sddf_dprintf("ETH|LOG: received notification on unexpected channel %llu\n", ch);
             break;
     }
 }

--- a/examples/echo_server/include/lwip/arch/cc.h
+++ b/examples/echo_server/include/lwip/arch/cc.h
@@ -61,11 +61,11 @@ typedef unsigned long long ssize_t;
 /* Plaform specific diagnostic output */
 #define LWIP_PLATFORM_DIAG(x)           \
         do {                            \
-            printf x ;\
+            sddf_printf x ;\
         } while(0)
 
 #define LWIP_PLATFORM_ASSERT(x) \
         do {                                                    \
-            printf("Assertion failed: %s\n", #x);              \
+            sddf_printf("Assertion failed: %s\n", #x);              \
             while(1);                                           \
         } while(0)

--- a/examples/echo_server/lwip.c
+++ b/examples/echo_server/lwip.c
@@ -150,7 +150,7 @@ void enqueue_pbufs(struct pbuf *p)
 static err_t lwip_eth_send(struct netif *netif, struct pbuf *p)
 {   
     if (p->tot_len > BUFF_SIZE) {
-        dprintf("LWIP|ERROR: attempted to send a packet of size  %llx > BUFFER SIZE  %llx\n", p->tot_len, BUFF_SIZE);
+        sddf_dprintf("LWIP|ERROR: attempted to send a packet of size  %llx > BUFFER SIZE  %llx\n", p->tot_len, BUFF_SIZE);
         return ERR_MEM;
     }
 
@@ -186,10 +186,10 @@ void transmit(void)
         while(state.head != NULL && !ring_empty(state.tx_ring.free_ring)) {
             err_t err = lwip_eth_send(&state.netif, state.head);
             if (err == ERR_MEM) {
-                dprintf("LWIP|ERROR: attempted to send a packet of size  %llx > BUFFER SIZE  %llx\n", state.head->tot_len, BUFF_SIZE);
+                sddf_dprintf("LWIP|ERROR: attempted to send a packet of size  %llx > BUFFER SIZE  %llx\n", state.head->tot_len, BUFF_SIZE);
             }
             else if (err != ERR_OK) {
-                dprintf("LWIP|ERROR: unkown error when trying to send pbuf  %llx\n", state.head);
+                sddf_dprintf("LWIP|ERROR: unkown error when trying to send pbuf  %llx\n", state.head);
             }
             
             struct pbuf *temp = state.head;
@@ -221,7 +221,7 @@ void receive(void)
 
             struct pbuf *p = create_interface_buffer(buffer.phys_or_offset, buffer.len);
             if (state.netif.input(p, &state.netif) != ERR_OK) {
-                dprintf("LWIP|ERROR: unkown error inputting pbuf into network stack\n");
+                sddf_dprintf("LWIP|ERROR: unkown error inputting pbuf into network stack\n");
                 pbuf_free(p);
             }
         }
@@ -270,7 +270,7 @@ static void netif_status_callback(struct netif *netif)
         microkit_mr_set(2, (state.mac[2] << 24) |  (state.mac[3] << 16) | (state.mac[4] << 8) | state.mac[5]);
         microkit_ppcall(ARP, microkit_msginfo_new(0, 3));
 
-        printf("LWIP|NOTICE: DHCP request for %s returned IP address: %s\n", microkit_name, ip4addr_ntoa(netif_ip4_addr(netif)));
+        sddf_printf("LWIP|NOTICE: DHCP request for %s returned IP address: %s\n", microkit_name, ip4addr_ntoa(netif_ip4_addr(netif)));
     }
 }
 
@@ -297,13 +297,13 @@ void init(void)
     state.netif.name[1] = '0';
 
     if (!netif_add(&(state.netif), &ipaddr, &netmask, &gw, (void *)&state,
-              ethernet_init, ethernet_input)) dprintf("LWIP|ERROR: Netif add returned NULL\n");
+              ethernet_init, ethernet_input)) sddf_dprintf("LWIP|ERROR: Netif add returned NULL\n");
 
     netif_set_default(&(state.netif));
     netif_set_status_callback(&(state.netif), netif_status_callback);
     netif_set_up(&(state.netif));
 
-    if (dhcp_start(&(state.netif))) dprintf("LWIP|ERROR: failed to start DHCP negotiation\n");
+    if (dhcp_start(&(state.netif))) sddf_dprintf("LWIP|ERROR: failed to start DHCP negotiation\n");
 
     setup_udp_socket();
     setup_utilization_socket();
@@ -338,7 +338,7 @@ void notified(microkit_channel ch)
             receive();
             break;
         default:
-            dprintf("LWIP|LOG: received notification on unexpected channel: %lu\n", ch);
+            sddf_dprintf("LWIP|LOG: received notification on unexpected channel: %lu\n", ch);
             break;
     }
     

--- a/examples/echo_server/udp_echo_socket.c
+++ b/examples/echo_server/udp_echo_socket.c
@@ -62,7 +62,7 @@ const char * lwip_strerr(err_t err)
 static void lwip_udp_recv_callback(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port)
 {
     err_t error = udp_sendto(pcb, p, addr, port);
-    if (error) dprintf("Failed to send UDP packet through socket: %s\n", lwip_strerr(error));
+    if (error) sddf_dprintf("Failed to send UDP packet through socket: %s\n", lwip_strerr(error));
     pbuf_free(p);
 }
 
@@ -70,7 +70,7 @@ int setup_udp_socket(void)
 {
     udp_socket = udp_new_ip_type(IPADDR_TYPE_V4);
     if (udp_socket == NULL) {
-        dprintf("Failed to open a UDP socket\n");
+        sddf_dprintf("Failed to open a UDP socket\n");
         return -1;
     }
 
@@ -78,7 +78,7 @@ int setup_udp_socket(void)
     if (error == ERR_OK) {
         udp_recv(udp_socket, lwip_udp_recv_callback, udp_socket);
     } else {
-        dprintf("Failed to bind the UDP socket\n");
+        sddf_dprintf("Failed to bind the UDP socket\n");
         return -1;
     }
 

--- a/examples/echo_server/utilization_socket.c
+++ b/examples/echo_server/utilization_socket.c
@@ -137,15 +137,15 @@ static err_t utilization_recv_callback(void *arg, struct tcp_pcb *pcb, struct pb
 
     if (msg_match(data_packet_str, HELLO)) {
         error = tcp_write(pcb, OK_READY, strlen(OK_READY), TCP_WRITE_FLAG_COPY);
-        if (error) dprintf("Failed to send OK_READY message through utilization peer\n");
+        if (error) sddf_dprintf("Failed to send OK_READY message through utilization peer\n");
     } else if (msg_match(data_packet_str, LOAD)) {
         error = tcp_write(pcb, OK, strlen(OK), TCP_WRITE_FLAG_COPY);
-        if (error) dprintf("Failed to send OK message through utilization peer\n");
+        if (error) sddf_dprintf("Failed to send OK message through utilization peer\n");
     } else if (msg_match(data_packet_str, SETUP)) {
         error = tcp_write(pcb, OK, strlen(OK), TCP_WRITE_FLAG_COPY);
-        if (error) dprintf("Failed to send OK message through utilization peer\n");
+        if (error) sddf_dprintf("Failed to send OK message through utilization peer\n");
     } else if (msg_match(data_packet_str, START)) {
-        printf("%s measurement starting... \n", microkit_name);
+        sddf_printf("%s measurement starting... \n", microkit_name);
         if (!strcmp(microkit_name, "client0")) {
             start = bench->ts;
             idle_ccount_start = bench->ccount;
@@ -153,7 +153,7 @@ static err_t utilization_recv_callback(void *arg, struct tcp_pcb *pcb, struct pb
             microkit_notify(START_PMU);
         }
     } else if (msg_match(data_packet_str, STOP)) {
-        printf("%s measurement finished \n", microkit_name);
+        sddf_printf("%s measurement finished \n", microkit_name);
 
         uint64_t total = 0, idle = 0;
 
@@ -188,9 +188,9 @@ static err_t utilization_recv_callback(void *arg, struct tcp_pcb *pcb, struct pb
     } else if (msg_match(data_packet_str, QUIT)) {
         /* Do nothing for now */
     } else {
-        dprintf("Received a message that we can't handle %s\n", data_packet_str);
+        sddf_dprintf("Received a message that we can't handle %s\n", data_packet_str);
         error = tcp_write(pcb, ERROR, strlen(ERROR), TCP_WRITE_FLAG_COPY);
-        if (error) dprintf("Failed to send OK message through utilization peer\n");
+        if (error) sddf_dprintf("Failed to send OK message through utilization peer\n");
     }
 
     return ERR_OK;
@@ -198,9 +198,9 @@ static err_t utilization_recv_callback(void *arg, struct tcp_pcb *pcb, struct pb
 
 static err_t utilization_accept_callback(void *arg, struct tcp_pcb *newpcb, err_t err)
 {
-    printf("Utilization connection established!\n");
+    sddf_printf("Utilization connection established!\n");
     err_t error = tcp_write(newpcb, WHOAMI, strlen(WHOAMI), TCP_WRITE_FLAG_COPY);
-    if (error) dprintf("Failed to send WHOAMI message through utilization peer\n");
+    if (error) sddf_dprintf("Failed to send WHOAMI message through utilization peer\n");
     tcp_sent(newpcb, utilization_sent_callback);
     tcp_recv(newpcb, utilization_recv_callback);
 
@@ -211,19 +211,19 @@ int setup_utilization_socket(void)
 {
     utiliz_socket = tcp_new_ip_type(IPADDR_TYPE_V4);
     if (utiliz_socket == NULL) {
-        dprintf("Failed to open a socket for listening!\n");
+        sddf_dprintf("Failed to open a socket for listening!\n");
         return -1;
     }
 
     err_t error = tcp_bind(utiliz_socket, IP_ANY_TYPE, UTILIZATION_PORT);
     if (error) {
-        dprintf("Failed to bind the TCP socket");
+        sddf_dprintf("Failed to bind the TCP socket");
         return -1;
     }
 
     utiliz_socket = tcp_listen_with_backlog_and_err(utiliz_socket, 1, &error);
     if (error != ERR_OK) {
-        dprintf("Failed to listen on the utilization socket\n");
+        sddf_dprintf("Failed to listen on the utilization socket\n");
         return -1;
     }
     tcp_accept(utiliz_socket, utilization_accept_callback);

--- a/examples/i2c/client.c
+++ b/examples/i2c/client.c
@@ -10,11 +10,11 @@
 // #define DEBUG_CLIENT
 
 #ifdef DEBUG_CLIENT
-#define LOG_CLIENT(...) do{ printf("CLIENT|INFO: "); printf(__VA_ARGS__); }while(0)
+#define LOG_CLIENT(...) do{ sddf_dprintf("CLIENT|INFO: "); sddf_printf(__VA_ARGS__); }while(0)
 #else
 #define LOG_CLIENT(...) do{}while(0)
 #endif
-#define LOG_CLIENT_ERR(...) do{ printf("CLIENT|ERROR: "); printf(__VA_ARGS__); }while(0)
+#define LOG_CLIENT_ERR(...) do{ sddf_printf("CLIENT|ERROR: "); sddf_printf(__VA_ARGS__); }while(0)
 
 uintptr_t data_region;
 uintptr_t request_region;
@@ -137,12 +137,12 @@ void client_main(void) {
 
         if (success) {
             LOG_CLIENT("Found a card!\n");
-            printf("UID Length: %d bytes\n", uid_length);
-            printf("UID Value: ");
+            sddf_printf("UID Length: %d bytes\n", uid_length);
+            sddf_printf("UID Value: ");
             for (int i = 0; i < uid_length; i++) {
-                printf(" 0x%lx", uid[i]);
+                sddf_printf(" 0x%lx", uid[i]);
             }
-            printf("\n");
+            sddf_printf("\n");
         } else {
             // PN532 probably timed out waiting for a card
             LOG_CLIENT_ERR("Timed out waiting for a card\n");

--- a/examples/i2c/pn532.c
+++ b/examples/i2c/pn532.c
@@ -9,12 +9,12 @@
 // #define DEBUG_PN532
 
 #ifdef DEBUG_PN532
-#define LOG_PN532(...) do{ printf("PN532|INFO: "); printf(__VA_ARGS__); }while(0)
+#define LOG_PN532(...) do{ sddf_dprintf("PN532|INFO: "); sddf_dprintf(__VA_ARGS__); }while(0)
 #else
 #define LOG_PN532(...) do{}while(0)
 #endif
 
-#define LOG_PN532_ERR(...) do{ printf("PN532|ERROR: "); printf(__VA_ARGS__); }while(0)
+#define LOG_PN532_ERR(...) do{ sddf_printf("PN532|ERROR: "); sddf_printf(__VA_ARGS__); }while(0)
 
 extern cothread_t t_event;
 extern cothread_t t_main;

--- a/i2c/components/virtualiser.c
+++ b/i2c/components/virtualiser.c
@@ -12,12 +12,12 @@
 // #define DEBUG_VIRTUALISER
 
 #ifdef DEBUG_VIRTUALISER
-#define LOG_VIRTUALISER(...) do{ printf("I2C VIRTUALISER|INFO: "); printf(__VA_ARGS__); }while(0)
+#define LOG_VIRTUALISER(...) do{ sddf_dprintf("I2C VIRTUALISER|INFO: "); sddf_dprintf(__VA_ARGS__); }while(0)
 #else
 #define LOG_VIRTUALISER(...) do{}while(0)
 #endif
 
-#define LOG_VIRTUALISER_ERR(...) do{ printf("I2C VIRTUALISER|ERROR: "); printf(__VA_ARGS__); }while(0)
+#define LOG_VIRTUALISER_ERR(...) do{ sddf_printf("I2C VIRTUALISER|ERROR: "); sddf_printf(__VA_ARGS__); }while(0)
 
 #define BUS_UNCLAIMED (-1)
 

--- a/include/sddf/util/printf.h
+++ b/include/sddf/util/printf.h
@@ -29,8 +29,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef _PRINTF_H_
-#define _PRINTF_H_
+#ifndef _SDDF_PRINTF_H_
+#define _SDDF_PRINTF_H_
 
 #include <stdarg.h>
 #include <stddef.h>
@@ -41,9 +41,9 @@ extern "C" {
 #endif
 
 #ifdef CONFIG_DEBUG_BUILD
-#define dprintf(fmt, ...) printf(fmt, ##__VA_ARGS__);
+#define sddf_dprintf(fmt, ...) sddf_printf(fmt, ##__VA_ARGS__);
 #else
-#define dprintf(...)
+#define sddf_dprintf(...)
 #endif
 
 /**
@@ -51,7 +51,7 @@ extern "C" {
  * This function is declared here only. You have to write your custom implementation somewhere
  * \param character Character to output
  */
-void _putchar(char character);
+void _sddf_putchar(char character);
 
 
 /**
@@ -62,8 +62,8 @@ void _putchar(char character);
  * \param format A string that specifies the format of the output
  * \return The number of characters that are written into the array, not counting the terminating null character
  */
-#define printf printf_
-int printf_(const char* format, ...);
+#define sddf_printf sddf_printf_
+int sddf_printf_(const char* format, ...);
 
 
 /**
@@ -73,8 +73,8 @@ int printf_(const char* format, ...);
  * \param format A string that specifies the format of the output
  * \return The number of characters that are WRITTEN into the buffer, not counting the terminating null character
  */
-#define sprintf sprintf_
-int sprintf_(char* buffer, const char* format, ...);
+#define sddf_sprintf sddf_sprintf_
+int sddf_sprintf_(char* buffer, const char* format, ...);
 
 
 /**
@@ -87,10 +87,10 @@ int sprintf_(char* buffer, const char* format, ...);
  *         null character. A value equal or larger than count indicates truncation. Only when the returned value
  *         is non-negative and less than count, the string has been completely written.
  */
-#define snprintf  snprintf_
-#define vsnprintf vsnprintf_
-int  snprintf_(char* buffer, size_t count, const char* format, ...);
-int vsnprintf_(char* buffer, size_t count, const char* format, va_list va);
+#define sddf_snprintf  sddf_snprintf_
+#define sddf_vsnprintf sddf_vsnprintf_
+int  sddf_snprintf_(char* buffer, size_t count, const char* format, ...);
+int sddf_vsnprintf_(char* buffer, size_t count, const char* format, va_list va);
 
 
 /**
@@ -99,8 +99,8 @@ int vsnprintf_(char* buffer, size_t count, const char* format, va_list va);
  * \param va A value identifying a variable arguments list
  * \return The number of characters that are WRITTEN into the buffer, not counting the terminating null character
  */
-#define vprintf vprintf_
-int vprintf_(const char* format, va_list va);
+#define sddf_vprintf sddf_vprintf_
+int sddf_vprintf_(const char* format, va_list va);
 
 
 /**
@@ -111,7 +111,7 @@ int vprintf_(const char* format, va_list va);
  * \param format A string that specifies the format of the output
  * \return The number of characters that are sent to the output function, not counting the terminating null character
  */
-int fctprintf(void (*out)(char character, void* arg), void* arg, const char* format, ...);
+int sddf_fctprintf(void (*out)(char character, void* arg), void* arg, const char* format, ...);
 
 
 #ifdef __cplusplus
@@ -119,4 +119,4 @@ int fctprintf(void (*out)(char character, void* arg), void* arg, const char* for
 #endif
 
 
-#endif  // _PRINTF_H_
+#endif  // _SDDF_PRINTF_H_

--- a/include/sddf/util/util.h
+++ b/include/sddf/util/util.h
@@ -35,7 +35,7 @@
 
 static void _assert_fail(const char  *assertion, const char  *file, unsigned int line, const char  *function)
 {
-    dprintf("Failed assertion '%s' at %s:%u in function %s\n", assertion, file, line, function);
+    sddf_dprintf("Failed assertion '%s' at %s:%u in function %s\n", assertion, file, line, function);
     while (1) {}
 }
 

--- a/network/components/arp.c
+++ b/network/components/arp.c
@@ -92,7 +92,7 @@ static int arp_reply(const uint8_t ethsrc_addr[ETH_HWADDR_LEN],
                 const uint8_t hwdst_addr[ETH_HWADDR_LEN], const uint32_t ipdst_addr)
 {
     if (ring_empty(tx_ring.free_ring)) {
-        dprintf("ARP|LOG: Transmit free ring empty or transmit used ring full. Dropping reply\n");
+        sddf_dprintf("ARP|LOG: Transmit free ring empty or transmit used ring full. Dropping reply\n");
         return -1;
     }
 
@@ -182,7 +182,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
 {
     int client = ch - CLIENT_CH;
     if (client >= NUM_ARP_CLIENTS || client < 0) {
-        dprintf("ARP|LOG: PPC from unkown client %d\n", client);
+        sddf_dprintf("ARP|LOG: PPC from unkown client %d\n", client);
         return microkit_msginfo_new(0, 0);
     }
 
@@ -194,13 +194,13 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
     char buf[16];
     switch (microkit_msginfo_get_label(msginfo)) {
         case REG_IP:
-            printf("ARP|NOTICE: client%d registering ip address: %s with MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", 
+            sddf_printf("ARP|NOTICE: client%d registering ip address: %s with MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", 
                         client, ipaddr_to_string(ip_addr, buf, 16), mac >> 40, mac >> 32 & 0xff, mac >> 24 & 0xff, 
                         mac >> 16 & 0xff, mac >> 8 & 0xff, mac & 0xff);
             ipv4_addrs[client] = ip_addr;
             break;
         default:
-            dprintf("ARP|LOG: PPC from client%d with unknown message label %llu\n", client, microkit_msginfo_get_label(msginfo));
+            sddf_dprintf("ARP|LOG: PPC from client%d with unknown message label %llu\n", client, microkit_msginfo_get_label(msginfo));
             break;
     }
 

--- a/network/components/copy.c
+++ b/network/components/copy.c
@@ -33,7 +33,7 @@ void rx_return(void)
             assert(!err);
 
             if (cli_buffer.phys_or_offset % BUFF_SIZE || cli_buffer.phys_or_offset >= BUFF_SIZE * ((ring_buffer_t *)rx_free_cli)->size) {
-                dprintf("COPY|LOG: Client provided offset %llx which is not buffer aligned or outside of buffer region\n", cli_buffer.phys_or_offset);
+                sddf_dprintf("COPY|LOG: Client provided offset %llx which is not buffer aligned or outside of buffer region\n", cli_buffer.phys_or_offset);
                 continue;
             }
 

--- a/network/components/mux_tx.c
+++ b/network/components/mux_tx.c
@@ -59,7 +59,7 @@ void tx_provide(void)
 
                 if (buffer.phys_or_offset % BUFF_SIZE || 
                     buffer.phys_or_offset >= BUFF_SIZE * state.tx_ring_clients[client].used_ring->size) {
-                    dprintf("MUX_TX|LOG: Client provided offset %llx which is not buffer aligned or outside of buffer region\n", buffer.phys_or_offset);
+                    sddf_dprintf("MUX_TX|LOG: Client provided offset %llx which is not buffer aligned or outside of buffer region\n", buffer.phys_or_offset);
                     err = enqueue_free(&state.tx_ring_clients[client], buffer);
                     assert(!err);
                     continue;

--- a/util/printf.c
+++ b/util/printf.c
@@ -150,7 +150,7 @@ static inline void _out_char(char character, void* buffer, size_t idx, size_t ma
 {
   (void)buffer; (void)idx; (void)maxlen;
   if (character) {
-    _putchar(character);
+    _sddf_putchar(character);
   }
 }
 
@@ -859,7 +859,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
 
 ///////////////////////////////////////////////////////////////////////////////
 
-int printf_(const char* format, ...)
+int sddf_printf_(const char* format, ...)
 {
   va_list va;
   va_start(va, format);
@@ -870,7 +870,7 @@ int printf_(const char* format, ...)
 }
 
 
-int sprintf_(char* buffer, const char* format, ...)
+int sddf_sprintf_(char* buffer, const char* format, ...)
 {
   va_list va;
   va_start(va, format);
@@ -880,7 +880,7 @@ int sprintf_(char* buffer, const char* format, ...)
 }
 
 
-int snprintf_(char* buffer, size_t count, const char* format, ...)
+int sddf_snprintf_(char* buffer, size_t count, const char* format, ...)
 {
   va_list va;
   va_start(va, format);
@@ -890,20 +890,20 @@ int snprintf_(char* buffer, size_t count, const char* format, ...)
 }
 
 
-int vprintf_(const char* format, va_list va)
+int sddf_vprintf_(const char* format, va_list va)
 {
   char buffer[1];
   return _vsnprintf(_out_char, buffer, (size_t)-1, format, va);
 }
 
 
-int vsnprintf_(char* buffer, size_t count, const char* format, va_list va)
+int sddf_vsnprintf_(char* buffer, size_t count, const char* format, va_list va)
 {
   return _vsnprintf(_out_buffer, buffer, count, format, va);
 }
 
 
-int fctprintf(void (*out)(char character, void* arg), void* arg, const char* format, ...)
+int sddf_fctprintf(void (*out)(char character, void* arg), void* arg, const char* format, ...)
 {
   va_list va;
   va_start(va, format);

--- a/util/putchar_debug.c
+++ b/util/putchar_debug.c
@@ -1,6 +1,6 @@
 #include <microkit.h>
 
-void _putchar(char character)
+void _sddf_putchar(char character)
 {
     microkit_dbg_putc(character);
 }

--- a/util/putchar_serial.c
+++ b/util/putchar_serial.c
@@ -10,7 +10,7 @@ extern uintptr_t uart_base;
 #define TRANSMIT 0x40
 #define STAT_TDRE (1 << 14)
 
-void _putchar(char character)
+void _sddf_putchar(char character)
 {
     while (!(*REG_PTR(UART_STATUS) & STAT_TDRE)) { }
     *REG_PTR(TRANSMIT) = character;
@@ -24,7 +24,7 @@ void _putchar(char character)
 #define UART_WFIFO 0x0
 #define UART_TX_FULL (1 << 21)
 
-void _putchar(char character)
+void _sddf_putchar(char character)
 {
     while ((*REG_PTR(UART_STATUS) & UART_TX_FULL)) {}
     *REG_PTR(UART_WFIFO) = character & 0x7f;


### PR DESCRIPTION
We are encountering in LionsOS that our custom sDDF printf is clashing with printf from libc. This is a temporary measure to ensure systems using libc can be built with sDDF.

We have two options to deal with this:
* sDDF either declares the minimal libc functionality it needs (memcpy, some str functions, printf etc) and it is up to the user of sDDF to bring these functions along.
* Use our libc tailored for Microkit/LionsOS in this repository.

It is not clear what we will do yet.