### PR TITLE
Refactor serial subsystem to improve ability to change number of clients

### DIFF
--- a/drivers/serial/arm/uart.c
+++ b/drivers/serial/arm/uart.c
@@ -5,6 +5,7 @@
 #include "uart_config.h"
 #include <sddf/serial/queue.h>
 #include <sddf/util/util.h>
+#include <serial_config.h>
 
 /*
  * The PL011 is supposedly universal, which means that this driver should be
@@ -18,9 +19,9 @@
 #define LOG_DRIVER_ERR(...) do{ microkit_dbg_puts(microkit_name); microkit_dbg_puts("|ERROR: "); microkit_dbg_puts(__VA_ARGS__); }while(0)
 
 /* Defines to manage interrupts and notifications */
-#define IRQ_CH 1
-#define TX_CH  8
-#define RX_CH  10
+#define IRQ_CH 0
+#define TX_CH  1
+#define RX_CH  2
 
 /* Shared memory for queues */
 uintptr_t rx_free;
@@ -203,9 +204,8 @@ void handle_irq() {
 void init(void) {
     LOG_DRIVER("initialising\n");
 
-    // Init the shared queues
-    serial_queue_init(&rx_queue, (serial_queue_t *)rx_free, (serial_queue_t *)rx_active, 0, NUM_ENTRIES, NUM_ENTRIES);
-    serial_queue_init(&tx_queue, (serial_queue_t *)tx_free, (serial_queue_t *)tx_active, 0, NUM_ENTRIES, NUM_ENTRIES);
+    serial_queue_init(&rx_queue, (serial_queue_t *)rx_free, (serial_queue_t *)rx_active, RX_QUEUE_SIZE_DRIV);
+    serial_queue_init(&tx_queue, (serial_queue_t *)tx_free, (serial_queue_t *)tx_active, TX_QUEUE_SIZE_DRIV);
 
     volatile struct pl011_uart_regs *regs = (volatile struct pl011_uart_regs *) uart_base;
     // @ivanv what does 0x50 mean!

--- a/drivers/serial/imx/uart.c
+++ b/drivers/serial/imx/uart.c
@@ -6,15 +6,16 @@
 #include <stdint.h>
 #include <microkit.h>
 #include <sel4/sel4.h>
+#include <serial_config.h>
 #include "uart.h"
 #include "uart_config.h"
 
 #define BIT(nr) (1UL << (nr))
 
 // Defines to manage interrupts and notifications
-#define IRQ_CH 1
-#define TX_CH  8
-#define RX_CH  10
+#define IRQ_CH 0
+#define TX_CH  1
+#define RX_CH  2
 
 /* Memory regions. These all have to be here to keep compiler happy */
 // Queue components
@@ -319,8 +320,8 @@ void init(void) {
     microkit_dbg_puts(": elf PD init function running\n");
 
     // Init the shared queues
-    serial_queue_init(&rx_queue, (serial_queue_t *)rx_free, (serial_queue_t *)rx_active, 0, BUFFER_SIZE, BUFFER_SIZE);
-    serial_queue_init(&tx_queue, (serial_queue_t *)tx_free, (serial_queue_t *)tx_active, 0, BUFFER_SIZE, BUFFER_SIZE);
+    serial_queue_init(&rx_queue, (serial_queue_t *)rx_free, (serial_queue_t *)rx_active, RX_QUEUE_SIZE_DRIV);
+    serial_queue_init(&tx_queue, (serial_queue_t *)tx_free, (serial_queue_t *)tx_active, TX_QUEUE_SIZE_DRIV);
 
     volatile imx_uart_regs_t *regs = (imx_uart_regs_t *) uart_base;
 

--- a/drivers/serial/meson/uart.c
+++ b/drivers/serial/meson/uart.c
@@ -6,13 +6,14 @@
 #include <stdint.h>
 #include <microkit.h>
 #include <sddf/util/util.h>
+#include <serial_config.h>
 #include "uart.h"
 #include "uart_config.h"
 
 // Defines to manage interrupts and notifications
-#define IRQ_CH 1
-#define TX_CH  8
-#define RX_CH  10
+#define IRQ_CH 0
+#define TX_CH  1
+#define RX_CH  2
 
 /* Memory regions. These all have to be here to keep compiler happy */
 uintptr_t rx_free;
@@ -294,8 +295,8 @@ void init(void) {
     microkit_dbg_puts(": initialising\n");
 
     // Init the shared queues
-    serial_queue_init(&rx_queue, (serial_queue_t *)rx_free, (serial_queue_t *)rx_active, 0, BUFFER_SIZE, BUFFER_SIZE);
-    serial_queue_init(&tx_queue, (serial_queue_t *)tx_free, (serial_queue_t *)tx_active, 0, BUFFER_SIZE, BUFFER_SIZE);
+    serial_queue_init(&rx_queue, (serial_queue_t *)rx_free, (serial_queue_t *)rx_active, RX_QUEUE_SIZE_DRIV);
+    serial_queue_init(&tx_queue, (serial_queue_t *)tx_free, (serial_queue_t *)tx_active, TX_QUEUE_SIZE_DRIV);
 
     volatile meson_uart_regs_t *regs = (meson_uart_regs_t *) (uart_base + UART_REGS_OFFSET);
 

--- a/examples/serial/Makefile
+++ b/examples/serial/Makefile
@@ -21,6 +21,7 @@ AS := $(TOOLCHAIN)-as
 MICROKIT_TOOL := $(MICROKIT_SDK)/bin/microkit
 MICROKIT_CONFIG ?= debug
 BUILD_DIR ?= build
+SERIAL_CONFIG_INCLUDE ?= include/serial_config
 
 ifeq ($(strip $(MICROKIT_BOARD)), odroidc4)
 	DRIVER_DIR := meson
@@ -42,7 +43,7 @@ UART_DRIVER=$(SDDF)/drivers/serial/$(DRIVER_DIR)
 BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
 SYSTEM_FILE := board/$(MICROKIT_BOARD)/serial.system
 
-IMAGES := uart.elf serial_server_1.elf serial_server_2.elf virt_tx.elf virt_rx.elf
+IMAGES := uart.elf serial_server.elf virt_tx.elf virt_rx.elf
 CFLAGS := -mcpu=$(CPU) -mstrict-align -ffreestanding -g3 -O3 -Wall -Wno-unused-function -Werror
 LDFLAGS := -L$(BOARD_DIR)/lib -L$(SDDF)/lib
 LIBS := -lmicrokit -Tmicrokit.ld -lc
@@ -52,19 +53,19 @@ REPORT_FILE = $(BUILD_DIR)/report.txt
 
 CFLAGS += -I$(BOARD_DIR)/include \
 	-Iinclude	\
+	-I$(SERIAL_CONFIG_INCLUDE) \
 	-I$(UART_DRIVER)/include \
 	-I$(SDDF)/include \
 
 UART_OBJS := uart.o printf.o putchar_debug.o
-SERIAL_SERVER_OBJS1 := serial_server_1.o
-SERIAL_SERVER_OBJS2 := serial_server_2.o
+SERIAL_SERVER_OBJS := serial_server.o
 VIRT_TX_OBJS := virt_tx.o
 VIRT_RX_OBJS := virt_rx.o
 
 all: directories $(IMAGE_FILE)
 
 $(BUILD_DIR)/%.o: $(SERIAL_COMPONENTS)/%.c Makefile
-	$(CC) -c $(CFLAGS) -DSERIAL_NUM_CLIENTS=2 -DSERIAL_TRANSFER_WITH_COLOUR $< -o $@
+	$(CC) -c $(CFLAGS) -DSERIAL_TRANSFER_WITH_COLOUR $< -o $@
 
 $(BUILD_DIR)/%.o: $(SERIAL_QUEUE)/%.c Makefile
 	$(CC) -c $(CFLAGS) $< -o $@
@@ -78,11 +79,8 @@ $(BUILD_DIR)/printf.o: $(UTIL)/printf.c Makefile
 $(BUILD_DIR)/putchar_debug.o: $(UTIL)/putchar_debug.c Makefile
 	$(CC) -c $(CFLAGS) $< -o $@
 
-$(BUILD_DIR)/serial_server_1.o: serial_server.c Makefile
-	$(CC) -c $(CFLAGS) -DSERIAL_SERVER_NUMBER=1 $< -o $@
-
-$(BUILD_DIR)/serial_server_2.o: serial_server.c Makefile
-	$(CC) -c $(CFLAGS) -DSERIAL_SERVER_NUMBER=2 $< -o $@
+$(BUILD_DIR)/serial_server.o: serial_server.c Makefile
+	$(CC) -c $(CFLAGS) $< -o $@
 
 $(BUILD_DIR)/virt_tx.elf: $(addprefix $(BUILD_DIR)/, $(VIRT_TX_OBJS))
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
@@ -93,10 +91,7 @@ $(BUILD_DIR)/virt_rx.elf: $(addprefix $(BUILD_DIR)/, $(VIRT_RX_OBJS))
 $(BUILD_DIR)/uart.elf: $(addprefix $(BUILD_DIR)/, $(UART_OBJS))
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
-$(BUILD_DIR)/serial_server_1.elf: $(addprefix $(BUILD_DIR)/, $(SERIAL_SERVER_OBJS1))
-	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
-
-$(BUILD_DIR)/serial_server_2.elf: $(addprefix $(BUILD_DIR)/, $(SERIAL_SERVER_OBJS2))
+$(BUILD_DIR)/serial_server.elf: $(addprefix $(BUILD_DIR)/, $(SERIAL_SERVER_OBJS))
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 $(IMAGE_FILE) $(REPORT_FILE): $(addprefix $(BUILD_DIR)/, $(IMAGES)) $(SYSTEM_FILE)

--- a/examples/serial/board/maaxboard/serial.system
+++ b/examples/serial/board/maaxboard/serial.system
@@ -3,12 +3,12 @@
     <memory_region name="uart" size="0x1_000" phys_addr="0x30860000" />
 
     <memory_region name="tx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_client" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="tx_data_client0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="rx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_client" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="rx_data_client0" size="0x200_000" page_size="0x200_000" />
 
-    <memory_region name="tx_data_client2" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_client2" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="tx_data_client1" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="rx_data_client1" size="0x200_000" page_size="0x200_000" />
 
     <!-- shared memory for queue structures -->
     <memory_region name="rx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
@@ -16,79 +16,77 @@
     <memory_region name="tx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_active_serial_driver" size="0x200_000" page_size="0x200_000"/>
 
-    <memory_region name="tx_free_serial_client" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_client" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_client" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_client" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="tx_free_serial_client0" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="tx_active_serial_client0" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="rx_free_serial_client0" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="rx_active_serial_client0" size="0x200_000" page_size="0x200_000"/>
 
-    <memory_region name="tx_free_serial_client2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_client2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_client2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_client2" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="tx_free_serial_client1" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="tx_active_serial_client1" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="rx_free_serial_client1" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="rx_active_serial_client1" size="0x200_000" page_size="0x200_000"/>
 
     <protection_domain name="uart" priority="100" pp="true">
         <program_image path="uart.elf" />
-
         <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
 
         <!-- shared memory for queues -->
-        <map mr="rx_free_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
+        <map mr="rx_free_serial_driver" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
+        <map mr="rx_active_serial_driver" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
+        <map mr="tx_free_serial_driver" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
+        <map mr="tx_active_serial_driver" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
 
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" />
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" />
+        <map mr="tx_data_driver" vaddr="0x3_c00_000" perms="rw" cached="true" />
+        <map mr="rx_data_driver" vaddr="0x4_c00_000" perms="rw" cached="true" />
 
         <!-- UART interrupt -->
-        <irq irq="58" id="1" />
+        <irq irq="58" id="0" />
     </protection_domain>
 
-    <protection_domain name="serial_server_1" priority="97" pp="true">
-        <program_image path="serial_server_1.elf" />
+    <protection_domain name="serial_server0" priority="97" pp="true">
+        <program_image path="serial_server.elf" />
 
         <!-- shared memory for queues -->
-        <map mr="rx_free_serial_client" vaddr="0x4_800_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_client" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
+        <map mr="rx_free_serial_client0" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
+        <map mr="rx_active_serial_client0" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
 
-        <map mr="tx_free_serial_client" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_client" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
+        <map mr="tx_free_serial_client0" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
+        <map mr="tx_active_serial_client0" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
 
-        <map mr="tx_data_client" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
-        <map mr="rx_data_client" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_client0" vaddr="0x3_e00_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+        <map mr="rx_data_client0" vaddr="0x4_e00_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
     </protection_domain>
 
-    <protection_domain name="serial_server_2" priority="97" pp="true">
-    <program_image path="serial_server_2.elf" />
+    <protection_domain name="serial_server1" priority="97" pp="true">
+    <program_image path="serial_server.elf" />
 
         <!-- shared memory for queues -->
-        <map mr="rx_free_serial_client2" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_client2" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
+        <map mr="rx_free_serial_client1" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
+        <map mr="rx_active_serial_client1" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
 
-        <map mr="tx_free_serial_client2" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_client2" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
+        <map mr="tx_free_serial_client1" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
+        <map mr="tx_active_serial_client1" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
 
-        <map mr="tx_data_client2" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
-        <map mr="rx_data_client2" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_client1" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+        <map mr="rx_data_client1" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
     </protection_domain>
 
     <protection_domain name="virt_tx" priority="99" pp="true">
         <program_image path="virt_tx.elf" />
 
          <!-- shared memory for driver/virt queues -->
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_driver" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_driver" />
+        <map mr="tx_free_serial_driver" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="tx_free_driver" />
+        <map mr="tx_active_serial_driver" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="tx_active_driver" />
 
         <!-- shared memory for virt/client queues -->
-        <map mr="tx_free_serial_client" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_client" />
-        <map mr="tx_active_serial_client" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_client" />
-        <map mr="tx_free_serial_client2" vaddr="0x3_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_client2" />
-        <map mr="tx_active_serial_client2" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_active_client2" />
+        <map mr="tx_free_serial_client0" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_client0" />
+        <map mr="tx_active_serial_client0" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_client0" />
+        <map mr="tx_free_serial_client1" vaddr="0x3_800_000" perms="rw" cached="true"/>
+        <map mr="tx_active_serial_client1" vaddr="0x3_a00_000" perms="rw" cached="true"/>
 
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_data_driver" />
-
-        <map mr="tx_data_client" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_data_client" />
-        <map mr="tx_data_client2" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_data_client2" />
+        <map mr="tx_data_driver" vaddr="0x3_c00_000" perms="rw" cached="true" setvar_vaddr="tx_data_driver" />
+        <map mr="tx_data_client0" vaddr="0x3_e00_000" perms="rw" cached="true"/>
+        <map mr="tx_data_client1" vaddr="0x4_000_000" perms="rw" cached="true"/>
     </protection_domain>
 
     <protection_domain name="virt_rx" priority="98" pp="true">
@@ -99,44 +97,44 @@
         <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_driver" />
 
         <!-- shared memory for virt/client queues -->
-        <map mr="rx_free_serial_client" vaddr="0x4_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_client" />
-        <map mr="rx_active_serial_client" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_active_client" />
-        <map mr="rx_free_serial_client2" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_client2" />
-        <map mr="rx_active_serial_client2" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_client2" />
+        <map mr="rx_free_serial_client0" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_client0" />
+        <map mr="rx_active_serial_client0" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_client0" />
+        <map mr="rx_free_serial_client1" vaddr="0x4_800_000" perms="rw" cached="true" />
+        <map mr="rx_active_serial_client1" vaddr="0x4_a00_000" perms="rw" cached="true" />
 
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_data_driver" />
-        <map mr="rx_data_client" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_data_client" />
-        <map mr="rx_data_client2" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_data_client2" />
+        <map mr="rx_data_driver" vaddr="0x4_c00_000" perms="rw" cached="true" setvar_vaddr="rx_data_driver" />
+        <map mr="rx_data_client0" vaddr="0x4_e00_000" perms="rw" cached="true"/>
+        <map mr="rx_data_client1" vaddr="0x5_000_000" perms="rw" cached="true"/>
     </protection_domain>
 
     <!-- These following channels are needed for communication between the server and driver -->
     <channel>
-        <end pd="serial_server_1" id="0"/>
+        <end pd="uart" id="1"/>
+        <end pd="virt_tx" id="0"/>
+    </channel>
+
+    <channel>
+        <end pd="uart" id="2"/>
+        <end pd="virt_rx" id="0"/>
+    </channel>
+
+    <channel>
+        <end pd="serial_server0" id="0"/>
         <end pd="virt_tx" id="1"/>
     </channel>
 
     <channel>
-        <end pd="uart" id="8"/>
-        <end pd="virt_tx" id="9"/>
+        <end pd="serial_server1" id="0"/>
+        <end pd="virt_tx" id="2"/>
     </channel>
 
    <channel>
-        <end pd="serial_server_1" id="1"/>
+        <end pd="serial_server0" id="1"/>
         <end pd="virt_rx" id="1"/>
     </channel>
 
     <channel>
-        <end pd="uart" id="10"/>
-        <end pd="virt_rx" id="11"/>
-    </channel>
-
-    <channel>
-        <end pd="serial_server_2" id="0"/>
-        <end pd="virt_tx" id="2"/>
-    </channel>
-
-    <channel>
-        <end pd="serial_server_2" id="1"/>
+        <end pd="serial_server1" id="1"/>
         <end pd="virt_rx" id="2"/>
     </channel>
 </system>

--- a/examples/serial/board/odroidc4/serial.system
+++ b/examples/serial/board/odroidc4/serial.system
@@ -3,12 +3,12 @@
     <memory_region name="uart" size="0x1_000" phys_addr="0xff803000" />
 
     <memory_region name="tx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_client" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="tx_data_client0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="rx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_client" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="rx_data_client0" size="0x200_000" page_size="0x200_000" />
 
-    <memory_region name="tx_data_client2" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_client2" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="tx_data_client1" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="rx_data_client1" size="0x200_000" page_size="0x200_000" />
 
     <!-- shared memory for queue structures -->
     <memory_region name="rx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
@@ -16,79 +16,77 @@
     <memory_region name="tx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_active_serial_driver" size="0x200_000" page_size="0x200_000"/>
 
-    <memory_region name="tx_free_serial_client" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_client" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_client" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_client" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="tx_free_serial_client0" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="tx_active_serial_client0" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="rx_free_serial_client0" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="rx_active_serial_client0" size="0x200_000" page_size="0x200_000"/>
 
-    <memory_region name="tx_free_serial_client2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_client2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_client2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_client2" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="tx_free_serial_client1" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="tx_active_serial_client1" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="rx_free_serial_client1" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="rx_active_serial_client1" size="0x200_000" page_size="0x200_000"/>
 
     <protection_domain name="uart" priority="100" pp="true">
         <program_image path="uart.elf" />
-
         <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
 
         <!-- shared memory for queues -->
-        <map mr="rx_free_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
+        <map mr="rx_free_serial_driver" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
+        <map mr="rx_active_serial_driver" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
+        <map mr="tx_free_serial_driver" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
+        <map mr="tx_active_serial_driver" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
 
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" />
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" />
+        <map mr="tx_data_driver" vaddr="0x3_c00_000" perms="rw" cached="true" />
+        <map mr="rx_data_driver" vaddr="0x4_c00_000" perms="rw" cached="true" />
 
         <!-- UART interrupt -->
-        <irq irq="225" id="1" trigger="edge" />
+        <irq irq="225" id="0" trigger="edge" />
     </protection_domain>
 
-    <protection_domain name="serial_server_1" priority="97" pp="true">
-        <program_image path="serial_server_1.elf" />
+    <protection_domain name="serial_server0" priority="97" pp="true">
+        <program_image path="serial_server.elf" />
 
         <!-- shared memory for queues -->
-        <map mr="rx_free_serial_client" vaddr="0x4_800_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_client" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
+        <map mr="rx_free_serial_client0" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
+        <map mr="rx_active_serial_client0" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
 
-        <map mr="tx_free_serial_client" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_client" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
+        <map mr="tx_free_serial_client0" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
+        <map mr="tx_active_serial_client0" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
 
-        <map mr="tx_data_client" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
-        <map mr="rx_data_client" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_client0" vaddr="0x3_e00_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+        <map mr="rx_data_client0" vaddr="0x4_e00_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
     </protection_domain>
 
-    <protection_domain name="serial_server_2" priority="97" pp="true">
-    <program_image path="serial_server_2.elf" />
+    <protection_domain name="serial_server1" priority="97" pp="true">
+    <program_image path="serial_server.elf" />
 
         <!-- shared memory for queues -->
-        <map mr="rx_free_serial_client2" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_client2" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
+        <map mr="rx_free_serial_client1" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
+        <map mr="rx_active_serial_client1" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
 
-        <map mr="tx_free_serial_client2" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_client2" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
+        <map mr="tx_free_serial_client1" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
+        <map mr="tx_active_serial_client1" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
 
-        <map mr="tx_data_client2" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
-        <map mr="rx_data_client2" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_client1" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+        <map mr="rx_data_client1" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
     </protection_domain>
 
     <protection_domain name="virt_tx" priority="99" pp="true">
         <program_image path="virt_tx.elf" />
 
          <!-- shared memory for driver/virt queues -->
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_driver" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_driver" />
+        <map mr="tx_free_serial_driver" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="tx_free_driver" />
+        <map mr="tx_active_serial_driver" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="tx_active_driver" />
 
         <!-- shared memory for virt/client queues -->
-        <map mr="tx_free_serial_client" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_client" />
-        <map mr="tx_active_serial_client" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_client" />
-        <map mr="tx_free_serial_client2" vaddr="0x3_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_client2" />
-        <map mr="tx_active_serial_client2" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_active_client2" />
+        <map mr="tx_free_serial_client0" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_client0" />
+        <map mr="tx_active_serial_client0" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_client0" />
+        <map mr="tx_free_serial_client1" vaddr="0x3_800_000" perms="rw" cached="true"/>
+        <map mr="tx_active_serial_client1" vaddr="0x3_a00_000" perms="rw" cached="true"/>
 
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_data_driver" />
-
-        <map mr="tx_data_client" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_data_client" />
-        <map mr="tx_data_client2" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_data_client2" />
+        <map mr="tx_data_driver" vaddr="0x3_c00_000" perms="rw" cached="true" setvar_vaddr="tx_data_driver" />
+        <map mr="tx_data_client0" vaddr="0x3_e00_000" perms="rw" cached="true"/>
+        <map mr="tx_data_client1" vaddr="0x4_000_000" perms="rw" cached="true"/>
     </protection_domain>
 
     <protection_domain name="virt_rx" priority="98" pp="true">
@@ -99,44 +97,44 @@
         <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_driver" />
 
         <!-- shared memory for virt/client queues -->
-        <map mr="rx_free_serial_client" vaddr="0x4_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_client" />
-        <map mr="rx_active_serial_client" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_active_client" />
-        <map mr="rx_free_serial_client2" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_client2" />
-        <map mr="rx_active_serial_client2" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_client2" />
+        <map mr="rx_free_serial_client0" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_client0" />
+        <map mr="rx_active_serial_client0" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_client0" />
+        <map mr="rx_free_serial_client1" vaddr="0x4_800_000" perms="rw" cached="true" />
+        <map mr="rx_active_serial_client1" vaddr="0x4_a00_000" perms="rw" cached="true" />
 
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_data_driver" />
-        <map mr="rx_data_client" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_data_client" />
-        <map mr="rx_data_client2" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_data_client2" />
+        <map mr="rx_data_driver" vaddr="0x4_c00_000" perms="rw" cached="true" setvar_vaddr="rx_data_driver" />
+        <map mr="rx_data_client0" vaddr="0x4_e00_000" perms="rw" cached="true"/>
+        <map mr="rx_data_client1" vaddr="0x5_000_000" perms="rw" cached="true"/>
     </protection_domain>
 
     <!-- These following channels are needed for communication between the server and driver -->
     <channel>
-        <end pd="serial_server_1" id="0"/>
+        <end pd="uart" id="1"/>
+        <end pd="virt_tx" id="0"/>
+    </channel>
+
+    <channel>
+        <end pd="uart" id="2"/>
+        <end pd="virt_rx" id="0"/>
+    </channel>
+
+    <channel>
+        <end pd="serial_server0" id="0"/>
         <end pd="virt_tx" id="1"/>
     </channel>
 
     <channel>
-        <end pd="uart" id="8"/>
-        <end pd="virt_tx" id="9"/>
+        <end pd="serial_server1" id="0"/>
+        <end pd="virt_tx" id="2"/>
     </channel>
 
    <channel>
-        <end pd="serial_server_1" id="1"/>
+        <end pd="serial_server0" id="1"/>
         <end pd="virt_rx" id="1"/>
     </channel>
 
     <channel>
-        <end pd="uart" id="10"/>
-        <end pd="virt_rx" id="11"/>
-    </channel>
-
-    <channel>
-        <end pd="serial_server_2" id="0"/>
-        <end pd="virt_tx" id="2"/>
-    </channel>
-
-    <channel>
-        <end pd="serial_server_2" id="1"/>
+        <end pd="serial_server1" id="1"/>
         <end pd="virt_rx" id="2"/>
     </channel>
 </system>

--- a/examples/serial/board/qemu_arm_virt/serial.system
+++ b/examples/serial/board/qemu_arm_virt/serial.system
@@ -3,12 +3,12 @@
     <memory_region name="uart" size="0x1_000" phys_addr="0x9000000" />
 
     <memory_region name="tx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="tx_data_client" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="tx_data_client0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="rx_data_driver" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_client" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="rx_data_client0" size="0x200_000" page_size="0x200_000" />
 
-    <memory_region name="tx_data_client2" size="0x200_000" page_size="0x200_000" />
-    <memory_region name="rx_data_client2" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="tx_data_client1" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="rx_data_client1" size="0x200_000" page_size="0x200_000" />
 
     <!-- shared memory for queue structures -->
     <memory_region name="rx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
@@ -16,79 +16,77 @@
     <memory_region name="tx_free_serial_driver" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="tx_active_serial_driver" size="0x200_000" page_size="0x200_000"/>
 
-    <memory_region name="tx_free_serial_client" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_client" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_client" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_client" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="tx_free_serial_client0" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="tx_active_serial_client0" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="rx_free_serial_client0" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="rx_active_serial_client0" size="0x200_000" page_size="0x200_000"/>
 
-    <memory_region name="tx_free_serial_client2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="tx_active_serial_client2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_free_serial_client2" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="rx_active_serial_client2" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="tx_free_serial_client1" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="tx_active_serial_client1" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="rx_free_serial_client1" size="0x200_000" page_size="0x200_000"/>
+    <memory_region name="rx_active_serial_client1" size="0x200_000" page_size="0x200_000"/>
 
     <protection_domain name="uart" priority="100" pp="true">
         <program_image path="uart.elf" />
-
         <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
 
         <!-- shared memory for queues -->
-        <map mr="rx_free_serial_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
+        <map mr="rx_free_serial_driver" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
+        <map mr="rx_active_serial_driver" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
+        <map mr="tx_free_serial_driver" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
+        <map mr="tx_active_serial_driver" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
 
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" />
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" />
+        <map mr="tx_data_driver" vaddr="0x3_c00_000" perms="rw" cached="true" />
+        <map mr="rx_data_driver" vaddr="0x4_c00_000" perms="rw" cached="true" />
 
         <!-- UART interrupt -->
-        <irq irq="33" id="1" />
+        <irq irq="33" id="0" />
     </protection_domain>
 
-    <protection_domain name="serial_server_1" priority="97" pp="true">
-        <program_image path="serial_server_1.elf" />
+    <protection_domain name="serial_server0" priority="97" pp="true">
+        <program_image path="serial_server.elf" />
 
         <!-- shared memory for queues -->
-        <map mr="rx_free_serial_client" vaddr="0x4_800_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_client" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
+        <map mr="rx_free_serial_client0" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
+        <map mr="rx_active_serial_client0" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
 
-        <map mr="tx_free_serial_client" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_client" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
+        <map mr="tx_free_serial_client0" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
+        <map mr="tx_active_serial_client0" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
 
-        <map mr="tx_data_client" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
-        <map mr="rx_data_client" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_client0" vaddr="0x3_e00_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+        <map mr="rx_data_client0" vaddr="0x4_e00_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
     </protection_domain>
 
-    <protection_domain name="serial_server_2" priority="97" pp="true">
-    <program_image path="serial_server_2.elf" />
+    <protection_domain name="serial_server1" priority="97" pp="true">
+    <program_image path="serial_server.elf" />
 
         <!-- shared memory for queues -->
-        <map mr="rx_free_serial_client2" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-        <map mr="rx_active_serial_client2" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
+        <map mr="rx_free_serial_client1" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
+        <map mr="rx_active_serial_client1" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
 
-        <map mr="tx_free_serial_client2" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-        <map mr="tx_active_serial_client2" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
+        <map mr="tx_free_serial_client1" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
+        <map mr="tx_active_serial_client1" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
 
-        <map mr="tx_data_client2" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
-        <map mr="rx_data_client2" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_client1" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+        <map mr="rx_data_client1" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
     </protection_domain>
 
     <protection_domain name="virt_tx" priority="99" pp="true">
         <program_image path="virt_tx.elf" />
 
          <!-- shared memory for driver/virt queues -->
-        <map mr="tx_free_serial_driver" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_driver" />
-        <map mr="tx_active_serial_driver" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_driver" />
+        <map mr="tx_free_serial_driver" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="tx_free_driver" />
+        <map mr="tx_active_serial_driver" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="tx_active_driver" />
 
         <!-- shared memory for virt/client queues -->
-        <map mr="tx_free_serial_client" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_client" />
-        <map mr="tx_active_serial_client" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_client" />
-        <map mr="tx_free_serial_client2" vaddr="0x3_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_client2" />
-        <map mr="tx_active_serial_client2" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_active_client2" />
+        <map mr="tx_free_serial_client0" vaddr="0x3_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_client0" />
+        <map mr="tx_active_serial_client0" vaddr="0x3_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_client0" />
+        <map mr="tx_free_serial_client1" vaddr="0x3_800_000" perms="rw" cached="true"/>
+        <map mr="tx_active_serial_client1" vaddr="0x3_a00_000" perms="rw" cached="true"/>
 
-        <map mr="tx_data_driver" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_data_driver" />
-
-        <map mr="tx_data_client" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_data_client" />
-        <map mr="tx_data_client2" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_data_client2" />
+        <map mr="tx_data_driver" vaddr="0x3_c00_000" perms="rw" cached="true" setvar_vaddr="tx_data_driver" />
+        <map mr="tx_data_client0" vaddr="0x3_e00_000" perms="rw" cached="true"/>
+        <map mr="tx_data_client1" vaddr="0x4_000_000" perms="rw" cached="true"/>
     </protection_domain>
 
     <protection_domain name="virt_rx" priority="98" pp="true">
@@ -99,44 +97,44 @@
         <map mr="rx_active_serial_driver" vaddr="0x4_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_driver" />
 
         <!-- shared memory for virt/client queues -->
-        <map mr="rx_free_serial_client" vaddr="0x4_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_client" />
-        <map mr="rx_active_serial_client" vaddr="0x5_000_000" perms="rw" cached="true" setvar_vaddr="rx_active_client" />
-        <map mr="rx_free_serial_client2" vaddr="0x3_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_client2" />
-        <map mr="rx_active_serial_client2" vaddr="0x3_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_client2" />
+        <map mr="rx_free_serial_client0" vaddr="0x4_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_client0" />
+        <map mr="rx_active_serial_client0" vaddr="0x4_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_client0" />
+        <map mr="rx_free_serial_client1" vaddr="0x4_800_000" perms="rw" cached="true" />
+        <map mr="rx_active_serial_client1" vaddr="0x4_a00_000" perms="rw" cached="true" />
 
-        <map mr="rx_data_driver" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_data_driver" />
-        <map mr="rx_data_client" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_data_client" />
-        <map mr="rx_data_client2" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_data_client2" />
+        <map mr="rx_data_driver" vaddr="0x4_c00_000" perms="rw" cached="true" setvar_vaddr="rx_data_driver" />
+        <map mr="rx_data_client0" vaddr="0x4_e00_000" perms="rw" cached="true"/>
+        <map mr="rx_data_client1" vaddr="0x5_000_000" perms="rw" cached="true"/>
     </protection_domain>
 
     <!-- These following channels are needed for communication between the server and driver -->
     <channel>
-        <end pd="serial_server_1" id="0"/>
+        <end pd="uart" id="1"/>
+        <end pd="virt_tx" id="0"/>
+    </channel>
+
+    <channel>
+        <end pd="uart" id="2"/>
+        <end pd="virt_rx" id="0"/>
+    </channel>
+
+    <channel>
+        <end pd="serial_server0" id="0"/>
         <end pd="virt_tx" id="1"/>
     </channel>
 
     <channel>
-        <end pd="uart" id="8"/>
-        <end pd="virt_tx" id="9"/>
+        <end pd="serial_server1" id="0"/>
+        <end pd="virt_tx" id="2"/>
     </channel>
 
    <channel>
-        <end pd="serial_server_1" id="1"/>
+        <end pd="serial_server0" id="1"/>
         <end pd="virt_rx" id="1"/>
     </channel>
 
     <channel>
-        <end pd="uart" id="10"/>
-        <end pd="virt_rx" id="11"/>
-    </channel>
-
-    <channel>
-        <end pd="serial_server_2" id="0"/>
-        <end pd="virt_tx" id="2"/>
-    </channel>
-
-    <channel>
-        <end pd="serial_server_2" id="1"/>
+        <end pd="serial_server1" id="1"/>
         <end pd="virt_rx" id="2"/>
     </channel>
 </system>

--- a/examples/serial/include/serial_config/serial_config.h
+++ b/examples/serial/include/serial_config/serial_config.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <microkit.h>
+#include <sddf/serial/queue.h>
+
+#define NUM_CLIENTS 2
+
+#define CLI0_NAME "serial_server0"
+#define CLI1_NAME "serial_server1"
+#define VIRT_RX_NAME "virt_rx"
+#define VIRT_TX_NAME "virt_tx"
+#define DRIVER_NAME "uart"
+
+#define DATA_REGION_SIZE                    0x200000
+
+#define TX_QUEUE_SIZE_CLI0                   512
+#define TX_QUEUE_SIZE_CLI1                   512
+#define TX_QUEUE_SIZE_DRIV                   512
+
+#define TX_DATA_REGION_SIZE_DRIV            DATA_REGION_SIZE
+#define TX_DATA_REGION_SIZE_CLI0            DATA_REGION_SIZE
+#define TX_DATA_REGION_SIZE_CLI1            DATA_REGION_SIZE
+
+_Static_assert(TX_DATA_REGION_SIZE_DRIV >= TX_QUEUE_SIZE_DRIV * BUFFER_SIZE, "Driver TX data region size must fit Driver TX buffers");
+_Static_assert(TX_DATA_REGION_SIZE_CLI0 >= TX_QUEUE_SIZE_CLI0 * BUFFER_SIZE, "Client0 TX data region size must fit Client0 TX buffers");
+_Static_assert(TX_DATA_REGION_SIZE_CLI1 >= TX_QUEUE_SIZE_CLI1 * BUFFER_SIZE, "Client1 TX data region size must fit Client1 TX buffers");
+
+#define RX_QUEUE_SIZE_DRIV                   512
+#define RX_QUEUE_SIZE_CLI0                   512
+#define RX_QUEUE_SIZE_CLI1                   512
+
+#define RX_DATA_REGION_SIZE_DRIV            DATA_REGION_SIZE
+#define RX_DATA_REGION_SIZE_CLI0            DATA_REGION_SIZE
+#define RX_DATA_REGION_SIZE_CLI1            DATA_REGION_SIZE
+
+_Static_assert(RX_DATA_REGION_SIZE_DRIV >= RX_QUEUE_SIZE_DRIV * BUFFER_SIZE, "Driver RX data region size must fit Driver RX buffers");
+_Static_assert(RX_DATA_REGION_SIZE_CLI0 >= RX_QUEUE_SIZE_CLI0 * BUFFER_SIZE, "Client0 RX data region size must fit Client0 RX buffers");
+_Static_assert(RX_DATA_REGION_SIZE_CLI1 >= RX_QUEUE_SIZE_CLI1 * BUFFER_SIZE, "Client1 RX data region size must fit Client1 RX buffers");
+
+static inline bool __str_match(const char *s0, const char *s1)
+{
+    while (*s0 != '\0' && *s1 != '\0' && *s0 == *s1) {
+        s0++, s1++;
+    }
+    return *s0 == *s1;
+}
+
+static inline void cli_queue_init_sys(char *pd_name, serial_queue_handle_t *rx_queue, uintptr_t rx_free, uintptr_t rx_active,
+                                serial_queue_handle_t *tx_queue, uintptr_t tx_free, uintptr_t tx_active)
+{
+    if (__str_match(pd_name, CLI0_NAME)) {
+        serial_queue_init(rx_queue, (serial_queue_t *) rx_free, (serial_queue_t *) rx_active, RX_QUEUE_SIZE_CLI0);
+        serial_queue_init(tx_queue, (serial_queue_t *) tx_free, (serial_queue_t *) tx_active, TX_QUEUE_SIZE_CLI0);
+    } else if (__str_match(pd_name, CLI1_NAME)) {
+        serial_queue_init(rx_queue, (serial_queue_t *) rx_free, (serial_queue_t *) rx_active, RX_QUEUE_SIZE_CLI1);
+        serial_queue_init(tx_queue, (serial_queue_t *) tx_free, (serial_queue_t *) tx_active, TX_QUEUE_SIZE_CLI1);
+    }
+}
+
+static inline void virt_queue_init_sys(char *pd_name, serial_queue_handle_t *cli_queue, uintptr_t cli_free, uintptr_t cli_active)
+{
+    if (__str_match(pd_name, VIRT_RX_NAME)) {
+        serial_queue_init(cli_queue, (serial_queue_t *) cli_free, (serial_queue_t *) cli_active, RX_QUEUE_SIZE_CLI0);
+        serial_queue_init(&cli_queue[1], (serial_queue_t *) (cli_free + 2 * DATA_REGION_SIZE), (serial_queue_t *) (cli_active + 2 * DATA_REGION_SIZE), RX_QUEUE_SIZE_CLI1);
+    } else if (__str_match(pd_name, VIRT_TX_NAME)) {
+        serial_queue_init(cli_queue, (serial_queue_t *) cli_free, (serial_queue_t *) cli_active, TX_QUEUE_SIZE_CLI0);
+        serial_queue_init(&cli_queue[1], (serial_queue_t *) (cli_free + 2 * DATA_REGION_SIZE), (serial_queue_t *) (cli_active + 2 * DATA_REGION_SIZE), TX_QUEUE_SIZE_CLI1);
+    }
+}

--- a/serial/components/virt_rx.c
+++ b/serial/components/virt_rx.c
@@ -4,35 +4,26 @@
 #include <microkit.h>
 #include <sddf/serial/queue.h>
 #include <sddf/serial/util.h>
+#include <serial_config.h>
 #include "uart.h"
 #include "uart_config.h"
 
-#define CLI_CH 1
-#define DRV_CH 11
+#define DRV_CH 0
+#define CLIENT_OFFSET 1
 
-#ifndef SERIAL_NUM_CLIENTS
-#error "SERIAL_NUM_CLIENTS is expected to be defined for RX serial virtualiser"
-#endif
-
-/* Memory regions as defined in the system file */
+/* Memory regions as defined in the system file. All data regions must be mapped into the same virtual address in each client! */
 
 // Transmit queues with the driver
 uintptr_t rx_free_driver;
 uintptr_t rx_active_driver;
-
-// Transmit queues with the client
-uintptr_t rx_free_client;
-uintptr_t rx_active_client;
-uintptr_t rx_free_client2;
-uintptr_t rx_active_client2;
-
 uintptr_t rx_data_driver;
-// @ivanv: unused
-uintptr_t rx_data_client;
-uintptr_t rx_data_client2;
 
-serial_queue_handle_t rx_queue[SERIAL_NUM_CLIENTS];
+// Receive queues with the client. Client free, active and data regions must be mapped in contiguously
+uintptr_t rx_free_client0;
+uintptr_t rx_active_client0;
+
 serial_queue_handle_t drv_rx_queue;
+serial_queue_handle_t rx_queue[NUM_CLIENTS];
 
 /* We need to do some processing of the input stream to determine when we need
 to change direction. */
@@ -44,12 +35,12 @@ int virt_state;
 int client;
 // We want to keep track of each clients requests, so that they can be serviced once we have changed
 // input direction
-int num_to_get_chars[SERIAL_NUM_CLIENTS];
+int num_to_get_chars[NUM_CLIENTS];
 int multi_client;
 
 int give_multi_char(char *drv_buffer, int drv_buffer_len)
 {
-    for (int curr_client = 0; curr_client < SERIAL_NUM_CLIENTS; curr_client++) {
+    for (int curr_client = 0; curr_client < NUM_CLIENTS; curr_client++) {
 
         if (num_to_get_chars[curr_client] <= 0) {
             return 1;
@@ -86,7 +77,7 @@ int give_multi_char(char *drv_buffer, int drv_buffer_len)
 
 int give_single_char(int curr_client, char *drv_buffer, int drv_buffer_len)
 {
-    if (curr_client < 1 || curr_client > SERIAL_NUM_CLIENTS) {
+    if (curr_client > NUM_CLIENTS) {
         return 1;
     }
 
@@ -98,7 +89,7 @@ int give_single_char(int curr_client, char *drv_buffer, int drv_buffer_len)
     // Integer to store the length of the buffer
     unsigned int buffer_len = 0;
 
-    int ret = serial_dequeue_free(&rx_queue[curr_client - 1], &buffer, &buffer_len);
+    int ret = serial_dequeue_free(&rx_queue[curr_client], &buffer, &buffer_len);
 
     if (ret != 0) {
         microkit_dbg_puts(microkit_name);
@@ -110,7 +101,7 @@ int give_single_char(int curr_client, char *drv_buffer, int drv_buffer_len)
     buffer_len = drv_buffer_len;
 
     // Now place in the rx active queue
-    ret = serial_enqueue_active(&rx_queue[curr_client - 1], buffer, buffer_len);
+    ret = serial_enqueue_active(&rx_queue[curr_client], buffer, buffer_len);
 
     if (ret != 0) {
         microkit_dbg_puts(microkit_name);
@@ -182,7 +173,7 @@ void handle_rx()
                     got_char_terminated[0] = got_char;
                     got_char_terminated[1] = '\0';
                     int new_client = atoi(got_char_terminated);
-                    if (new_client < 1 || new_client > SERIAL_NUM_CLIENTS) {
+                    if (new_client < 0 || new_client >= NUM_CLIENTS) {
                         microkit_dbg_puts("VIRT|RX: Attempted to switch to invalid client number: ");
                         puthex64(new_client);
                         microkit_dbg_puts("\n");
@@ -243,36 +234,18 @@ void handle_rx()
 
 void init(void)
 {
-    // We want to init the client queues here. Currently this only inits one client
-    serial_queue_init(&rx_queue[0], (serial_queue_t *)rx_free_client, (serial_queue_t *)rx_active_client, 0, NUM_ENTRIES,
-                      NUM_ENTRIES);
-    // @ivanv: terrible temporary hack
-#if SERIAL_NUM_CLIENTS > 1
-    serial_queue_init(&rx_queue[1], (serial_queue_t *)rx_free_client2, (serial_queue_t *)rx_active_client2, 0, NUM_ENTRIES,
-                      NUM_ENTRIES);
-#endif
+    serial_queue_init(&drv_rx_queue, (serial_queue_t *)rx_free_driver, (serial_queue_t *)rx_active_driver, RX_QUEUE_SIZE_DRIV);
+    serial_buffers_init(&drv_rx_queue, rx_data_driver);
+    virt_queue_init_sys(microkit_name, rx_queue, rx_free_client0, rx_active_client0);
 
-    serial_queue_init(&drv_rx_queue, (serial_queue_t *)rx_free_driver, (serial_queue_t *)rx_active_driver, 0, NUM_ENTRIES,
-                      NUM_ENTRIES);
-
-    for (int i = 0; i < NUM_ENTRIES - 1; i++) {
-        int ret = serial_enqueue_free(&drv_rx_queue, rx_data_driver + (i * BUFFER_SIZE), BUFFER_SIZE);
-
-        if (ret != 0) {
-            microkit_dbg_puts(microkit_name);
-            microkit_dbg_puts(": virt rx buffer population, unable to enqueue buffer\n");
-            return;
-        }
-    }
-
-    // We initialise the current client to 1
-    client = 1;
+    // We initialise the current client to 0
+    client = 0;
     // Set the current escape character to 0, we can't have recieved an escape character yet
     virt_state = 0;
     // Disable simultaneous multi client input
     multi_client = 0;
     // No chars have been requested yet
-    for (int i = 0; i < SERIAL_NUM_CLIENTS; i++) {
+    for (int i = 0; i < NUM_CLIENTS; i++) {
         num_to_get_chars[i] = 0;
     }
 }
@@ -283,11 +256,11 @@ void notified(microkit_channel ch)
     // Sanity check the client
     if (ch == DRV_CH) {
         handle_rx();
-    } else if (ch < 1 || ch > SERIAL_NUM_CLIENTS) {
+    } else if (ch > NUM_CLIENTS) {
         microkit_dbg_puts("Received a bad client channel\n");
         return;
     }  else {
         // This was recieved on a client channel. Index the number of characters to get
-        num_to_get_chars[ch - 1] += 1;
+        num_to_get_chars[ch - CLIENT_OFFSET] += 1;
     }
 }

--- a/serial/components/virt_tx.c
+++ b/serial/components/virt_tx.c
@@ -5,46 +5,39 @@
 #include <microkit.h>
 #include <sddf/serial/queue.h>
 #include <sddf/serial/util.h>
+#include <serial_config.h>
 #include "uart.h"
 
-#define DRIVER_CH 9
-
-#ifndef SERIAL_NUM_CLIENTS
-#error "SERIAL_NUM_CLIENTS is expected to be defined for TX serial virt"
-#endif
+#define DRIVER_CH 0
+#define CLIENT_OFFSET 1
 
 #define COLOUR_START_LEN 5
 #define COLOUR_END_LEN 4
 
-#define MAX_NUM_CLIENTS 2
+#define MAX_NUM_CLIENTS 8
 
 /* This is a simple sanity check that we have defined as many colours
    as the user as specified clients */
-#if SERIAL_NUM_CLIENTS > MAX_NUM_CLIENTS && defined(SERIAL_TRANSFER_WITH_COLOUR)
+#if NUM_CLIENTS > MAX_NUM_CLIENTS && defined(SERIAL_TRANSFER_WITH_COLOUR)
 #error "There are more clients then there are colours to differentiate them"
 #endif
 
-char *client_colours[MAX_NUM_CLIENTS] = { "\x1b[32m", "\x1b[31m" };
+char *client_colours[MAX_NUM_CLIENTS] = { "\x1b[30m", "\x1b[31m", "\x1b[32m", "\x1b[33m", "\x1b[34m", "\x1b[35m", "\x1b[36m", "\x1b[37m" };
 char *client_colour_end = "\x1b[0m";
 
-/* Memory regions as defined in the system file */
+/* Memory regions as defined in the system file. All data regions must be mapped into the same virtual address in each client! */
 
 // Transmit queues with the driver
 uintptr_t tx_free_driver;
 uintptr_t tx_active_driver;
-
-// Transmit queues with the client
-uintptr_t tx_free_client;
-uintptr_t tx_active_client;
-uintptr_t tx_free_client2;
-uintptr_t tx_active_client2;
-
 uintptr_t tx_data_driver;
-uintptr_t tx_data_client;
-uintptr_t tx_data_client2;
 
-serial_queue_handle_t tx_queue[SERIAL_NUM_CLIENTS];
+// Transmit queues with the client. Client free, active and data regions must be mapped in contiguously
+uintptr_t tx_free_client0;
+uintptr_t tx_active_client0;
+
 serial_queue_handle_t drv_tx_queue;
+serial_queue_handle_t tx_queue[NUM_CLIENTS];
 
 size_t copy_with_colour(size_t client, size_t buffer_len, char *driver_buf, char *client_buf)
 {
@@ -78,10 +71,8 @@ int handle_tx(int curr_client)
     uintptr_t client_buf = 0;
     unsigned int client_buf_len = 0;
 
-    bool was_empty = serial_queue_empty(drv_tx_queue.active);
-
     // Loop over all clients here
-    for (int client = 0; client < SERIAL_NUM_CLIENTS; client++) {
+    for (int client = 0; client < NUM_CLIENTS; client++) {
         // The client can plug their queue. If plugged, we won't process it.
         if (serial_queue_plugged(tx_queue[client].active)) {
             continue;
@@ -129,43 +120,22 @@ int handle_tx(int curr_client)
         }
     }
 
-    if (was_empty) {
-        microkit_notify(DRIVER_CH);
-    }
-
+    microkit_notify(DRIVER_CH);
     return 0;
 }
 
 void init(void)
 {
-    // We want to init the client queues here. Currently this only inits one client
-    serial_queue_init(&tx_queue[0], (serial_queue_t *)tx_free_client, (serial_queue_t *)tx_active_client, 0, NUM_ENTRIES,
-                      NUM_ENTRIES);
-    // @ivanv: terrible temporary hack
-#if SERIAL_NUM_CLIENTS > 1
-    serial_queue_init(&tx_queue[1], (serial_queue_t *)tx_free_client2, (serial_queue_t *)tx_active_client2, 0, NUM_ENTRIES,
-                      NUM_ENTRIES);
-#endif
-    serial_queue_init(&drv_tx_queue, (serial_queue_t *)tx_free_driver, (serial_queue_t *)tx_active_driver, 0, NUM_ENTRIES,
-                      NUM_ENTRIES);
-
-    // Add buffers to the driver tx queue from our shared dma region
-    for (int i = 0; i < NUM_ENTRIES - 1; i++) {
-        // Have to start at the memory region left of by the rx queue
-        int ret = serial_enqueue_free(&drv_tx_queue, tx_data_driver + ((i + NUM_ENTRIES) * BUFFER_SIZE), BUFFER_SIZE);
-
-        if (ret != 0) {
-            microkit_dbg_puts(microkit_name);
-            microkit_dbg_puts(": tx buffer population, unable to enqueue buffer\n");
-        }
-    }
+    serial_queue_init(&drv_tx_queue, (serial_queue_t *)tx_free_driver, (serial_queue_t *)tx_active_driver, TX_QUEUE_SIZE_DRIV);
+    serial_buffers_init(&drv_tx_queue, tx_data_driver);
+    virt_queue_init_sys(microkit_name, tx_queue, tx_free_client0, tx_active_client0);
 }
 
 void notified(microkit_channel ch)
 {
     // We should only ever recieve notifications from the client
     // Sanity check the client
-    if (ch < 1 || ch > SERIAL_NUM_CLIENTS) {
+    if (ch == DRIVER_CH || ch > NUM_CLIENTS) {
         microkit_dbg_puts("Received a bad client channel\n");
         return;
     }


### PR DESCRIPTION
This pull request improves the usability of the serial subsystem by making it easier to add and remove clients from the system, as well as change the total number of buffers each client has.

This is done by using a _serial config_ file which contains all system configuration information. All initialisation dependent on the system is handled in this file.

This pull request also simplifies a couple of notification decisions to notify unconditionally - as I noticed there were some possible scenarios where deadlock could occur. 

This pull request contains only a small number of the changes which are still under development to improve the subsystem. There will be a larger pull request improving data management (removing buffers from the system) and hardware interactions, as well as protocol improvements to remove any possible deadlocks and all busy-waiting from every component. 

(FYI - these changes have been tested on the odroidc4 as well as the maaxboard, but I have no experience with running qemu so someone will have to test this system on my behalf. Thanks.)