### PR TITLE
i2c: add helpers for claiming and releasing a bus

### DIFF
--- a/examples/i2c/client.c
+++ b/examples/i2c/client.c
@@ -172,9 +172,11 @@ void init(void) {
 
     queue = i2c_queue_init((i2c_queue_t *) request_region, (i2c_queue_t *) response_region);
 
-    microkit_msginfo msginfo = microkit_msginfo_new(I2C_BUS_CLAIM, 1);
-    microkit_mr_set(I2C_BUS_SLOT, PN532_I2C_BUS_ADDRESS);
-    msginfo = microkit_ppcall(I2C_VIRTUALISER_CH, msginfo);
+    bool claimed = i2c_bus_claim(I2C_VIRTUALISER_CH, PN532_I2C_BUS_ADDRESS);
+    if (!claimed) {
+        LOG_CLIENT_ERR("failed to claim PN532 bus\n");
+        return;
+    }
 
     /* Define the event loop/notified thread as the active co-routine */
     t_event = co_active();

--- a/include/sddf/i2c/client.h
+++ b/include/sddf/i2c/client.h
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
+#include <microkit.h>
 
 /* By default we assume a 7-bit bus address. */
 #ifndef I2C_BUS_ADDRESS_MAX
@@ -18,3 +19,20 @@
 /* This is the label of the PPC response from the virtualiser */
 #define I2C_SUCCESS (0)
 #define I2C_FAILURE (1)
+
+/* Helpers for interacting with the virutaliser. */
+static inline bool i2c_bus_claim(microkit_channel virt_ch, size_t bus_address) {
+    microkit_msginfo msginfo = microkit_msginfo_new(I2C_BUS_CLAIM, 1);
+    microkit_mr_set(I2C_BUS_SLOT, bus_address);
+    msginfo = microkit_ppcall(virt_ch, msginfo);
+
+    return microkit_msginfo_get_label(msginfo) == I2C_SUCCESS;
+}
+
+static inline bool i2c_bus_release(microkit_channel virt_ch, size_t bus_address) {
+    microkit_msginfo msginfo = microkit_msginfo_new(I2C_BUS_RELEASE, 1);
+    microkit_mr_set(I2C_BUS_SLOT, bus_address);
+    msginfo = microkit_ppcall(virt_ch, msginfo);
+
+    return microkit_msginfo_get_label(msginfo) == I2C_SUCCESS;
+}


### PR DESCRIPTION
Abstracts over the possible interactions to the virtualiser, this will decrease the duplicated code across clients but more importantly, will mean that slight changes to the API with the virtualiser do not lead to breaking changes to the clientss since they aren't doing PPC directly.