### PR TITLE
Support emitting warnings for incorrectly using sddf printf functions.

### DIFF
--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -113,8 +113,8 @@ static void print_benchmark_details(uint64_t pd_id, uint64_t kernel_util, uint64
         case PD_ARP_ID: sddf_printf("ARP"); break;
         case PD_TIMER_ID: sddf_printf("TIMER"); break;
     }
-    if (pd_id != PD_TOTAL) sddf_printf(" ( %llx)", pd_id);
-    sddf_printf("\n{\nKernelUtilisation:  %llx\nKernelEntries:  %llx\nNumberSchedules:  %llx\nTotalUtilisation:  %llx\n}\n", 
+    if (pd_id != PD_TOTAL) sddf_printf(" ( %lx)", pd_id);
+    sddf_printf("\n{\nKernelUtilisation:  %lx\nKernelEntries:  %lx\nNumberSchedules:  %lx\nTotalUtilisation:  %lx\n}\n",
             kernel_util, kernel_entries, number_schedules, total_util);
 }
 #endif

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -177,7 +177,7 @@ void notified(microkit_channel ch)
 
             sddf_printf("{\n");
             for (int i = 0; i < ARRAY_SIZE(benchmarking_events); i++) {
-                sddf_printf("%s: %llX\n", counter_names[i], counter_values[i]);
+                sddf_printf("%s: %lX\n", counter_names[i], counter_values[i]);
             }
             sddf_printf("}\n");
 

--- a/benchmark/idle.c
+++ b/benchmark/idle.c
@@ -57,7 +57,7 @@ void notified(microkit_channel ch)
             count_idle();
             break;
         default:
-            sddf_dprintf("Idle thread notified on unexpected channel: %llu\n", ch);
+            sddf_dprintf("Idle thread notified on unexpected channel: %u\n", ch);
     }
 }
 

--- a/drivers/clock/imx/timer.c
+++ b/drivers/clock/imx/timer.c
@@ -154,7 +154,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
             }
             break;
         default:
-            sddf_dprintf("TIMER DRIVER|LOG: Unknown request %llu to timer from channel %llu\n", microkit_msginfo_get_label(msginfo), ch);
+            sddf_dprintf("TIMER DRIVER|LOG: Unknown request %lu to timer from channel %u\n", microkit_msginfo_get_label(msginfo), ch);
             break;
     }
 

--- a/drivers/clock/meson/timer.c
+++ b/drivers/clock/meson/timer.c
@@ -131,7 +131,7 @@ notified(microkit_channel ch)
         handle_irq(ch);
         microkit_irq_ack_delayed(ch);
     } else {
-        sddf_dprintf("TIMER DRIVER|LOG: unexpected notification %llu\n", ch);
+        sddf_dprintf("TIMER DRIVER|LOG: unexpected notification %u\n", ch);
     }
 }
 
@@ -169,7 +169,7 @@ protected(microkit_channel ch, microkit_msginfo msginfo)
             }
             break;
         default:
-            sddf_dprintf("TIMER DRIVER|LOG: Unknown request %llu to timer from channel %llu\n", microkit_msginfo_get_label(msginfo), ch);
+            sddf_dprintf("TIMER DRIVER|LOG: Unknown request %lu to timer from channel %u\n", microkit_msginfo_get_label(msginfo), ch);
             break;
     }
 

--- a/drivers/i2c/meson/i2c.c
+++ b/drivers/i2c/meson/i2c.c
@@ -511,7 +511,7 @@ static inline void handle_request(void) {
         LOG_DRIVER("Loading request from client %u to address 0x%x of sz %zu\n", req[0], req[1], size);
 
         if (size > I2C_MAX_DATA_SIZE) {
-            LOG_DRIVER_ERR("Invalid request size: %zu!\n", size);
+            LOG_DRIVER_ERR("Invalid request size: %u!\n", size);
             return;
         }
         i2c_ifState.curr_request_data = (i2c_token_t *) DATA_REGIONS_START + offset;

--- a/drivers/network/imx/ethernet.c
+++ b/drivers/network/imx/ethernet.c
@@ -325,7 +325,7 @@ void notified(microkit_channel ch)
             tx_provide();
             break;
         default:
-            sddf_dprintf("ETH|LOG: received notification on unexpected channel: %lu\n", ch);
+            sddf_dprintf("ETH|LOG: received notification on unexpected channel: %u\n", ch);
             break;
     }
 }

--- a/drivers/network/meson/ethernet.c
+++ b/drivers/network/meson/ethernet.c
@@ -277,7 +277,7 @@ void notified(microkit_channel ch)
             tx_provide();
             break;
         default:
-            sddf_dprintf("ETH|LOG: received notification on unexpected channel %llu\n", ch);
+            sddf_dprintf("ETH|LOG: received notification on unexpected channel %u\n", ch);
             break;
     }
 }

--- a/examples/echo_server/lwip.c
+++ b/examples/echo_server/lwip.c
@@ -151,7 +151,7 @@ void enqueue_pbufs(struct pbuf *p)
 static err_t lwip_eth_send(struct netif *netif, struct pbuf *p)
 {   
     if (p->tot_len > NET_BUFFER_SIZE) {
-        sddf_dprintf("LWIP|ERROR: attempted to send a packet of size  %llx > BUFFER SIZE  %llx\n", p->tot_len, NET_BUFFER_SIZE);
+        sddf_dprintf("LWIP|ERROR: attempted to send a packet of size  %u > BUFFER SIZE  %u\n", p->tot_len, NET_BUFFER_SIZE);
         return ERR_MEM;
     }
 
@@ -187,10 +187,10 @@ void transmit(void)
         while(state.head != NULL && !net_queue_empty(state.tx_queue.free)) {
             err_t err = lwip_eth_send(&state.netif, state.head);
             if (err == ERR_MEM) {
-                sddf_dprintf("LWIP|ERROR: attempted to send a packet of size  %llx > BUFFER SIZE  %llx\n", state.head->tot_len, NET_BUFFER_SIZE);
+                sddf_dprintf("LWIP|ERROR: attempted to send a packet of size  %u > BUFFER SIZE  %u\n", state.head->tot_len, NET_BUFFER_SIZE);
             }
             else if (err != ERR_OK) {
-                sddf_dprintf("LWIP|ERROR: unkown error when trying to send pbuf  %llx\n", state.head);
+                sddf_dprintf("LWIP|ERROR: unkown error when trying to send pbuf  %p\n", state.head);
             }
             
             struct pbuf *temp = state.head;
@@ -339,7 +339,7 @@ void notified(microkit_channel ch)
             receive();
             break;
         default:
-            sddf_dprintf("LWIP|LOG: received notification on unexpected channel: %lu\n", ch);
+            sddf_dprintf("LWIP|LOG: received notification on unexpected channel: %u\n", ch);
             break;
     }
     

--- a/examples/i2c/client.c
+++ b/examples/i2c/client.c
@@ -41,7 +41,7 @@ bool read_passive_target_id(uint8_t card_baud_rate, uint8_t *uid_buf, uint8_t *u
     if (!response_ret) return false;
 
     if (response[0] != 1) {
-        LOG_CLIENT_ERR("tags found has wrong response value (0x%lx)!\n", response[0]);
+        LOG_CLIENT_ERR("tags found has wrong response value (0x%x)!\n", response[0]);
         return false;
     }
 
@@ -140,7 +140,7 @@ void client_main(void) {
             sddf_printf("UID Length: %d bytes\n", uid_length);
             sddf_printf("UID Value: ");
             for (int i = 0; i < uid_length; i++) {
-                sddf_printf(" 0x%lx", uid[i]);
+                sddf_printf(" 0x%x", uid[i]);
             }
             sddf_printf("\n");
         } else {

--- a/examples/i2c/pn532.c
+++ b/examples/i2c/pn532.c
@@ -69,7 +69,7 @@ void response_init(struct response *response) {
 
 uint8_t response_read(struct response *response) {
     if (response->read_idx >= response->data_size) {
-        LOG_PN532_ERR("trying to read more data than exists in response (buffer: 0x%lx)\n", response->buffer);
+        LOG_PN532_ERR("trying to read more data than exists in response (buffer: %p)\n", response->buffer);
         return 0;
     }
 
@@ -81,7 +81,7 @@ uint8_t response_read(struct response *response) {
 
 uint8_t response_read_idx(struct response *response, uint8_t idx) {
     if (idx >= response->data_size) {
-        LOG_PN532_ERR("trying to read more data than exists in response (buffer: 0x%lx)\n", response->buffer);
+        LOG_PN532_ERR("trying to read more data than exists in response (buffer: %p)\n", response->buffer);
         return 0;
     }
 
@@ -399,7 +399,7 @@ bool pn532_read_response(uint8_t *buffer, uint8_t buffer_len, size_t retries) {
     // Read length
     size_t data_length = response_read(&response);
     if (data_length != length) {
-        LOG_PN532_ERR("Received data_length of 0x%lx, was expecting 0x%lx\n", data_length, length);
+        LOG_PN532_ERR("Received data_length of 0x%lx, was expecting 0x%x\n", data_length, length);
         response_finish(&response);
         return false;
     }
@@ -412,7 +412,7 @@ bool pn532_read_response(uint8_t *buffer, uint8_t buffer_len, size_t retries) {
     response_read(&response);
     // Read command data
     if (data_length > buffer_len) {
-        LOG_PN532_ERR("returned data length (0x%lx) greater than user-provided buffer length (0x%lx)\n", data_length, buffer_len);
+        LOG_PN532_ERR("returned data length (0x%lx) greater than user-provided buffer length (0x%x)\n", data_length, buffer_len);
         response_finish(&response);
         return false;
     }

--- a/i2c/components/virt.c
+++ b/i2c/components/virt.c
@@ -68,12 +68,12 @@ void process_request(microkit_channel ch) {
 
         // Check that client can actually access bus
         if (bus_address > I2C_BUS_ADDRESS_MAX || security_list[bus_address] != ch) {
-            LOG_VIRTUALISER_ERR("invalid bus address (0x%lx) requested by client 0x%lx\n", bus_address, ch);
+            LOG_VIRTUALISER_ERR("invalid bus address (0x%lx) requested by client 0x%x\n", bus_address, ch);
             continue;
         }
 
         if (offset > client_data_sizes[ch]) {
-            LOG_VIRTUALISER_ERR("invalid offset (0x%lx) given by client 0x%lx. Max offset is 0x%lx\n", offset, ch, client_data_sizes[ch]);
+            LOG_VIRTUALISER_ERR("invalid offset (0x%lx) given by client 0x%x. Max offset is 0x%lx\n", offset, ch, client_data_sizes[ch]);
             continue;
         }
 
@@ -148,13 +148,13 @@ seL4_MessageInfo_t protected(microkit_channel ch, seL4_MessageInfo_t msginfo) {
     size_t bus = microkit_mr_get(I2C_BUS_SLOT);
 
     if (label != I2C_BUS_CLAIM && label != I2C_BUS_RELEASE) {
-        LOG_VIRTUALISER_ERR("unknown label (0x%lx) given by client on channel 0x%lx\n", label, ch);
+        LOG_VIRTUALISER_ERR("unknown label (0x%lx) given by client on channel 0x%x\n", label, ch);
         return microkit_msginfo_new(I2C_FAILURE, 0);
     }
 
     if (bus > I2C_BUS_ADDRESS_MAX) {
         LOG_VIRTUALISER_ERR("invalid bus address (0x%lx) given by client on "
-                            "channel 0x%lx. Max bus address is 0x%lx\n", bus, ch, I2C_BUS_ADDRESS_MAX);
+                            "channel 0x%x. Max bus address is 0x%x\n", bus, ch, I2C_BUS_ADDRESS_MAX);
         return microkit_msginfo_new(I2C_FAILURE, 0);
     }
 
@@ -162,7 +162,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, seL4_MessageInfo_t msginfo) {
         case I2C_BUS_CLAIM:
             // We have a valid bus address, we need to make sure no one else has claimed it.
             if (security_list[bus] != BUS_UNCLAIMED) {
-                LOG_VIRTUALISER_ERR("bus address 0x%lx already claimed, cannot claim for channel 0x%lx\n", bus, ch);
+                LOG_VIRTUALISER_ERR("bus address 0x%lx already claimed, cannot claim for channel 0x%x\n", bus, ch);
                 return microkit_msginfo_new(I2C_FAILURE, 0);
             }
 
@@ -170,7 +170,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, seL4_MessageInfo_t msginfo) {
             break;
         case I2C_BUS_RELEASE:
             if (security_list[bus] != ch) {
-                LOG_VIRTUALISER_ERR("bus address 0x%lx is not claimed by channel 0x%lx\n", bus, ch);
+                LOG_VIRTUALISER_ERR("bus address 0x%lx is not claimed by channel 0x%x\n", bus, ch);
                 return microkit_msginfo_new(I2C_FAILURE, 0);
             }
 

--- a/include/sddf/util/printf.h
+++ b/include/sddf/util/printf.h
@@ -63,7 +63,7 @@ void _sddf_putchar(char character);
  * \return The number of characters that are written into the array, not counting the terminating null character
  */
 #define sddf_printf sddf_printf_
-int sddf_printf_(const char* format, ...);
+int sddf_printf_(const char* format, ...) __attribute__((format(printf, 1, 2)));
 
 
 /**
@@ -74,7 +74,7 @@ int sddf_printf_(const char* format, ...);
  * \return The number of characters that are WRITTEN into the buffer, not counting the terminating null character
  */
 #define sddf_sprintf sddf_sprintf_
-int sddf_sprintf_(char* buffer, const char* format, ...);
+int sddf_sprintf_(char* buffer, const char* format, ...) __attribute__((format(printf, 2, 3)));
 
 
 /**
@@ -89,7 +89,7 @@ int sddf_sprintf_(char* buffer, const char* format, ...);
  */
 #define sddf_snprintf  sddf_snprintf_
 #define sddf_vsnprintf sddf_vsnprintf_
-int  sddf_snprintf_(char* buffer, size_t count, const char* format, ...);
+int  sddf_snprintf_(char* buffer, size_t count, const char* format, ...) __attribute__((format(printf, 3, 4)));
 int sddf_vsnprintf_(char* buffer, size_t count, const char* format, va_list va);
 
 
@@ -111,7 +111,7 @@ int sddf_vprintf_(const char* format, va_list va);
  * \param format A string that specifies the format of the output
  * \return The number of characters that are sent to the output function, not counting the terminating null character
  */
-int sddf_fctprintf(void (*out)(char character, void* arg), void* arg, const char* format, ...);
+int sddf_fctprintf(void (*out)(char character, void* arg), void* arg, const char* format, ...) __attribute__((format(printf, 3, 4)));
 
 
 #ifdef __cplusplus

--- a/network/components/arp.c
+++ b/network/components/arp.c
@@ -194,13 +194,13 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
     char buf[16];
     switch (microkit_msginfo_get_label(msginfo)) {
         case REG_IP:
-            sddf_printf("ARP|NOTICE: client%d registering ip address: %s with MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", 
+            sddf_printf("ARP|NOTICE: client%d registering ip address: %s with MAC: %02lx:%02lx:%02lx:%02lx:%02lx:%02lx\n", 
                         client, ipaddr_to_string(ip_addr, buf, 16), mac >> 40, mac >> 32 & 0xff, mac >> 24 & 0xff, 
                         mac >> 16 & 0xff, mac >> 8 & 0xff, mac & 0xff);
             ipv4_addrs[client] = ip_addr;
             break;
         default:
-            sddf_dprintf("ARP|LOG: PPC from client%d with unknown message label %llu\n", client, microkit_msginfo_get_label(msginfo));
+            sddf_dprintf("ARP|LOG: PPC from client%d with unknown message label %lu\n", client, microkit_msginfo_get_label(msginfo));
             break;
     }
 

--- a/network/components/copy.c
+++ b/network/components/copy.c
@@ -33,7 +33,7 @@ void rx_return(void)
             assert(!err);
 
             if (cli_buffer.phys_or_offset % NET_BUFFER_SIZE || cli_buffer.phys_or_offset >= NET_BUFFER_SIZE * ((net_queue_t *)rx_free_cli)->size) {
-                sddf_dprintf("COPY|LOG: Client provided offset %llx which is not buffer aligned or outside of buffer region\n", cli_buffer.phys_or_offset);
+                sddf_dprintf("COPY|LOG: Client provided offset %lx which is not buffer aligned or outside of buffer region\n", cli_buffer.phys_or_offset);
                 continue;
             }
 

--- a/network/components/virt_tx.c
+++ b/network/components/virt_tx.c
@@ -59,7 +59,7 @@ void tx_provide(void)
 
                 if (buffer.phys_or_offset % NET_BUFFER_SIZE || 
                     buffer.phys_or_offset >= NET_BUFFER_SIZE * state.tx_queue_clients[client].active->size) {
-                    sddf_dprintf("VIRT_TX|LOG: Client provided offset %llx which is not buffer aligned or outside of buffer region\n", buffer.phys_or_offset);
+                    sddf_dprintf("VIRT_TX|LOG: Client provided offset %lx which is not buffer aligned or outside of buffer region\n", buffer.phys_or_offset);
                     err = net_enqueue_free(&state.tx_queue_clients[client], buffer);
                     assert(!err);
                     continue;


### PR DESCRIPTION
This makes sddf_printf (and others) be recognised as printf by the compiler, and raise warnings if the arguments don't match the format string.