### PR TITLE
net: add refcounts for buffs in virtrx to account for broadcast packets

### DIFF
--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -107,7 +107,6 @@ static void microkit_benchmark_start(void)
     seL4_BenchmarkResetThreadUtilisation(BASE_TCB_CAP + PD_COPY1_ID);
     seL4_BenchmarkResetThreadUtilisation(BASE_TCB_CAP + PD_LWIP_ID);
     seL4_BenchmarkResetThreadUtilisation(BASE_TCB_CAP + PD_LWIP1_ID);
-    seL4_BenchmarkResetThreadUtilisation(BASE_TCB_CAP + PD_ARP_ID);
     seL4_BenchmarkResetThreadUtilisation(BASE_TCB_CAP + PD_TIMER_ID);
     seL4_BenchmarkResetLog();
 }
@@ -249,9 +248,6 @@ void notified(microkit_channel ch)
 
         microkit_benchmark_stop_tcb(PD_LWIP1_ID, &total, &number_schedules, &kernel, &entries);
         print_benchmark_details(PD_LWIP1_ID, kernel, entries, number_schedules, total);
-
-        microkit_benchmark_stop_tcb(PD_ARP_ID, &total, &number_schedules, &kernel, &entries);
-        print_benchmark_details(PD_ARP_ID, kernel, entries, number_schedules, total);
 
         microkit_benchmark_stop_tcb(PD_TIMER_ID, &total, &number_schedules, &kernel, &entries);
         print_benchmark_details(PD_TIMER_ID, kernel, entries, number_schedules, total);

--- a/examples/echo_server/Makefile
+++ b/examples/echo_server/Makefile
@@ -46,7 +46,7 @@ NETWORK_COMPONENTS=$(SDDF)/network/components
 BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
 SYSTEM_FILE := board/$(MICROKIT_BOARD)/echo_server.system
 
-IMAGES := eth.elf lwip.elf benchmark.elf idle.elf virt_rx.elf virt_tx.elf copy.elf arp.elf timer.elf
+IMAGES := eth.elf lwip.elf benchmark.elf idle.elf virt_rx.elf virt_tx.elf copy.elf timer.elf
 CFLAGS := -mcpu=$(CPU) -mstrict-align -ffreestanding -g3 -O3 -Wall -Wno-unused-function -DMICROKIT_CONFIG_$(MICROKIT_CONFIG)
 
 LDFLAGS := -L$(BOARD_DIR)/lib -L$(LIBC)
@@ -108,12 +108,11 @@ VIRT_TX_OBJS := $(NETWORK_COMPONENTS)/virt_tx.o $(UTIL)/cache.o printf.o putchar
 COPY_OBJS := $(NETWORK_COMPONENTS)/copy.o printf.o putchar_debug.o
 BENCH_OBJS := $(BENCHMARK)/benchmark.o printf.o putchar_serial.o
 IDLE_OBJS := $(BENCHMARK)/idle.o printf.o putchar_debug.o
-ARP_OBJS := $(NETWORK_COMPONENTS)/arp.o printf.o putchar_serial.o
 TIMER_OBJS := $(TIMER_DRIVER)/timer.o printf.o putchar_debug.o
 
 OBJS := $(sort $(addprefix $(BUILD_DIR)/, $(ETH_OBJS) $(VIRT_RX_OBJS) $(VIRT_TX_OBJS)\
 	$(COPY_OBJS) $(BENCH_OBJS) $(IDLE_OBJS) \
-	$(LWIP_OBJS) $(ARP_OBJS) $(TIMER_OBJS)))
+	$(LWIP_OBJS) $(TIMER_OBJS)))
 DEPS := $(OBJS:.o=.d)
 
 all: $(IMAGE_FILE)
@@ -157,9 +156,6 @@ $(BUILD_DIR)/benchmark.elf: $(addprefix $(BUILD_DIR)/, $(BENCH_OBJS))
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 $(BUILD_DIR)/idle.elf: $(addprefix $(BUILD_DIR)/, $(IDLE_OBJS))
-	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
-
-$(BUILD_DIR)/arp.elf: $(addprefix $(BUILD_DIR)/, $(ARP_OBJS))
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 $(BUILD_DIR)/timer.elf: $(addprefix $(BUILD_DIR)/, $(TIMER_OBJS))

--- a/examples/echo_server/board/imx8mm_evk/echo_server.system
+++ b/examples/echo_server/board/imx8mm_evk/echo_server.system
@@ -9,7 +9,6 @@
 
     <!-- DMA and virtualised DMA regions -->
     <memory_region name="rx_buffer_data_region" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_buffer_data_region_arp" size="0x200_000" page_size="0x200_000" />
     <memory_region name="tx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="rx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="tx_buffer_data_region_cli1" size="0x200_000" page_size="0x200_000" />
@@ -21,9 +20,7 @@
     <memory_region name="tx_free_drv" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_active_drv" size="0x200_000" page_size="0x200_000"/>
 
-    <!-- shared memory for virt_rx/copy/arp queue mechanism -->
-    <memory_region name="rx_free_arp" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_arp" size="0x200_000" page_size="0x200_000"/>
+    <!-- shared memory for virt_rx/copy queue mechanism -->
     <memory_region name="rx_free_copy0" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="rx_active_copy0" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="rx_free_copy1" size="0x200_000" page_size="0x200_000"/>
@@ -35,9 +32,7 @@
     <memory_region name="rx_free_cli1" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="rx_active_cli1" size="0x200_000" page_size="0x200_000"/>
 
-    <!-- shared memory for arp/lwip/virt_tx queue mechanism -->
-    <memory_region name="tx_free_arp" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_arp" size="0x200_000" page_size="0x200_000"/>
+    <!-- shared memory for lwip/virt_tx queue mechanism -->
     <memory_region name="tx_free_cli0" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_active_cli0" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_free_cli1" size="0x200_000" page_size="0x200_000"/>
@@ -76,14 +71,12 @@
             <map mr="rx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_drv" />
             <map mr="rx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_drv" />
 
-            <map mr="rx_free_arp" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_arp" />
-            <map mr="rx_active_arp" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_arp" />
-            <map mr="rx_free_copy0" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
-            <map mr="rx_active_copy0" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
-            <map mr="rx_free_copy1" vaddr="0x2_c00_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli1" />
-            <map mr="rx_active_copy1" vaddr="0x2_e00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli1" />
+            <map mr="rx_free_copy0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
+            <map mr="rx_active_copy0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
+            <map mr="rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli1" />
+            <map mr="rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli1" />
 
-            <map mr="rx_buffer_data_region" vaddr="0x3_000_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
+            <map mr="rx_buffer_data_region" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
             <setvar symbol="buffer_data_paddr" region_paddr="rx_buffer_data_region" />
         </protection_domain>
 
@@ -116,17 +109,13 @@
             <map mr="tx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="tx_free_drv" />
             <map mr="tx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_active_drv" />
 
-            <map mr="tx_free_arp" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_arp" />
-            <map mr="tx_active_arp" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_arp" />
-            <map mr="tx_free_cli0" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli0" />
-            <map mr="tx_active_cli0" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli0" />
-            <map mr="tx_free_cli1" vaddr="0x2_c00_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli1" />
-            <map mr="tx_active_cli1" vaddr="0x2_e00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli1" />
+            <map mr="tx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli0" />
+            <map mr="tx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli0" />
+            <map mr="tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli1" />
+            <map mr="tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli1" />
 
-            <map mr="tx_buffer_data_region_arp" vaddr="0x3_000_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_arp_vaddr" />
-            <map mr="tx_buffer_data_region_cli0" vaddr="0x3_200_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli0_vaddr" />
-            <map mr="tx_buffer_data_region_cli1" vaddr="0x3_400_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli1_vaddr" />
-            <setvar symbol="buffer_data_region_arp_paddr" region_paddr="tx_buffer_data_region_arp" />
+            <map mr="tx_buffer_data_region_cli0" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli0_vaddr" />
+            <map mr="tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli1_vaddr" />
             <setvar symbol="buffer_data_region_cli0_paddr" region_paddr="tx_buffer_data_region_cli0" />
             <setvar symbol="buffer_data_region_cli1_paddr" region_paddr="tx_buffer_data_region_cli1" />
         </protection_domain>
@@ -159,20 +148,6 @@
             <map mr="tx_buffer_data_region_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
         </protection_domain>
 
-        <protection_domain name="arp" priority="98" budget="20000" pp="true" id="8">
-            <program_image path="arp.elf" />
-            <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
-
-            <map mr="rx_free_arp" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-            <map mr="rx_active_arp" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
-
-            <map mr="tx_free_arp" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-            <map mr="tx_active_arp" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
-
-            <map mr="tx_buffer_data_region_arp" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
-            <map mr="rx_buffer_data_region" vaddr="0x2_a00_000" perms="r" cached="true" setvar_vaddr="rx_buffer_data_region" />
-        </protection_domain>
-
         <protection_domain name="timer" priority="101" pp="true" id="9" passive="true">
             <program_image path="timer.elf" />
             <map mr="timer" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
@@ -187,16 +162,11 @@
 
     <channel>
         <end pd="virt_rx" id="1" />
-        <end pd="arp" id="0" />
-    </channel>
-
-    <channel>
-        <end pd="virt_rx" id="2" />
         <end pd="copy0" id="0" />
     </channel>
 
     <channel>
-        <end pd="virt_rx" id="3" />
+        <end pd="virt_rx" id="2" />
         <end pd="copy1" id="0" />
     </channel>
 
@@ -217,16 +187,11 @@
 
     <channel>
         <end pd="virt_tx" id="1" />
-        <end pd="arp" id="1" />
-    </channel>
-
-    <channel>
-        <end pd="virt_tx" id="2" />
         <end pd="client0" id="3" />
     </channel>
 
     <channel>
-        <end pd="virt_tx" id="3" />
+        <end pd="virt_tx" id="2" />
         <end pd="client1" id="3" />
     </channel>
 
@@ -243,16 +208,6 @@
     <channel>
         <end pd="benchIdle" id="3" /> <!-- bench init channel -->
         <end pd="bench" id="3" />
-    </channel>
-
-    <channel>
-        <end pd="arp" id="2" />
-        <end pd="client0" id="7" />
-    </channel>
-
-    <channel>
-        <end pd="arp" id="3" />
-        <end pd="client1" id="7" />
     </channel>
 
     <channel>

--- a/examples/echo_server/board/maaxboard/echo_server.system
+++ b/examples/echo_server/board/maaxboard/echo_server.system
@@ -9,7 +9,6 @@
 
     <!-- DMA and virtualised DMA regions -->
     <memory_region name="rx_buffer_data_region" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_buffer_data_region_arp" size="0x200_000" page_size="0x200_000" />
     <memory_region name="tx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="rx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="tx_buffer_data_region_cli1" size="0x200_000" page_size="0x200_000" />
@@ -21,9 +20,7 @@
     <memory_region name="tx_free_drv" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_active_drv" size="0x200_000" page_size="0x200_000"/>
 
-    <!-- shared memory for virt_rx/copy/arp queue mechanism -->
-    <memory_region name="rx_free_arp" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_arp" size="0x200_000" page_size="0x200_000"/>
+    <!-- shared memory for virt_rx/copy queue mechanism -->
     <memory_region name="rx_free_copy0" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="rx_active_copy0" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="rx_free_copy1" size="0x200_000" page_size="0x200_000"/>
@@ -35,9 +32,7 @@
     <memory_region name="rx_free_cli1" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="rx_active_cli1" size="0x200_000" page_size="0x200_000"/>
 
-    <!-- shared memory for arp/lwip/virt_tx queue mechanism -->
-    <memory_region name="tx_free_arp" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_arp" size="0x200_000" page_size="0x200_000"/>
+    <!-- shared memory for lwip/virt_tx queue mechanism -->
     <memory_region name="tx_free_cli0" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_active_cli0" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_free_cli1" size="0x200_000" page_size="0x200_000"/>
@@ -76,14 +71,12 @@
             <map mr="rx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_drv" />
             <map mr="rx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_drv" />
 
-            <map mr="rx_free_arp" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_arp" />
-            <map mr="rx_active_arp" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_arp" />
-            <map mr="rx_free_copy0" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
-            <map mr="rx_active_copy0" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
-            <map mr="rx_free_copy1" vaddr="0x2_c00_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli1" />
-            <map mr="rx_active_copy1" vaddr="0x2_e00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli1" />
+            <map mr="rx_free_copy0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
+            <map mr="rx_active_copy0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
+            <map mr="rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli1" />
+            <map mr="rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli1" />
 
-            <map mr="rx_buffer_data_region" vaddr="0x3_000_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
+            <map mr="rx_buffer_data_region" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
             <setvar symbol="buffer_data_paddr" region_paddr="rx_buffer_data_region" />
         </protection_domain>
 
@@ -116,17 +109,13 @@
             <map mr="tx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="tx_free_drv" />
             <map mr="tx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_active_drv" />
 
-            <map mr="tx_free_arp" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_arp" />
-            <map mr="tx_active_arp" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_arp" />
-            <map mr="tx_free_cli0" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli0" />
-            <map mr="tx_active_cli0" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli0" />
-            <map mr="tx_free_cli1" vaddr="0x2_c00_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli1" />
-            <map mr="tx_active_cli1" vaddr="0x2_e00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli1" />
+            <map mr="tx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli0" />
+            <map mr="tx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli0" />
+            <map mr="tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli1" />
+            <map mr="tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli1" />
 
-            <map mr="tx_buffer_data_region_arp" vaddr="0x3_000_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_arp_vaddr" />
-            <map mr="tx_buffer_data_region_cli0" vaddr="0x3_200_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli0_vaddr" />
-            <map mr="tx_buffer_data_region_cli1" vaddr="0x3_400_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli1_vaddr" />
-            <setvar symbol="buffer_data_region_arp_paddr" region_paddr="tx_buffer_data_region_arp" />
+            <map mr="tx_buffer_data_region_cli0" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli0_vaddr" />
+            <map mr="tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli1_vaddr" />
             <setvar symbol="buffer_data_region_cli0_paddr" region_paddr="tx_buffer_data_region_cli0" />
             <setvar symbol="buffer_data_region_cli1_paddr" region_paddr="tx_buffer_data_region_cli1" />
         </protection_domain>
@@ -159,20 +148,6 @@
             <map mr="tx_buffer_data_region_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
         </protection_domain>
 
-        <protection_domain name="arp" priority="98" budget="20000" pp="true" id="8">
-            <program_image path="arp.elf" />
-            <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
-
-            <map mr="rx_free_arp" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-            <map mr="rx_active_arp" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
-
-            <map mr="tx_free_arp" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-            <map mr="tx_active_arp" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
-
-            <map mr="tx_buffer_data_region_arp" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
-            <map mr="rx_buffer_data_region" vaddr="0x2_a00_000" perms="r" cached="true" setvar_vaddr="rx_buffer_data_region" />
-        </protection_domain>
-
         <protection_domain name="timer" priority="101" pp="true" id="9" passive="true">
             <program_image path="timer.elf" />
             <map mr="timer" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
@@ -187,16 +162,11 @@
 
     <channel>
         <end pd="virt_rx" id="1" />
-        <end pd="arp" id="0" />
-    </channel>
-
-    <channel>
-        <end pd="virt_rx" id="2" />
         <end pd="copy0" id="0" />
     </channel>
 
     <channel>
-        <end pd="virt_rx" id="3" />
+        <end pd="virt_rx" id="2" />
         <end pd="copy1" id="0" />
     </channel>
 
@@ -217,16 +187,11 @@
 
     <channel>
         <end pd="virt_tx" id="1" />
-        <end pd="arp" id="1" />
-    </channel>
-
-    <channel>
-        <end pd="virt_tx" id="2" />
         <end pd="client0" id="3" />
     </channel>
 
     <channel>
-        <end pd="virt_tx" id="3" />
+        <end pd="virt_tx" id="2" />
         <end pd="client1" id="3" />
     </channel>
 
@@ -243,16 +208,6 @@
     <channel>
         <end pd="benchIdle" id="3" /> <!-- bench init channel -->
         <end pd="bench" id="3" />
-    </channel>
-
-    <channel>
-        <end pd="arp" id="2" />
-        <end pd="client0" id="7" />
-    </channel>
-
-    <channel>
-        <end pd="arp" id="3" />
-        <end pd="client1" id="7" />
     </channel>
 
     <channel>

--- a/examples/echo_server/board/odroidc4/echo_server.system
+++ b/examples/echo_server/board/odroidc4/echo_server.system
@@ -9,7 +9,6 @@
 
     <!-- DMA and virtualised DMA regions -->
     <memory_region name="rx_buffer_data_region" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_buffer_data_region_arp" size="0x200_000" page_size="0x200_000" />
     <memory_region name="tx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="rx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="tx_buffer_data_region_cli1" size="0x200_000" page_size="0x200_000" />
@@ -21,13 +20,11 @@
     <memory_region name="tx_free_drv" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_active_drv" size="0x200_000" page_size="0x200_000"/>
 
-    <!-- shared memory for virt_rx/copy/arp queue mechanism -->
+    <!-- shared memory for virt_rx/copy queue mechanism -->
     <memory_region name="rx_free_copy0" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="rx_active_copy0" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="rx_free_copy1" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="rx_active_copy1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_arp" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_arp" size="0x200_000" page_size="0x200_000"/>
 
     <!-- shared memory for copy/lwip queue mechanism -->
     <memory_region name="rx_free_cli0" size="0x200_000" page_size="0x200_000"/>
@@ -35,13 +32,11 @@
     <memory_region name="rx_free_cli1" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="rx_active_cli1" size="0x200_000" page_size="0x200_000"/>
 
-    <!-- shared memory for arp/lwip/virt_tx queue mechanism -->
+    <!-- shared memory for lwip/virt_tx queue mechanism -->
     <memory_region name="tx_free_cli0" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_active_cli0" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_free_cli1" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_active_cli1" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_free_arp" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_arp" size="0x200_000" page_size="0x200_000"/>
 
     <memory_region name="cyclecounters" size="0x1000"/>
 
@@ -76,14 +71,12 @@
             <map mr="rx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_drv" />
             <map mr="rx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_drv" />
 
-            <map mr="rx_free_arp" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_arp" />
-            <map mr="rx_active_arp" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_arp" />
-            <map mr="rx_free_copy0" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
-            <map mr="rx_active_copy0" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
-            <map mr="rx_free_copy1" vaddr="0x2_c00_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli1" />
-            <map mr="rx_active_copy1" vaddr="0x2_e00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli1" />
+            <map mr="rx_free_copy0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
+            <map mr="rx_active_copy0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
+            <map mr="rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli1" />
+            <map mr="rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli1" />
 
-            <map mr="rx_buffer_data_region" vaddr="0x3_000_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
+            <map mr="rx_buffer_data_region" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
             <setvar symbol="buffer_data_paddr" region_paddr="rx_buffer_data_region" />
         </protection_domain>
 
@@ -116,17 +109,13 @@
             <map mr="tx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="tx_free_drv" />
             <map mr="tx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_active_drv" />
 
-            <map mr="tx_free_arp" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_arp" />
-            <map mr="tx_active_arp" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_arp" />
-            <map mr="tx_free_cli0" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli0" />
-            <map mr="tx_active_cli0" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli0" />
-            <map mr="tx_free_cli1" vaddr="0x2_c00_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli1" />
-            <map mr="tx_active_cli1" vaddr="0x2_e00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli1" />
+            <map mr="tx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli0" />
+            <map mr="tx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli0" />
+            <map mr="tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli1" />
+            <map mr="tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli1" />
 
-            <map mr="tx_buffer_data_region_arp" vaddr="0x3_000_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_arp_vaddr" />
-            <map mr="tx_buffer_data_region_cli0" vaddr="0x3_200_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli0_vaddr" />
-            <map mr="tx_buffer_data_region_cli1" vaddr="0x3_400_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli1_vaddr" />
-            <setvar symbol="buffer_data_region_arp_paddr" region_paddr="tx_buffer_data_region_arp" />
+            <map mr="tx_buffer_data_region_cli0" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli0_vaddr" />
+            <map mr="tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli1_vaddr" />
             <setvar symbol="buffer_data_region_cli0_paddr" region_paddr="tx_buffer_data_region_cli0" />
             <setvar symbol="buffer_data_region_cli1_paddr" region_paddr="tx_buffer_data_region_cli1" />
         </protection_domain>
@@ -159,20 +148,6 @@
             <map mr="tx_buffer_data_region_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
         </protection_domain>
 
-        <protection_domain name="arp" priority="98" budget="20000" pp="true" id="8">
-            <program_image path="arp.elf" />
-            <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
-
-            <map mr="rx_free_arp" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-            <map mr="rx_active_arp" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
-
-            <map mr="tx_free_arp" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-            <map mr="tx_active_arp" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
-
-            <map mr="tx_buffer_data_region_arp" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
-            <map mr="rx_buffer_data_region" vaddr="0x2_a00_000" perms="r" cached="true" setvar_vaddr="rx_buffer_data_region" />
-        </protection_domain>
-
         <protection_domain name="timer" priority="101" pp="true" id="9" passive="true">
             <program_image path="timer.elf" />
             <map mr="timer" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
@@ -187,16 +162,11 @@
 
     <channel>
         <end pd="virt_rx" id="1" />
-        <end pd="arp" id="0" />
-    </channel>
-
-    <channel>
-        <end pd="virt_rx" id="2" />
         <end pd="copy0" id="0" />
     </channel>
 
     <channel>
-        <end pd="virt_rx" id="3" />
+        <end pd="virt_rx" id="2" />
         <end pd="copy1" id="0" />
     </channel>
 
@@ -217,16 +187,11 @@
 
     <channel>
         <end pd="virt_tx" id="1" />
-        <end pd="arp" id="1" />
-    </channel>
-
-    <channel>
-        <end pd="virt_tx" id="2" />
         <end pd="client0" id="3" />
     </channel>
 
     <channel>
-        <end pd="virt_tx" id="3" />
+        <end pd="virt_tx" id="2" />
         <end pd="client1" id="3" />
     </channel>
 
@@ -243,16 +208,6 @@
     <channel>
         <end pd="benchIdle" id="3" /> <!-- bench init channel -->
         <end pd="bench" id="3" />
-    </channel>
-
-    <channel>
-        <end pd="arp" id="2" />
-        <end pd="client0" id="7" />
-    </channel>
-
-    <channel>
-        <end pd="arp" id="3" />
-        <end pd="client1" id="7" />
     </channel>
 
     <channel>

--- a/examples/echo_server/lwip.c
+++ b/examples/echo_server/lwip.c
@@ -80,7 +80,7 @@ uint32_t sys_now(void)
 
 /**
  * Free a pbuf. This also returns the underlying buffer to the receive free ring.
- * 
+ *
  * @param p pbuf to free.
  */
 static void interface_free_buffer(struct pbuf *p)
@@ -112,18 +112,18 @@ static struct pbuf *create_interface_buffer(uintptr_t offset, size_t length)
     custom_pbuf_offset->custom.custom_free_function = interface_free_buffer;
 
     return pbuf_alloced_custom(
-        PBUF_RAW,
-        length,
-        PBUF_REF,
-        &custom_pbuf_offset->custom,
-        (void *)(offset + rx_buffer_data_region),
-        NET_BUFFER_SIZE 
-    );
+               PBUF_RAW,
+               length,
+               PBUF_REF,
+               &custom_pbuf_offset->custom,
+               (void *)(offset + rx_buffer_data_region),
+               NET_BUFFER_SIZE
+           );
 }
 
 /**
  * Stores a pbuf to be transmitted upon available transmit buffers.
- * 
+ *
  * @param p pbuf to be stored.
  */
 void enqueue_pbufs(struct pbuf *p)
@@ -142,12 +142,12 @@ void enqueue_pbufs(struct pbuf *p)
     pbuf_ref(p);
 }
 
-/** 
- * Insert pbuf into transmit active queue. If no free buffers available or transmit active queue is full, 
- * stores pbuf to be sent upon buffers becoming available. 
+/**
+ * Insert pbuf into transmit active queue. If no free buffers available or transmit active queue is full,
+ * stores pbuf to be sent upon buffers becoming available.
  * */
 static err_t lwip_eth_send(struct netif *netif, struct pbuf *p)
-{   
+{
     if (p->tot_len > NET_BUFFER_SIZE) {
         sddf_dprintf("LWIP|ERROR: attempted to send a packet of size  %u > BUFFER SIZE  %u\n", p->tot_len, NET_BUFFER_SIZE);
         return ERR_MEM;
@@ -157,7 +157,7 @@ static err_t lwip_eth_send(struct netif *netif, struct pbuf *p)
         enqueue_pbufs(p);
         return ERR_OK;
     }
-    
+
     net_buff_desc_t buffer;
     int err = net_dequeue_free(&state.tx_queue, &buffer);
     assert(!err);
@@ -182,24 +182,29 @@ void transmit(void)
 {
     bool reprocess = true;
     while (reprocess) {
-        while(state.head != NULL && !net_queue_empty_free(&state.tx_queue)) {
+        while (state.head != NULL && !net_queue_empty_free(&state.tx_queue)) {
             err_t err = lwip_eth_send(&state.netif, state.head);
             if (err == ERR_MEM) {
-                sddf_dprintf("LWIP|ERROR: attempted to send a packet of size  %u > BUFFER SIZE  %u\n", state.head->tot_len, NET_BUFFER_SIZE);
-            }
-            else if (err != ERR_OK) {
+                sddf_dprintf("LWIP|ERROR: attempted to send a packet of size  %u > BUFFER SIZE  %u\n", state.head->tot_len,
+                             NET_BUFFER_SIZE);
+            } else if (err != ERR_OK) {
                 sddf_dprintf("LWIP|ERROR: unkown error when trying to send pbuf  %p\n", state.head);
             }
-            
+
             struct pbuf *temp = state.head;
             state.head = temp->next_chain;
-            if (state.head == NULL) state.tail = NULL;
+            if (state.head == NULL) {
+                state.tail = NULL;
+            }
             pbuf_free(temp);
         }
 
         /* Only request a signal if no more pbufs enqueud to send */
-        if (state.head == NULL || !net_queue_empty_free(&state.tx_queue)) net_cancel_signal_free(&state.tx_queue);
-        else net_request_signal_free(&state.tx_queue);
+        if (state.head == NULL || !net_queue_empty_free(&state.tx_queue)) {
+            net_cancel_signal_free(&state.tx_queue);
+        } else {
+            net_request_signal_free(&state.tx_queue);
+        }
         reprocess = false;
 
         if (state.head != NULL && !net_queue_empty_free(&state.tx_queue)) {
@@ -224,7 +229,7 @@ void receive(void)
                 pbuf_free(p);
             }
         }
-        
+
         net_request_signal_active(&state.rx_queue);
         reprocess = false;
 
@@ -237,12 +242,14 @@ void receive(void)
 
 /**
  * Initialise the network interface data structure.
- * 
+ *
  * @param netif network interface data structuer.
  */
 static err_t ethernet_init(struct netif *netif)
 {
-    if (netif->state == NULL) return ERR_ARG;
+    if (netif->state == NULL) {
+        return ERR_ARG;
+    }
     state_t *data = netif->state;
 
     netif->hwaddr[0] = data->mac[0];
@@ -264,7 +271,8 @@ static err_t ethernet_init(struct netif *netif)
 static void netif_status_callback(struct netif *netif)
 {
     if (dhcp_supplied_address(netif)) {
-        sddf_printf("LWIP|NOTICE: DHCP request for %s returned IP address: %s\n", microkit_name, ip4addr_ntoa(netif_ip4_addr(netif)));
+        sddf_printf("LWIP|NOTICE: DHCP request for %s returned IP address: %s\n", microkit_name,
+                    ip4addr_ntoa(netif_ip4_addr(netif)));
     }
 }
 
@@ -291,13 +299,17 @@ void init(void)
     state.netif.name[1] = '0';
 
     if (!netif_add(&(state.netif), &ipaddr, &netmask, &gw, (void *)&state,
-              ethernet_init, ethernet_input)) sddf_dprintf("LWIP|ERROR: Netif add returned NULL\n");
+                   ethernet_init, ethernet_input)) {
+        sddf_dprintf("LWIP|ERROR: Netif add returned NULL\n");
+    }
 
     netif_set_default(&(state.netif));
     netif_set_status_callback(&(state.netif), netif_status_callback);
     netif_set_up(&(state.netif));
 
-    if (dhcp_start(&(state.netif))) sddf_dprintf("LWIP|ERROR: failed to start DHCP negotiation\n");
+    if (dhcp_start(&(state.netif))) {
+        sddf_dprintf("LWIP|ERROR: failed to start DHCP negotiation\n");
+    }
 
     setup_udp_socket();
     setup_utilization_socket();
@@ -305,48 +317,60 @@ void init(void)
     if (notify_rx && net_require_signal_free(&state.rx_queue)) {
         net_cancel_signal_free(&state.rx_queue);
         notify_rx = false;
-        if (!have_signal) microkit_notify_delayed(RX_CH);
-        else if (signal_cap != BASE_OUTPUT_NOTIFICATION_CAP + RX_CH) microkit_notify(RX_CH);
+        if (!have_signal) {
+            microkit_notify_delayed(RX_CH);
+        } else if (signal_cap != BASE_OUTPUT_NOTIFICATION_CAP + RX_CH) {
+            microkit_notify(RX_CH);
+        }
     }
 
     if (notify_tx && net_require_signal_active(&state.tx_queue)) {
         net_cancel_signal_active(&state.tx_queue);
         notify_tx = false;
-        if (!have_signal) microkit_notify_delayed(TX_CH);
-        else if (signal_cap != BASE_OUTPUT_NOTIFICATION_CAP + TX_CH) microkit_notify(TX_CH);
+        if (!have_signal) {
+            microkit_notify_delayed(TX_CH);
+        } else if (signal_cap != BASE_OUTPUT_NOTIFICATION_CAP + TX_CH) {
+            microkit_notify(TX_CH);
+        }
     }
 }
 
 void notified(microkit_channel ch)
 {
-    switch(ch) {
-        case RX_CH:
-            receive();
-            break;
-        case TIMER:
-            sys_check_timeouts();
-            set_timeout();
-            break;
-        case TX_CH:
-            transmit();
-            receive();
-            break;
-        default:
-            sddf_dprintf("LWIP|LOG: received notification on unexpected channel: %u\n", ch);
-            break;
+    switch (ch) {
+    case RX_CH:
+        receive();
+        break;
+    case TIMER:
+        sys_check_timeouts();
+        set_timeout();
+        break;
+    case TX_CH:
+        transmit();
+        receive();
+        break;
+    default:
+        sddf_dprintf("LWIP|LOG: received notification on unexpected channel: %u\n", ch);
+        break;
     }
-    
+
     if (notify_rx && net_require_signal_free(&state.rx_queue)) {
         net_cancel_signal_free(&state.rx_queue);
         notify_rx = false;
-        if (!have_signal) microkit_notify_delayed(RX_CH);
-        else if (signal_cap != BASE_OUTPUT_NOTIFICATION_CAP + RX_CH) microkit_notify(RX_CH);
+        if (!have_signal) {
+            microkit_notify_delayed(RX_CH);
+        } else if (signal_cap != BASE_OUTPUT_NOTIFICATION_CAP + RX_CH) {
+            microkit_notify(RX_CH);
+        }
     }
 
     if (notify_tx && net_require_signal_active(&state.tx_queue)) {
         net_cancel_signal_active(&state.tx_queue);
         notify_tx = false;
-        if (!have_signal) microkit_notify_delayed(TX_CH);
-        else if (signal_cap != BASE_OUTPUT_NOTIFICATION_CAP + TX_CH) microkit_notify(TX_CH);
+        if (!have_signal) {
+            microkit_notify_delayed(TX_CH);
+        } else if (signal_cap != BASE_OUTPUT_NOTIFICATION_CAP + TX_CH) {
+            microkit_notify(TX_CH);
+        }
     }
 }

--- a/examples/echo_server/lwip.c
+++ b/examples/echo_server/lwip.c
@@ -8,7 +8,6 @@
 #include <microkit.h>
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
-#include <sddf/network/arp.h>
 #include <sddf/network/queue.h>
 #include <sddf/timer/client.h>
 #include <sddf/benchmark/sel4bench.h>
@@ -29,7 +28,6 @@
 #define TIMER  1
 #define RX_CH  2
 #define TX_CH  3
-#define ARP    7
 
 #define LWIP_TICK_MS 100
 #define NUM_PBUFFS 512
@@ -262,16 +260,11 @@ static err_t ethernet_init(struct netif *netif)
     return ERR_OK;
 }
 
-/* Callback function that prints DHCP supplied IP address and registers it with ARP component. */
+/* Callback function that prints DHCP supplied IP address. */
 static void netif_status_callback(struct netif *netif)
 {
     if (dhcp_supplied_address(netif)) {
-        bool success = arp_register_ipv4(ARP, ip4_addr_get_u32(netif_ip4_addr(netif)), state.mac);
-        if (!success) {
-            sddf_printf("LWIP|ERR: could not register IP with ARP\n");
-        } else {
-            sddf_printf("LWIP|NOTICE: DHCP request for %s returned IP address: %s\n", microkit_name, ip4addr_ntoa(netif_ip4_addr(netif)));
-        }
+        sddf_printf("LWIP|NOTICE: DHCP request for %s returned IP address: %s\n", microkit_name, ip4addr_ntoa(netif_ip4_addr(netif)));
     }
 }
 

--- a/network/components/virt_rx.c
+++ b/network/components/virt_rx.c
@@ -48,33 +48,25 @@ static bool notify_drv;
   is a broadcast address. */
 int get_mac_addr_match(struct ethernet_header *buffer)
 {
-    bool broadcast_packet = false;
-
     for (int client = 0; client < NUM_CLIENTS; client++) {
         bool match = true;
-        bool is_broadcast = true;
-        for (int i = 0; (i < ETH_HWADDR_LEN) && (match || is_broadcast); i++) {
+        for (int i = 0; (i < ETH_HWADDR_LEN) && match; i++) {
             if (buffer->dest.addr[i] != state.mac_addrs[client][i]) {
                 match = false;
             }
-            /* This assumes that the only broadcast address is 0xFFFFFFFF.*/
-            if (buffer->dest.addr[i] != 0xFF) {
-                is_broadcast = false;
-            }
         }
-
         if (match) {
             return client;
-        } else if (is_broadcast) {
-            /* Mark the existance of a broadcast packet */
-            broadcast_packet = true;
         }
     }
 
-    /* We will only get here if this is a broadcast packet
-        and no client match has been made. In this case,
-        the packet will be sent to all clients. */
-    if (broadcast_packet) {
+    bool broadcast_match = true;
+    for (int i = 0; (i < ETH_HWADDR_LEN) && broadcast_match; i++) {
+        if (buffer->dest.addr[i] != 0xFF) {
+            broadcast_match = false;
+        }
+    }
+    if (broadcast_match) {
         return BROADCAST_ID;
     }
 

--- a/network/components/virt_rx.c
+++ b/network/components/virt_rx.c
@@ -28,6 +28,8 @@ uintptr_t rx_active_cli1;
 uintptr_t buffer_data_vaddr;
 uintptr_t buffer_data_paddr;
 
+int buff_refs[RX_QUEUE_SIZE_DRIV] = {0};
+
 typedef struct state {
     net_queue_handle_t rx_queue_drv;
     net_queue_handle_t rx_queue_clients[NUM_CLIENTS];
@@ -38,6 +40,18 @@ state_t state;
 
 /* Boolean to indicate whether a packet has been enqueued into the driver's free queue during notification handling */
 static bool notify_drv;
+
+bool is_broadcast(struct ethernet_header *buffer)
+{
+    bool match = true;
+    for (int i = 0; (i < ETH_HWADDR_LEN) && match; i++) {
+        if (buffer->dest.addr[i] != 0xFF) {
+            match = false;
+        }
+    }
+
+    return match;
+}
 
 /* Return the client ID if the Mac address is a match. */
 int get_client(struct ethernet_header *buffer)
@@ -92,24 +106,44 @@ void rx_return(void)
             // [2]: https://developer.arm.com/documentation/100236/0002/functional-description/cache-behavior-and-cache-protection/invalidating-or-cleaning-a-cache
             cache_clean_and_invalidate(buffer_vaddr, buffer_vaddr + ROUND_UP(buffer.len, 1 << CONFIG_L1_CACHE_LINE_SIZE_BITS));
 
-            int client = get_client((struct ethernet_header *) buffer_vaddr);
-            if (client >= 0) {
-                err = net_enqueue_active(&state.rx_queue_clients[client], buffer);
-                assert(!err);
-                notify_clients[client] = true;
-            } else {
-                // We are returning buffers to the device for DMA, which
-                // normally requires an invalidate (see rx_provide), but not
-                // here since we know there aren't any writes to the buffer
-                // since we invalidated above.
+            bool is_broadcast_packet = is_broadcast((struct ethernet_header *) buffer_vaddr);
 
-                buffer.io_or_offset = buffer.io_or_offset + buffer_data_paddr;
-                err = net_enqueue_free(&state.rx_queue_drv, buffer);
-                assert(!err);
-                notify_drv = true;
+            if (is_broadcast_packet) {
+                int ref_index = buffer.io_or_offset / NET_BUFFER_SIZE;
+                assert(buff_refs[ref_index] == 0);
+                // For broadcast packets, set the refcount to number of clients
+                // in the system. Only enqueue buffer back to driver if
+                // all clients have consumed the buffer.
+                buff_refs[ref_index] = NUM_CLIENTS;
+
+                for (int i = 0; i < NUM_CLIENTS; i++) {
+                    err = net_enqueue_active(&state.rx_queue_clients[i], buffer);
+                    assert(!err);
+                    notify_clients[i] = true;
+                }
+            } else {
+                int client = get_client((struct ethernet_header *) buffer_vaddr);
+                if (client >= 0) {
+                    int ref_index = buffer.io_or_offset / NET_BUFFER_SIZE;
+                    assert(buff_refs[ref_index] == 0);
+                    buff_refs[ref_index] = 1;
+
+                    err = net_enqueue_active(&state.rx_queue_clients[client], buffer);
+                    assert(!err);
+                    notify_clients[client] = true;
+                } else {
+                    // We are returning buffers to the device for DMA, which
+                    // normally requires an invalidate (see rx_provide), but not
+                    // here since we know there aren't any writes to the buffer
+                    // since we invalidated above.
+
+                    buffer.io_or_offset = buffer.io_or_offset + buffer_data_paddr;
+                    err = net_enqueue_free(&state.rx_queue_drv, buffer);
+                    assert(!err);
+                    notify_drv = true;
+                }
             }
         }
-
         net_request_signal_active(&state.rx_queue_drv);
         reprocess = false;
 
@@ -139,6 +173,14 @@ void rx_provide(void)
                 assert(!(buffer.io_or_offset % NET_BUFFER_SIZE) &&
                        (buffer.io_or_offset < NET_BUFFER_SIZE * state.rx_queue_clients[client].size));
 
+                int ref_index = buffer.io_or_offset / NET_BUFFER_SIZE;
+                assert(buff_refs[ref_index] != 0);
+
+                buff_refs[ref_index]--;
+
+                if (buff_refs[ref_index] != 0) {
+                    continue;
+                }
                 // Cache invalidate before DMA write to discard dirty
                 // cachelines, so they don't overwrite received data.
                 //

--- a/network/components/virt_rx.c
+++ b/network/components/virt_rx.c
@@ -28,7 +28,10 @@ uintptr_t rx_active_cli1;
 uintptr_t buffer_data_vaddr;
 uintptr_t buffer_data_paddr;
 
-int buff_refs[RX_QUEUE_SIZE_DRIV] = {0};
+/* In order to handle broadcast packets where the same buffer is given to multiple clients
+  * we keep track of a reference count of each buffer and only hand it back to the driver once
+  * all clients have returned the buffer. */
+uint32_t buff_refs[RX_QUEUE_SIZE_DRIV] = {0};
 
 typedef struct state {
     net_queue_handle_t rx_queue_drv;

--- a/network/components/virt_rx.c
+++ b/network/components/virt_rx.c
@@ -14,6 +14,8 @@
 #define DRIVER_CH 0
 #define CLIENT_CH 1
 
+/* Used to signify that a packet has come in for the broadcast address and does not match with
+ * any particular client. */
 #define BROADCAST_ID (NUM_CLIENTS + 1)
 
 /* Queue regions */

--- a/network/components/virt_tx.c
+++ b/network/components/virt_tx.c
@@ -11,18 +11,14 @@
 
 uintptr_t tx_free_drv;
 uintptr_t tx_active_drv;
-uintptr_t tx_free_arp;
-uintptr_t tx_active_arp;
 uintptr_t tx_free_cli0;
 uintptr_t tx_active_cli0;
 uintptr_t tx_free_cli1;
 uintptr_t tx_active_cli1;
 
-uintptr_t buffer_data_region_arp_vaddr;
 uintptr_t buffer_data_region_cli0_vaddr;
 uintptr_t buffer_data_region_cli1_vaddr;
 
-uintptr_t buffer_data_region_arp_paddr;
 uintptr_t buffer_data_region_cli0_paddr;
 uintptr_t buffer_data_region_cli1_paddr;
 
@@ -136,14 +132,13 @@ void notified(microkit_channel ch)
 void init(void)
 {
     net_queue_init(&state.tx_queue_drv, (net_queue_t *)tx_free_drv, (net_queue_t *)tx_active_drv, TX_QUEUE_SIZE_DRIV);
-    virt_queue_init_sys(microkit_name, state.tx_queue_clients, tx_free_arp, tx_active_arp);
+    virt_queue_init_sys(microkit_name, state.tx_queue_clients, tx_free_cli0, tx_active_cli0);
 
-    mem_region_init_sys(microkit_name, state.buffer_region_vaddrs, buffer_data_region_arp_vaddr);
+    mem_region_init_sys(microkit_name, state.buffer_region_vaddrs, buffer_data_region_cli0_vaddr);
 
     /* CDTODO: Can we make this system agnostic? */
-    state.buffer_region_paddrs[0] = buffer_data_region_arp_paddr;
-    state.buffer_region_paddrs[1] = buffer_data_region_cli0_paddr;
-    state.buffer_region_paddrs[2] = buffer_data_region_cli1_paddr;
+    state.buffer_region_paddrs[0] = buffer_data_region_cli0_paddr;
+    state.buffer_region_paddrs[1] = buffer_data_region_cli1_paddr;
 
     tx_provide();
 }


### PR DESCRIPTION
This change adds a reference count for each buffer in the virt rx component. This allows us to properly handle broadcast packets that need to be sent to multiple clients, and ensuring that we are still adhering to the consumer/producer pattern that is expected. On broadcasts, we set the refcount to the number of clients in the system, and for unicast just 1. We decrement the refcount when we receive a buffer back from the client, and enqueue back into the driver queues when the refcount reaches zero.