### PR TITLE
blk virtualiser

### DIFF
--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -135,11 +135,13 @@ static void partitions_init()
 static void request_mbr()
 {
     uintptr_t mbr_addr;
-    fsmalloc_alloc(&fsmalloc, &mbr_addr, 1);
+    int err = fsmalloc_alloc(&fsmalloc, &mbr_addr, 1);
+    assert(!err);
 
     uint64_t mbr_req_id;
     reqbk_t mbr_req_data = {0, 0, 0, mbr_addr, 1, 0};
-    ialloc_alloc(&ialloc, &mbr_req_id);
+    err = ialloc_alloc(&ialloc, &mbr_req_id);
+    assert(!err);
     reqbk[mbr_req_id] = mbr_req_data;
 
     int err = blk_enqueue_req(&drv_h, READ_BLOCKS, mbr_addr, 0, 1, mbr_req_id);
@@ -341,7 +343,8 @@ static void handle_client(int cli_id)
 
         // Bookkeep client request and generate driver req ID
         reqbk_t cli_data = {cli_id, cli_req_id, cli_addr, drv_addr, cli_count, cli_code};
-        ialloc_alloc(&ialloc, &drv_req_id);
+        err = ialloc_alloc(&ialloc, &drv_req_id);
+        assert(!err);
         reqbk[drv_req_id] = cli_data;
 
         err = blk_enqueue_req(&drv_h, cli_code, drv_addr, drv_block_number, cli_count, drv_req_id);

--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -1,0 +1,371 @@
+#include <microkit.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <sddf/blk/fsmalloc.h>
+#include <sddf/blk/queue.h>
+#include <sddf/blk/msdos_mbr.h>
+#include <sddf/blk/util.h>
+#include <sddf/util/cache.h>
+#include <sddf/util/ialloc.h>
+#include <sddf/util/printf.h>
+#include <sddf/util/util.h>
+
+// #define DEBUG_BLK_VIRT
+
+#if defined(DEBUG_BLK_VIRT)
+#define LOG_BLK_VIRT(...) do{ sddf_dprintf("BLK_VIRT|INFO: "); sddf_dprintf(__VA_ARGS__); }while(0)
+#else
+#define LOG_BLK_VIRT(...) do{}while(0)
+#endif
+
+
+#define LOG_BLK_VIRT_ERR(...) do{ sddf_dprintf("BLK_VIRT|ERROR: "); sddf_dprintf(__VA_ARGS__); }while(0)
+
+/* TODO: Currently only works for 1 and 2 clients, need to handle multiple clients */
+
+#define MAX_BLK_NUM_CLIENTS 16
+
+#define DRIVER_CH 1
+#define CLIENT_CH_1 3
+#define CLIENT_CH_2 4
+
+#define MEM_REGION_SIZE 0x200000 //@ericc: autogen this from microkit xml system file
+#define DRV_MAX_DATA_BUFFERS (MEM_REGION_SIZE / BLK_TRANSFER_SIZE)
+
+#define REQBK_SIZE (BLK_NUM_CLIENTS * BLK_QUEUE_SIZE)
+
+uintptr_t blk_config_driver;
+uintptr_t blk_req_queue_driver;
+uintptr_t blk_resp_queue_driver;
+uintptr_t blk_data_driver;
+
+uintptr_t blk_config;
+uintptr_t blk_config2;
+uintptr_t blk_req_queue;
+uintptr_t blk_req_queue2;
+uintptr_t blk_resp_queue;
+uintptr_t blk_resp_queue2;
+uintptr_t blk_data;
+uintptr_t blk_data2;
+
+/* Client specific info */
+typedef struct client {
+    blk_queue_handle_t queue_h;
+    microkit_channel ch;
+    uint32_t start_sector;
+    uint32_t sectors;
+} client_t;
+client_t clients[MAX_BLK_NUM_CLIENTS];
+
+blk_queue_handle_t drv_h;
+
+/* Fixed size memory allocator */
+static fsmalloc_t fsmalloc;
+static bitarray_t fsmalloc_avail_bitarr;
+static word_t fsmalloc_avail_bitarr_words[roundup_bits2words64(DRV_MAX_DATA_BUFFERS)];
+
+/* Bookkeeping struct per request */
+typedef struct reqbk {
+    uint32_t cli_id;
+    uint32_t cli_req_id;
+    uintptr_t cli_addr;
+    uintptr_t drv_addr;
+    uint16_t count;
+    blk_request_code_t code;
+} reqbk_t;
+static reqbk_t reqbk[REQBK_SIZE];
+
+/* Index allocator for request bookkeep */
+static ialloc_t ialloc;
+static uint64_t ialloc_idxlist[REQBK_SIZE];
+
+/* MS-DOS Master boot record */
+struct msdos_mbr msdos_mbr;
+
+/* The virtualiser is not initialised until we can read the MBR and populate the block device configuration. */
+bool initialised = false;
+
+static void partitions_init()
+{
+    if (msdos_mbr.signature != MSDOS_MBR_SIGNATURE) {
+        LOG_BLK_VIRT_ERR("Invalid MBR signature\n");
+        return;
+    }
+
+    //@ericc: Figure out a better way to assign partitions to clients
+    int client_idx = 0;
+    int num_parts = 0;
+    for (int i = 0; i < MSDOS_MBR_MAX_PRIMARY_PARTITIONS; i++) {
+        if (msdos_mbr.partitions[i].type == MSDOS_MBR_PARTITION_TYPE_EMPTY) {
+            continue;
+        } else {
+            num_parts++;
+        }
+
+        if (client_idx < BLK_NUM_CLIENTS) {
+            clients[client_idx].start_sector = msdos_mbr.partitions[i].lba_start;
+            clients[client_idx].sectors = msdos_mbr.partitions[i].sectors;
+            client_idx++;
+        }
+
+        if (msdos_mbr.partitions[i].lba_start % (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE) != 0) {
+            LOG_BLK_VIRT_ERR("Partition %d start sector %d not aligned to sDDF transfer size\n", i,
+                             msdos_mbr.partitions[i].lba_start);
+            return;
+        }
+    }
+
+    if (num_parts < BLK_NUM_CLIENTS) {
+        LOG_BLK_VIRT_ERR("Not enough partitions to assign to clients\n");
+        return;
+    }
+
+    ((blk_storage_info_t *)blk_config)->sector_size = ((blk_storage_info_t *)blk_config_driver)->sector_size;
+    ((blk_storage_info_t *)blk_config)->size = clients[0].sectors / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE);
+    ((blk_storage_info_t *)blk_config)->read_only = false;
+    ((blk_storage_info_t *)blk_config)->ready = true;
+#if BLK_NUM_CLIENTS > 1
+    ((blk_storage_info_t *)blk_config2)->sector_size = ((blk_storage_info_t *)blk_config_driver)->sector_size;
+    ((blk_storage_info_t *)blk_config2)->size = clients[1].sectors / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE);
+    ((blk_storage_info_t *)blk_config2)->read_only = false;
+    ((blk_storage_info_t *)blk_config2)->ready = true;
+#endif
+}
+
+static void request_mbr()
+{
+    uintptr_t mbr_addr;
+    fsmalloc_alloc(&fsmalloc, &mbr_addr, 1);
+
+    uint64_t mbr_req_id;
+    reqbk_t mbr_req_data = {0, 0, 0, mbr_addr, 1, 0};
+    ialloc_alloc(&ialloc, &mbr_req_id);
+    reqbk[mbr_req_id] = mbr_req_data;
+
+    int err = blk_enqueue_req(&drv_h, READ_BLOCKS, mbr_addr, 0, 1, mbr_req_id);
+    assert(!err);
+
+    microkit_notify_delayed(DRIVER_CH);
+}
+
+static bool handle_mbr_reply()
+{
+    int err = 0;
+
+    if (blk_resp_queue_empty(&drv_h)) {
+        LOG_BLK_VIRT("Notified by driver but queue is empty, expecting a response to READ into sector 0\n");
+        return false;
+    }
+
+    blk_response_status_t drv_status;
+    uint16_t drv_success_count;
+    uint32_t drv_resp_id;
+    err = blk_dequeue_resp(&drv_h, &drv_status, &drv_success_count, &drv_resp_id);
+    assert(!err);
+
+    reqbk_t mbr_req_data = reqbk[drv_resp_id];
+    ialloc_free(&ialloc, drv_resp_id);
+
+    if (drv_status != SUCCESS) {
+        LOG_BLK_VIRT_ERR("Failed to read sector 0 from driver\n");
+        return false;
+    }
+
+    microkit_arm_vspace_data_invalidate(mbr_req_data.drv_addr,
+                                        mbr_req_data.drv_addr + (BLK_TRANSFER_SIZE * mbr_req_data.count));
+    memcpy(&msdos_mbr, (void *)mbr_req_data.drv_addr, sizeof(struct msdos_mbr));
+    fsmalloc_free(&fsmalloc, mbr_req_data.drv_addr, mbr_req_data.count);
+
+    return true;
+}
+
+void init(void)
+{
+    // @ericc: Hack, spin wait for config from driver to be set
+    while (!(((blk_storage_info_t *)blk_config_driver)->ready)) {
+        asm("");
+    }
+
+    // Initialise driver queue handle
+    blk_queue_init(&drv_h, (blk_req_queue_t *)blk_req_queue_driver, (blk_resp_queue_t *)blk_resp_queue_driver,
+                   BLK_QUEUE_SIZE);
+
+    // Initialise client queue handles
+    blk_queue_init(&(clients[0].queue_h), (blk_req_queue_t *)blk_req_queue, (blk_resp_queue_t *)blk_resp_queue,
+                   BLK_QUEUE_SIZE);
+#if BLK_NUM_CLIENTS > 1
+    blk_queue_init(&(clients[1].queue_h), (blk_req_queue_t *)blk_req_queue2, (blk_resp_queue_t *)blk_resp_queue2,
+                   BLK_QUEUE_SIZE);
+#endif
+
+    // Initialise fixed size memory allocator and ialloc
+    ialloc_init(&ialloc, ialloc_idxlist, REQBK_SIZE);
+    fsmalloc_init(&fsmalloc, blk_data_driver, BLK_TRANSFER_SIZE, DRV_MAX_DATA_BUFFERS, &fsmalloc_avail_bitarr,
+                  fsmalloc_avail_bitarr_words, roundup_bits2words64(DRV_MAX_DATA_BUFFERS));
+
+    // Initialise client channels
+    clients[0].ch = CLIENT_CH_1;
+#if BLK_NUM_CLIENTS > 1
+    clients[1].ch = CLIENT_CH_2;
+#endif
+
+    request_mbr();
+}
+
+static void handle_driver()
+{
+    blk_response_status_t drv_status;
+    uint16_t drv_success_count;
+    uint32_t drv_resp_id;
+
+    int err = 0;
+    while (!blk_resp_queue_empty(&drv_h)) {
+        err = blk_dequeue_resp(&drv_h, &drv_status, &drv_success_count, &drv_resp_id);
+        assert(!err);
+
+        reqbk_t cli_data = reqbk[drv_resp_id];
+        ialloc_free(&ialloc, drv_resp_id);
+
+        // Free bookkeeping data structures regardless of success or failure
+        switch (cli_data.code) {
+        case WRITE_BLOCKS:
+            fsmalloc_free(&fsmalloc, cli_data.drv_addr, cli_data.count);
+            break;
+        case READ_BLOCKS:
+            fsmalloc_free(&fsmalloc, cli_data.drv_addr, cli_data.count);
+            break;
+        case FLUSH:
+            break;
+        case BARRIER:
+            break;
+        }
+
+        // Get the corresponding client queue handle
+        blk_queue_handle_t h = clients[cli_data.cli_id].queue_h;
+
+        // Drop response if client resp queue is full
+        if (blk_resp_queue_full(&h)) {
+            continue;
+        }
+
+        if (drv_status == SUCCESS) {
+            switch (cli_data.code) {
+            case READ_BLOCKS:
+                // Invalidate cache
+                microkit_arm_vspace_data_invalidate(cli_data.drv_addr, cli_data.drv_addr + (BLK_TRANSFER_SIZE * cli_data.count));
+                // Copy data buffers from driver to client
+                memcpy((void *)cli_data.cli_addr, (void *)cli_data.drv_addr, BLK_TRANSFER_SIZE * cli_data.count);
+                err = blk_enqueue_resp(&h, SUCCESS, drv_success_count, cli_data.cli_req_id);
+                assert(!err);
+                break;
+            case WRITE_BLOCKS:
+                err = blk_enqueue_resp(&h, SUCCESS, drv_success_count, cli_data.cli_req_id);
+                assert(!err);
+                break;
+            case FLUSH:
+            case BARRIER:
+                err = blk_enqueue_resp(&h, SUCCESS, drv_success_count, cli_data.cli_req_id);
+                assert(!err);
+                break;
+            }
+        } else {
+            // When more error conditions are added, this will need to be updated to a switch statement
+            err = blk_enqueue_resp(&h, SEEK_ERROR, drv_success_count, cli_data.cli_req_id);
+            assert(!err);
+        }
+
+        // Notify corresponding client
+        microkit_notify(clients[cli_data.cli_id].ch);
+    }
+}
+
+static void handle_client(int cli_id)
+{
+    blk_queue_handle_t h = clients[cli_id].queue_h;
+
+    blk_request_code_t cli_code;
+    uintptr_t cli_addr;
+    uint32_t cli_block_number;
+    uint16_t cli_count;
+    uint32_t cli_req_id;
+
+    uintptr_t drv_addr;
+    uint32_t drv_block_number;
+    uint64_t drv_req_id;
+
+    int err = 0;
+    while (!blk_req_queue_empty(&h)) {
+        err = blk_dequeue_req(&h, &cli_code, &cli_addr, &cli_block_number, &cli_count, &cli_req_id);
+        assert(!err);
+
+        drv_block_number = cli_block_number + (clients[cli_id].start_sector / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE));
+
+        // Check if client request is within its allocated bounds
+        if (cli_code == READ_BLOCKS || cli_code == WRITE_BLOCKS) {
+            unsigned long client_sectors = clients[cli_id].sectors / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE);
+            unsigned long client_start_sector = clients[cli_id].start_sector / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE);
+            if (drv_block_number < client_start_sector || drv_block_number + cli_count > client_start_sector + client_sectors) {
+                err = blk_enqueue_resp(&h, SEEK_ERROR, 0, cli_req_id);
+                assert(!err);
+                continue;
+            }
+        }
+
+        switch (cli_code) {
+        case READ_BLOCKS:
+            if (blk_req_queue_full(&drv_h) || ialloc_full(&ialloc) || fsmalloc_full(&fsmalloc, cli_count)) {
+                continue;
+            }
+            // Allocate driver data buffers
+            fsmalloc_alloc(&fsmalloc, &drv_addr, cli_count);
+            break;
+        case WRITE_BLOCKS:
+            if (blk_req_queue_full(&drv_h) || ialloc_full(&ialloc) || fsmalloc_full(&fsmalloc, cli_count)) {
+                continue;
+            }
+            // Allocate driver data buffers
+            fsmalloc_alloc(&fsmalloc, &drv_addr, cli_count);
+            // Copy data buffers from client to driver
+            memcpy((void *)drv_addr, (void *)cli_addr, BLK_TRANSFER_SIZE * cli_count);
+            // Flush the cache
+            cache_clean(drv_addr, drv_addr + (BLK_TRANSFER_SIZE * cli_count));
+            break;
+        case FLUSH:
+        case BARRIER:
+            if (blk_req_queue_full(&drv_h) || ialloc_full(&ialloc)) {
+                continue;
+            }
+            drv_addr = cli_addr;
+            break;
+        }
+
+        // Bookkeep client request and generate driver req ID
+        reqbk_t cli_data = {cli_id, cli_req_id, cli_addr, drv_addr, cli_count, cli_code};
+        ialloc_alloc(&ialloc, &drv_req_id);
+        reqbk[drv_req_id] = cli_data;
+
+        err = blk_enqueue_req(&drv_h, cli_code, drv_addr, drv_block_number, cli_count, drv_req_id);
+        assert(!err);
+    }
+}
+
+void notified(microkit_channel ch)
+{
+    if (initialised == false) {
+        bool success = handle_mbr_reply();
+        if (success) {
+            partitions_init();
+            initialised = true;
+        };
+        return;
+    }
+
+    if (ch == DRIVER_CH) {
+        handle_driver();
+    } else {
+        for (int i = 0; i < BLK_NUM_CLIENTS; i++) {
+            handle_client(i);
+        }
+        microkit_notify_delayed(DRIVER_CH);
+    }
+}

--- a/blk/util/bitarray.c
+++ b/blk/util/bitarray.c
@@ -1,0 +1,196 @@
+#include <sddf/blk/bitarray.h>
+
+#define WORD_MAX  (~(word_t)0)
+
+#define bitmask(nbits,type) ((nbits) ? ~(type)0 >> (sizeof(type)*8-(nbits)): (type)0)
+#define bitmask32(nbits) bitmask(nbits,uint32_t)
+#define bitmask64(nbits) bitmask(nbits,uint64_t)
+
+#define bitset64_wrd(bit_pos) ((bit_pos) >> 6)
+#define bitset64_idx(bit_pos) ((bit_pos) & 63)
+
+/**
+ * Set a region of bits in a bit array to a specified value.
+ *
+ * @param arr The bit array.
+ * @param start The starting position of the region.
+ * @param len The length of the region.
+ */
+#define SET_REGION(arr,start,len) _set_region((arr),(start),(len),FILL_REGION)
+
+/**
+ * Clear a region of bits in a bit array, setting them to 0.
+ *
+ * @param arr The bit array.
+ * @param start The starting position of the region.
+ * @param len The length of the region.
+ */
+#define CLEAR_REGION(arr,start,len) _set_region((arr),(start),(len),ZERO_REGION)
+
+/**
+ * Toggle a region of bits in a bit array, flipping their values.
+ *
+ * @param arr The bit array.
+ * @param start The starting position of the region.
+ * @param len The length of the region.
+ */
+#define TOGGLE_REGION(arr,start,len) _set_region((arr),(start),(len),SWAP_REGION)
+
+void bitarray_init(bitarray_t *bitarr, word_t *words, word_index_t num_of_words)
+{
+    bitarr->words = words;
+    bitarr->num_of_words = num_of_words;
+    bitarr->num_of_bits = num_of_words * 64;
+}
+
+char bitarray_get_bit(bitarray_t *bitarr, bit_index_t index)
+{
+    word_index_t word = bitset64_wrd(index);
+    word_offset_t offset = bitset64_idx(index);
+    return (bitarr->words[word] >> offset) & 1;
+}
+
+// FillAction is fill with 0 or 1 or toggle
+typedef enum {ZERO_REGION, FILL_REGION, SWAP_REGION} FillAction;
+
+static inline void _set_region(bitarray_t *bitarr, bit_index_t start,
+                               bit_index_t length, FillAction action)
+{
+    if (length == 0) {
+        return;
+    }
+
+    word_index_t first_word = bitset64_wrd(start);
+    word_index_t last_word = bitset64_wrd(start + length - 1);
+    word_offset_t foffset = bitset64_idx(start);
+    word_offset_t loffset = bitset64_idx(start + length - 1);
+
+    if (first_word == last_word) {
+        word_t mask = bitmask64(length) << foffset;
+
+        switch (action) {
+        case ZERO_REGION:
+            bitarr->words[first_word] &= ~mask;
+            break;
+        case FILL_REGION:
+            bitarr->words[first_word] |=  mask;
+            break;
+        case SWAP_REGION:
+            bitarr->words[first_word] ^=  mask;
+            break;
+        }
+    } else {
+        // Set first word
+        switch (action) {
+        case ZERO_REGION:
+            bitarr->words[first_word] &=  bitmask64(foffset);
+            break;
+        case FILL_REGION:
+            bitarr->words[first_word] |= ~bitmask64(foffset);
+            break;
+        case SWAP_REGION:
+            bitarr->words[first_word] ^= ~bitmask64(foffset);
+            break;
+        }
+
+        word_index_t i;
+
+        // Set whole words
+        switch (action) {
+        case ZERO_REGION:
+            for (i = first_word + 1; i < last_word; i++) {
+                bitarr->words[i] = (word_t)0;
+            }
+            break;
+        case FILL_REGION:
+            for (i = first_word + 1; i < last_word; i++) {
+                bitarr->words[i] = WORD_MAX;
+            }
+            break;
+        case SWAP_REGION:
+            for (i = first_word + 1; i < last_word; i++) {
+                bitarr->words[i] ^= WORD_MAX;
+            }
+            break;
+        }
+
+        // Set last word
+        switch (action) {
+        case ZERO_REGION:
+            bitarr->words[last_word] &= ~bitmask64(loffset + 1);
+            break;
+        case FILL_REGION:
+            bitarr->words[last_word] |=  bitmask64(loffset + 1);
+            break;
+        case SWAP_REGION:
+            bitarr->words[last_word] ^=  bitmask64(loffset + 1);
+            break;
+        }
+    }
+}
+
+void bitarray_set_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len)
+{
+    // assert(start + len <= bitarr->num_of_bits);
+    SET_REGION(bitarr, start, len);
+}
+
+void bitarray_clear_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len)
+{
+    // assert(start + len <= bitarr->num_of_bits);
+    CLEAR_REGION(bitarr, start, len);
+}
+
+void bitarray_toggle_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len)
+{
+    // assert(start + len <= bitarr->num_of_bits);
+    TOGGLE_REGION(bitarr, start, len);
+}
+
+bool bitarray_cmp_region(bitarray_t *bitarr1, bit_index_t start1,
+                         bitarray_t *bitarr2, bit_index_t start2, bit_index_t len)
+{
+    if (len == 0) {
+        return true;
+    }
+
+    while (len > 0) {
+        // calculate the word index and bit offset for both arrays
+        word_index_t word_idx1 = bitset64_wrd(start1);
+        word_offset_t bit_offset1 = bitset64_idx(start1);
+        word_index_t word_idx2 = bitset64_wrd(start2);
+        word_offset_t bit_offset2 = bitset64_idx(start2);
+
+        // calculate the number of bits to compare in this iteration
+        bit_index_t bits_in_current_word1 = 64 - bit_offset1;
+        bit_index_t bits_in_current_word2 = 64 - bit_offset2;
+        bit_index_t bits_to_compare = len;
+        if (bits_to_compare > bits_in_current_word1) {
+            bits_to_compare = bits_in_current_word1;
+        }
+        if (bits_to_compare > bits_in_current_word2) {
+            bits_to_compare = bits_in_current_word2;
+        }
+
+        // create masks for the bits to compare
+        word_t mask1 = bitmask64(bits_to_compare) << bit_offset1;
+        word_t mask2 = bitmask64(bits_to_compare) << bit_offset2;
+
+        // extract the relevant bits from each array
+        word_t bits1 = (bitarr1->words[word_idx1] & mask1) >> bit_offset1;
+        word_t bits2 = (bitarr2->words[word_idx2] & mask2) >> bit_offset2;
+
+        // compare the bits
+        if (bits1 != bits2) {
+            return false;
+        }
+
+        // update for the next iteration
+        len -= bits_to_compare;
+        start1 += bits_to_compare;
+        start2 += bits_to_compare;
+    }
+
+    return true;
+}
+

--- a/blk/util/bitarray.c
+++ b/blk/util/bitarray.c
@@ -1,4 +1,5 @@
 #include <sddf/blk/bitarray.h>
+#include <sddf/util/util.h>
 
 #define WORD_MAX  (~(word_t)0)
 
@@ -131,25 +132,28 @@ static inline void _set_region(bitarray_t *bitarr, bit_index_t start,
 
 void bitarray_set_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len)
 {
-    // assert(start + len <= bitarr->num_of_bits);
+    assert(start + len <= bitarr->num_of_bits);
     SET_REGION(bitarr, start, len);
 }
 
 void bitarray_clear_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len)
 {
-    // assert(start + len <= bitarr->num_of_bits);
+    assert(start + len <= bitarr->num_of_bits);
     CLEAR_REGION(bitarr, start, len);
 }
 
 void bitarray_toggle_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len)
 {
-    // assert(start + len <= bitarr->num_of_bits);
+    assert(start + len <= bitarr->num_of_bits);
     TOGGLE_REGION(bitarr, start, len);
 }
 
 bool bitarray_cmp_region(bitarray_t *bitarr1, bit_index_t start1,
                          bitarray_t *bitarr2, bit_index_t start2, bit_index_t len)
 {
+    assert(start1 + len <= bitarr1->num_of_bits);
+    assert(start2 + len <= bitarr2->num_of_bits);
+
     if (len == 0) {
         return true;
     }

--- a/blk/util/fsmalloc.c
+++ b/blk/util/fsmalloc.c
@@ -1,0 +1,115 @@
+#include <stdint.h>
+#include <sddf/blk/bitarray.h>
+#include <sddf/blk/fsmalloc.h>
+
+/**
+ * Convert a bit position to the address of the corresponding data cell.
+ *
+ * @param bitpos bit position of the data cell
+ * @return address of the data cell
+ */
+static inline uintptr_t bitpos_to_addr(fsmalloc_t *fsmalloc, uint64_t bitpos)
+{
+    return fsmalloc->base_addr + (uintptr_t)(bitpos * fsmalloc->cell_size);
+}
+
+/**
+ * Convert an address to the bit position of the corresponding data cell.
+ *
+ * @param addr address of the data cell
+ * @return bit position of the data cell
+ */
+static inline uint64_t addr_to_bitpos(fsmalloc_t *fsmalloc, uintptr_t addr)
+{
+    return (uint64_t)(addr - fsmalloc->base_addr) / fsmalloc->cell_size;
+}
+
+/**
+ * Check if count number of cells will overflow the end of the data region.
+ *
+ * @param count number of cells to check
+ * @return true if count number of cells will overflow the end of the data region, false otherwise
+ */
+static inline bool fsmalloc_overflow(fsmalloc_t *fsmalloc, uint64_t count)
+{
+    return (fsmalloc->avail_bitpos + count > fsmalloc->num_cells);
+}
+
+bool fsmalloc_full(fsmalloc_t *fsmalloc, uint64_t count)
+{
+    if (count > fsmalloc->num_cells) {
+        return true;
+    }
+
+    if (count == 0) {
+        return false;
+    }
+
+    unsigned int start_bitpos = fsmalloc->avail_bitpos;
+    if (fsmalloc_overflow(fsmalloc, count)) {
+        start_bitpos = 0;
+    }
+
+    // Create a bit mask with count many 1's
+    bitarray_t bitarr_mask;
+    word_t words[roundup_bits2words64(count)];
+    bitarray_init(&bitarr_mask, words, roundup_bits2words64(count));
+    bitarray_set_region(&bitarr_mask, 0, count);
+
+    if (bitarray_cmp_region(fsmalloc->avail_bitarr, start_bitpos, &bitarr_mask, 0, count)) {
+        return false;
+    }
+
+    return true;
+}
+
+void fsmalloc_free(fsmalloc_t *fsmalloc, uintptr_t addr, uint64_t count)
+{
+    unsigned int start_bitpos = addr_to_bitpos(fsmalloc, addr);
+
+    // Assert here in case we try to free cells that overflow the data region
+    // assert(start_bitpos + count <= fsmalloc->num_cells);
+
+    // Set the next count many bits as available
+    bitarray_set_region(fsmalloc->avail_bitarr, start_bitpos, count);
+}
+
+int fsmalloc_alloc(fsmalloc_t *fsmalloc, uintptr_t *addr, uint64_t count)
+{
+    if (fsmalloc_full(fsmalloc, count)) {
+        return -1;
+    }
+
+    if (fsmalloc_overflow(fsmalloc, count)) {
+        fsmalloc->avail_bitpos = 0;
+    }
+
+    *addr = bitpos_to_addr(fsmalloc, fsmalloc->avail_bitpos);
+
+    // Set the next count many bits as unavailable
+    bitarray_clear_region(fsmalloc->avail_bitarr, fsmalloc->avail_bitpos, count);
+
+    // Update the bitpos
+    uint64_t new_bitpos = fsmalloc->avail_bitpos + count;
+    if (new_bitpos == fsmalloc->num_cells) {
+        new_bitpos = 0;
+    }
+    fsmalloc->avail_bitpos = new_bitpos;
+
+    return 0;
+}
+
+void fsmalloc_init(fsmalloc_t *fsmalloc, uintptr_t base_addr, uint64_t cell_size, uint64_t num_cells,
+                   bitarray_t *bitarr, word_t *words, word_index_t num_words)
+{
+    bitarray_init(bitarr, words, num_words);
+
+    fsmalloc->avail_bitpos = 0;
+    fsmalloc->avail_bitarr = bitarr;
+    fsmalloc->base_addr = base_addr;
+    fsmalloc->cell_size = cell_size;
+    fsmalloc->num_cells = num_cells;
+
+    /* Set all available bits to 1 to indicate all cells are available */
+    bitarray_set_region(bitarr, 0, num_cells);
+}

--- a/blk/util/fsmalloc.c
+++ b/blk/util/fsmalloc.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <sddf/blk/bitarray.h>
 #include <sddf/blk/fsmalloc.h>
+#include <sddf/util/util.h>
 
 /**
  * Convert a bit position to the address of the corresponding data cell.
@@ -68,7 +69,7 @@ void fsmalloc_free(fsmalloc_t *fsmalloc, uintptr_t addr, uint64_t count)
     unsigned int start_bitpos = addr_to_bitpos(fsmalloc, addr);
 
     // Assert here in case we try to free cells that overflow the data region
-    // assert(start_bitpos + count <= fsmalloc->num_cells);
+    assert(start_bitpos + count <= fsmalloc->num_cells);
 
     // Set the next count many bits as available
     bitarray_set_region(fsmalloc->avail_bitarr, start_bitpos, count);

--- a/blk/util/util.c
+++ b/blk/util/util.c
@@ -1,0 +1,10 @@
+#include <sddf/blk/util.h>
+
+void *memset(void *dest, int c, size_t n)
+{
+    unsigned char *s = dest;
+    for (; n; n--, s++) {
+        *s = c;
+    }
+    return dest;
+}

--- a/blk/util/util.c
+++ b/blk/util/util.c
@@ -8,3 +8,13 @@ void *memset(void *dest, int c, size_t n)
     }
     return dest;
 }
+
+void *memcpy(void *restrict dest, const void *restrict src, size_t n)
+{
+    unsigned char *d = dest;
+    const unsigned char *s = src;
+    for (; n; n--) {
+        *d++ = *s++;
+    }
+    return dest;
+}

--- a/include/sddf/blk/bitarray.h
+++ b/include/sddf/blk/bitarray.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * This file provides functions and macros to manipulate bit arrays efficiently.
+ * In a bit array, the bits are stored in a sequence of words, where each word is typically a machine word
+ * (e.g., 32 bits or 64 bits). This implementation uses 64 bits.
+ */
+
+typedef uint64_t word_t; /* type of word in the bitarray. */
+typedef uint64_t word_index_t; /* type for index of a word in the bitarray. */
+typedef uint64_t bit_index_t; /* type for index of a bit in the bitarray. */
+typedef uint8_t word_offset_t; /* type for offset of a bit within a word in the bitarray. */
+
+/**
+ * Rounds up the number of bits to the nearest number of bytes.
+ *
+ * @param bits The number of bits.
+ * @return The number of bytes.
+ */
+#define roundup_bits2bytes(bits)   (((bits)+7)/8)
+
+/**
+ * Rounds up the number of bits to the nearest number of 32-bit words.
+ *
+ * @param bits The number of bits.
+ * @return The number of 32-bit words.
+ */
+#define roundup_bits2words32(bits) (((bits)+31)/32)
+
+/**
+ * Rounds up the number of bits to the nearest number of 64-bit words.
+ *
+ * @param bits The number of bits.
+ * @return The number of 64-bit words.
+ */
+#define roundup_bits2words64(bits) (((bits)+63)/64)
+
+typedef struct bitarray {
+    word_t *words; /* Word array */
+    bit_index_t num_of_bits; /* Number of bits, calculated by number of words * size of word */
+    word_index_t num_of_words; /* Number of words */
+} bitarray_t;
+
+/**
+ * Initialise a bit array.
+ *
+ * @param bitarr pointer to the bitarray struct.
+ * @param words pointer to the word array.
+ * @param num_of_words number of words in the word array.
+ */
+void bitarray_init(bitarray_t *bitarr, word_t *words, word_index_t num_of_words);
+
+/**
+ * Get the value of a specific bit in the bit array.
+ *
+ * @param bitarr pointer to the bitarray struct.
+ * @param index index of the bit to get.
+ * @return the value of the bit (0 or 1).
+ */
+char bitarray_get_bit(bitarray_t *bitarr, bit_index_t index);
+
+/**
+ * Set all the bits in a specific region of the bit array.
+ *
+ * @param bitarr pointer to the bitarray struct.
+ * @param start starting index of the region.
+ * @param len length of the region.
+ */
+void bitarray_set_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len);
+
+/**
+ * Toggle all the bits in a specific region of the bit array.
+ *
+ * @param bitarr pointer to the bitarray struct.
+ * @param start starting index of the region.
+ * @param len length of the region.
+ */
+void bitarray_toggle_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len);
+
+/**
+ * Clear all the bits in a specific region of the bit array.
+ *
+ * @param bitarr pointer to the bitarray struct.
+ * @param start starting index of the region.
+ * @param len length of the region.
+ */
+void bitarray_clear_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len);
+
+/**
+ * Compare two regions of bit arrays.
+ *
+ * @param bitarr1 pointer to the first bitarray struct.
+ * @param start1 starting index of the first region.
+ * @param bitarr2 pointer to the second bitarray struct.
+ * @param start2 starting index of the second region.
+ * @param len length of the regions to compare.
+ * @return true if the two regions are equal, false otherwise.
+ */
+bool bitarray_cmp_region(bitarray_t *bitarr1, bit_index_t start1, bitarray_t *bitarr2, bit_index_t start2,
+                         bit_index_t len);

--- a/include/sddf/blk/fsmalloc.h
+++ b/include/sddf/blk/fsmalloc.h
@@ -1,0 +1,63 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <sddf/blk/bitarray.h>
+
+/**
+ * This file handles the allocation and freeing of fixed size data cells in a memory region.
+ * The allocator uses a really simple algorithm, it stores a memory region offset that is incremented
+ * on allocation of a cell. The allocator does not handle fragmentation, it will only check for
+ * available cells from the offset. The allocator uses a bit array to keep track of available cells.
+ */
+
+/* Data struct that handles allocation and freeing of fixed size data cells in memory region */
+typedef struct fsmalloc {
+    uint64_t avail_bitpos; /* bit position of next available cell */
+    bitarray_t *avail_bitarr; /* bit array representing available data cells */
+    uint64_t num_cells; /* number of cells in data region */
+    uint64_t cell_size; /* number of bytes in a cell */
+    uintptr_t base_addr; /* base address of data region */
+} fsmalloc_t;
+
+/**
+ * Check if the memory region can fit count more free cells.
+ *
+ * @param fsmalloc pointer to the fsmalloc struct.
+ * @param count number of cells to check.
+ *
+ * @return true indicates the data region is full, false otherwise.
+ */
+bool fsmalloc_full(fsmalloc_t *fsmalloc, uint64_t count);
+
+/**
+ * Get count many free cells in the data region.
+ *
+ * @param fsmalloc pointer to the fsmalloc struct.
+ * @param addr pointer to base address of the resulting contiguous cell.
+ * @param count number of free cells to get.
+ *
+ * @return -1 when data region is full, 0 on success.
+ */
+int fsmalloc_alloc(fsmalloc_t *fsmalloc, uintptr_t *addr, uint64_t count);
+
+/**
+ * Free count many available cells in the data region.
+ *
+ * @param fsmalloc pointer to the fsmalloc struct.
+ * @param addr base address of the contiguous cell to free.
+ * @param count number of cells to free.
+ */
+void fsmalloc_free(fsmalloc_t *fsmalloc, uintptr_t addr, uint64_t count);
+
+/**
+ * Initialise fixed size memory allocation struct.
+ *
+ * @param fsmalloc pointer to the fsmalloc struct.
+ * @param base_addr base address of the data region.
+ * @param cell_size number of bytes in a cell.
+ * @param num_cells number of cells in the data region.
+ * @param bitarr pointer to the bitarray struct representing available data cells.
+ * @param words pointer to the array of words in bitarray struct.
+ * @param num_words number of words in the array of bitarray struct. This needs to be > num_cells/64. Can be calculated using roundup_bits2words64(num_cells).
+ */
+void fsmalloc_init(fsmalloc_t *fsmalloc, uintptr_t base_addr, uint64_t cell_size, uint64_t num_cells,
+                   bitarray_t *bitarr, word_t *words, word_index_t num_words);

--- a/include/sddf/blk/msdos_mbr.h
+++ b/include/sddf/blk/msdos_mbr.h
@@ -1,0 +1,28 @@
+/**
+ * Master Boot Record with MSDOS partition table.
+ *
+ * https://en.wikipedia.org/wiki/Master_boot_record
+*/
+
+#include <stdint.h>
+
+#define MSDOS_MBR_SIGNATURE 0xAA55
+#define MSDOS_MBR_MAX_PRIMARY_PARTITIONS 4
+#define MSDOS_MBR_SECTOR_SIZE 512
+
+struct msdos_mbr_partition {
+    uint8_t status;
+    uint8_t chs_start[3];
+    uint8_t type;
+    uint8_t chs_end[3];
+    uint32_t lba_start;
+    uint32_t sectors;
+} __attribute__((packed));
+
+struct msdos_mbr {
+    uint8_t bootstrap[446];
+    struct msdos_mbr_partition partitions[MSDOS_MBR_MAX_PRIMARY_PARTITIONS];
+    uint16_t signature;
+} __attribute__((packed));
+
+#define MSDOS_MBR_PARTITION_TYPE_EMPTY 0x00

--- a/include/sddf/blk/queue.h
+++ b/include/sddf/blk/queue.h
@@ -13,15 +13,13 @@
 
 /* Size of a single block to be transferred */
 #define BLK_TRANSFER_SIZE 4096
-/* Maximum number of slots in the request queue. Can be configured. */
-#define BLK_REQ_QUEUE_SIZE 1024
-/* Maximum number of slots in the response queue. Can be configured. */
-#define BLK_RESP_QUEUE_SIZE 1024
+/* Maximum number of slots in each queue. Can be configured. */
+#define BLK_QUEUE_SIZE 1024
 /* Device serial number max string length */
 #define BLK_MAX_SERIAL_NUMBER 63
 
 typedef struct blk_storage_info {
-    char serial_number[BLK_MAX_SERIAL_NUMBER + 1]; 
+    char serial_number[BLK_MAX_SERIAL_NUMBER + 1];
     bool read_only;
     bool ready; /* true if component closer to driver is ready */
     uint16_t sector_size; /* size of a sector */
@@ -66,14 +64,14 @@ typedef struct blk_req_queue {
     uint32_t head;
     uint32_t tail;
     bool plugged; /* prevent requests from being dequeued when plugged */
-    blk_request_t buffers[BLK_REQ_QUEUE_SIZE];
+    blk_request_t buffers[BLK_QUEUE_SIZE];
 } blk_req_queue_t;
 
 /* Circular buffer containing responses */
 typedef struct blk_resp_queue {
     uint32_t head;
     uint32_t tail;
-    blk_response_t buffers[BLK_RESP_QUEUE_SIZE];
+    blk_response_t buffers[BLK_QUEUE_SIZE];
 } blk_resp_queue_t;
 
 /* A queue handle for queueing/dequeueing request and responses */
@@ -92,9 +90,9 @@ typedef struct blk_queue_handle {
  * @param queue_size number of entries in each queue.
  */
 static inline void blk_queue_init(blk_queue_handle_t *h,
-                                blk_req_queue_t *request,
-                                blk_resp_queue_t *response,
-                                uint32_t queue_size)
+                                  blk_req_queue_t *request,
+                                  blk_resp_queue_t *response,
+                                  uint32_t queue_size)
 {
     h->req_queue = request;
     h->resp_queue = response;
@@ -177,8 +175,6 @@ static inline int blk_resp_queue_size(blk_queue_handle_t *h)
  * Enqueue an element into the request queue.
  *
  * @param h queue handle containing request queue to enqueue to.
- * @param code request code.
- * @param addr encoded dma address of data to read/write.
  * @param block_number block number to read/write to.
  * @param count the number of blocks to read/write
  * @param id request ID to identify this request.
@@ -186,11 +182,11 @@ static inline int blk_resp_queue_size(blk_queue_handle_t *h)
  * @return -1 when request queue is full, 0 on success.
  */
 static inline int blk_enqueue_req(blk_queue_handle_t *h,
-                                        blk_request_code_t code,
-                                        uintptr_t addr,
-                                        uint32_t block_number,
-                                        uint16_t count,
-                                        uint32_t id)
+                                  blk_request_code_t code,
+                                  uintptr_t addr,
+                                  uint32_t block_number,
+                                  uint16_t count,
+                                  uint32_t id)
 {
     if (blk_req_queue_full(h)) {
         return -1;
@@ -220,9 +216,9 @@ static inline int blk_enqueue_req(blk_queue_handle_t *h,
  * @return -1 when response queue is full, 0 on success.
  */
 static inline int blk_enqueue_resp(blk_queue_handle_t *h,
-                                        blk_response_status_t status,
-                                        uint16_t success_count,
-                                        uint32_t id)
+                                   blk_response_status_t status,
+                                   uint16_t success_count,
+                                   uint32_t id)
 {
     if (blk_resp_queue_full(h)) {
         return -1;
@@ -251,11 +247,11 @@ static inline int blk_enqueue_resp(blk_queue_handle_t *h,
  * @return -1 when request queue is empty, 0 on success.
  */
 static inline int blk_dequeue_req(blk_queue_handle_t *h,
-                                        blk_request_code_t *code,
-                                        uintptr_t *addr,
-                                        uint32_t *block_number,
-                                        uint16_t *count,
-                                        uint32_t *id)
+                                  blk_request_code_t *code,
+                                  uintptr_t *addr,
+                                  uint32_t *block_number,
+                                  uint16_t *count,
+                                  uint32_t *id)
 {
     if (blk_req_queue_empty(h)) {
         return -1;
@@ -283,9 +279,9 @@ static inline int blk_dequeue_req(blk_queue_handle_t *h,
  * @return -1 when response queue is empty, 0 on success.
  */
 static inline int blk_dequeue_resp(blk_queue_handle_t *h,
-                                        blk_response_status_t *status,
-                                        uint16_t *success_count,
-                                        uint32_t *id)
+                                   blk_response_status_t *status,
+                                   uint16_t *success_count,
+                                   uint32_t *id)
 {
     if (blk_resp_queue_empty(h)) {
         return -1;
@@ -306,7 +302,8 @@ static inline int blk_dequeue_resp(blk_queue_handle_t *h,
  *
  * @param h queue handle containing request queue to check for plug.
 */
-static inline void blk_req_queue_plug(blk_queue_handle_t *h) {
+static inline void blk_req_queue_plug(blk_queue_handle_t *h)
+{
     h->req_queue->plugged = true;
 }
 
@@ -315,7 +312,8 @@ static inline void blk_req_queue_plug(blk_queue_handle_t *h) {
  *
  * @param h queue handle containing request queue to check for plug.
 */
-static inline void blk_req_queue_unplug(blk_queue_handle_t *h) {
+static inline void blk_req_queue_unplug(blk_queue_handle_t *h)
+{
     h->req_queue->plugged = false;
 }
 
@@ -326,7 +324,8 @@ static inline void blk_req_queue_unplug(blk_queue_handle_t *h) {
  *
  * @return true when request queue is plugged, false when unplugged.
 */
-static inline bool blk_req_queue_plugged(blk_queue_handle_t *h) {
+static inline bool blk_req_queue_plugged(blk_queue_handle_t *h)
+{
     return h->req_queue->plugged;
 }
 

--- a/include/sddf/blk/util.h
+++ b/include/sddf/blk/util.h
@@ -1,15 +1,7 @@
 #include <stddef.h>
 
 // @ericc: When we have libc implementation replace this
-static void *memcpy(void *restrict dest, const void *restrict src, size_t n)
-{
-    unsigned char *d = dest;
-    const unsigned char *s = src;
-    for (; n; n--) {
-        *d++ = *s++;
-    }
-    return dest;
-}
 /* We need an externally linked memset definition for
    copying structs */
+void *memcpy(void *restrict dest, const void *restrict src, size_t n);
 void *memset(void *dest, int c, size_t n);

--- a/include/sddf/blk/util.h
+++ b/include/sddf/blk/util.h
@@ -1,0 +1,15 @@
+#include <stddef.h>
+
+// @ericc: When we have libc implementation replace this
+static void *memcpy(void *restrict dest, const void *restrict src, size_t n)
+{
+    unsigned char *d = dest;
+    const unsigned char *s = src;
+    for (; n; n--) {
+        *d++ = *s++;
+    }
+    return dest;
+}
+/* We need an externally linked memset definition for
+   copying structs */
+void *memset(void *dest, int c, size_t n);


### PR DESCRIPTION
This PR provides a virtualiser implementation for sDDF blk. It parses an msdos/mbr partition table in order to allocate one partition to one client. It uses memcpy to transfer client and driver data. This is done for now for simplicity with an existing driver VM implementation, but I expect in the near future we pass a physical pointer to do DMA.

Also includes minor changes to sDDF queue in regards to the queue size hash defines