### PR TITLE
Remove checked in libc

### DIFF
--- a/examples/echo_server/Makefile
+++ b/examples/echo_server/Makefile
@@ -10,6 +10,7 @@ endif
 
 ifeq ($(strip $(TOOLCHAIN)),)
 	TOOLCHAIN := aarch64-none-elf
+	LIBC := $(dir $(realpath $(shell aarch64-none-elf-gcc --print-file-name libc.a)))
 endif
 
 BUILD_DIR ?= build
@@ -48,7 +49,7 @@ SYSTEM_FILE := board/$(MICROKIT_BOARD)/echo_server.system
 IMAGES := eth.elf lwip.elf benchmark.elf idle.elf virt_rx.elf virt_tx.elf copy.elf arp.elf timer.elf
 CFLAGS := -mcpu=$(CPU) -mstrict-align -ffreestanding -g3 -O3 -Wall -Wno-unused-function -DMICROKIT_CONFIG_$(MICROKIT_CONFIG)
 
-LDFLAGS := -L$(BOARD_DIR)/lib -L$(SDDF)/lib
+LDFLAGS := -L$(BOARD_DIR)/lib -L$(LIBC)
 LIBS := -lmicrokit -Tmicrokit.ld -lc
 
 IMAGE_FILE = $(BUILD_DIR)/loader.img
@@ -99,7 +100,7 @@ NETIFFILES=$(LWIP)/netif/ethernet.c
 
 # LWIPFILES: All the above.
 LWIPFILES=lwip.c $(COREFILES) $(CORE4FILES) $(NETIFFILES)
-LWIP_OBJS := $(LWIPFILES:.c=.o) lwip.o utilization_socket.o udp_echo_socket.o printf.o putchar_serial.o
+LWIP_OBJS := $(LWIPFILES:.c=.o) lwip.o utilization_socket.o udp_echo_socket.o printf.o putchar_serial.o newlibc.o
 
 ETH_OBJS := $(ETHERNET_DRIVER)/ethernet.o printf.o putchar_debug.o
 VIRT_RX_OBJS := $(NETWORK_COMPONENTS)/virt_rx.o $(UTIL)/cache.o printf.o putchar_debug.o
@@ -127,6 +128,9 @@ $(BUILD_DIR)/%.o: %.s Makefile
 
 $(BUILD_DIR)/printf.o: $(UTIL)/printf.c $(SDDF_INCLUDE)/util/printf.h
 	$(CC) -c $(CFLAGS) $(UTIL)/printf.c -o $(BUILD_DIR)/printf.o
+
+$(BUILD_DIR)/newlibc.o: $(UTIL)/newlibc.c
+	$(CC) -c $(CFLAGS) $(UTIL)/newlibc.c -o $(BUILD_DIR)/newlibc.o
 
 $(BUILD_DIR)/putchar_debug.o: $(UTIL)/putchar_debug.c
 	$(CC) -c $(CFLAGS) $(UTIL)/putchar_debug.c -o $(BUILD_DIR)/putchar_debug.o

--- a/examples/i2c/Makefile
+++ b/examples/i2c/Makefile
@@ -34,8 +34,8 @@ TIMER_DRIVER := $(SDDF)/drivers/clock/meson
 
 IMAGES := virt.elf driver.elf client.elf timer.elf
 CFLAGS := -mcpu=$(CPU) -mstrict-align -ffreestanding -g3 -O3 -Wall -Wno-unused-function
-LDFLAGS := -L$(BOARD_DIR)/lib -L$(SDDF)/lib
-LIBS := -lmicrokit -Tmicrokit.ld -lc
+LDFLAGS := -L$(BOARD_DIR)/lib
+LIBS := -lmicrokit -Tmicrokit.ld
 
 IMAGE_FILE = $(BUILD_DIR)/loader.img
 REPORT_FILE = $(BUILD_DIR)/report.txt

--- a/examples/serial/Makefile
+++ b/examples/serial/Makefile
@@ -44,8 +44,8 @@ SYSTEM_FILE := board/$(MICROKIT_BOARD)/serial.system
 
 IMAGES := uart.elf serial_server_1.elf serial_server_2.elf virt_tx.elf virt_rx.elf
 CFLAGS := -mcpu=$(CPU) -mstrict-align -ffreestanding -g3 -O3 -Wall -Wno-unused-function -Werror
-LDFLAGS := -L$(BOARD_DIR)/lib -L$(SDDF)/lib
-LIBS := -lmicrokit -Tmicrokit.ld -lc
+LDFLAGS := -L$(BOARD_DIR)/lib
+LIBS := -lmicrokit -Tmicrokit.ld
 
 IMAGE_FILE = $(BUILD_DIR)/loader.img
 REPORT_FILE = $(BUILD_DIR)/report.txt

--- a/util/newlibc.c
+++ b/util/newlibc.c
@@ -1,0 +1,34 @@
+#include <microkit.h>
+
+/*
+ * This source file is intended to be compiled with other code
+ * that links with the newlib C library. Newlib expects these
+ * function definitions to exist. At the time of writing, we do
+ * not depend on any of the OS-level calls and hence leave them
+ * unimplemented.
+ */
+
+void _close(void)
+{
+    microkit_dbg_puts("NEWLIB ERROR: calling unimplemented _close()");
+}
+
+void _lseek(void)
+{
+    microkit_dbg_puts("NEWLIB ERROR: calling unimplemented _lseek()");
+}
+
+void _read(void)
+{
+    microkit_dbg_puts("NEWLIB ERROR: calling unimplemented _read()");
+}
+
+void _write(void)
+{
+    microkit_dbg_puts("NEWLIB ERROR: calling unimplemented _write()");
+}
+
+void _sbrk(void)
+{
+    microkit_dbg_puts("NEWLIB ERROR: calling unimplemented _sbrk()");
+}


### PR DESCRIPTION
This was a hack done to make it easier to develop but turns out the toolchain we use packages newlibc which can be easily used instead.