### PR TITLE
Change ialloc from 64-bit to 32-bit

### DIFF
--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -77,7 +77,7 @@ static reqbk_t reqbk[REQBK_SIZE];
 
 /* Index allocator for request bookkeep */
 static ialloc_t ialloc;
-static uint64_t ialloc_idxlist[REQBK_SIZE];
+static uint32_t ialloc_idxlist[REQBK_SIZE];
 
 /* MS-DOS Master boot record */
 struct msdos_mbr msdos_mbr;
@@ -138,7 +138,7 @@ static void request_mbr()
     int err = fsmalloc_alloc(&fsmalloc, &mbr_addr, 1);
     assert(!err);
 
-    uint64_t mbr_req_id;
+    uint32_t mbr_req_id;
     reqbk_t mbr_req_data = {0, 0, 0, mbr_addr, 1, 0};
     err = ialloc_alloc(&ialloc, &mbr_req_id);
     assert(!err);
@@ -293,7 +293,7 @@ static void handle_client(int cli_id)
 
     uintptr_t drv_addr;
     uint32_t drv_block_number;
-    uint64_t drv_req_id;
+    uint32_t drv_req_id;
 
     int err = 0;
     while (!blk_req_queue_empty(&h)) {

--- a/include/sddf/util/ialloc.h
+++ b/include/sddf/util/ialloc.h
@@ -10,11 +10,11 @@
  */
 
 typedef struct ialloc {
-    uint64_t *idxlist; /* linked list pointing to the next free index */
-    uint64_t size; /* length of linked list */
-    uint64_t head; /* next free index */
-    uint64_t tail; /* last free index */
-    uint64_t num_free; /* number of free indices */
+    uint32_t *idxlist; /* linked list pointing to the next free index */
+    uint32_t size; /* length of linked list */
+    uint32_t head; /* next free index */
+    uint32_t tail; /* last free index */
+    uint32_t num_free; /* number of free indices */
 } ialloc_t;
 
 /**
@@ -37,7 +37,7 @@ static inline bool ialloc_full(ialloc_t *ia)
  *
  * @return 0 on success, -1 if index list is full.
  */
-static inline int ialloc_alloc(ialloc_t *ia, uint64_t *id)
+static inline int ialloc_alloc(ialloc_t *ia, uint32_t *id)
 {
     if (ialloc_full(ia)) {
         return -1;
@@ -56,7 +56,7 @@ static inline int ialloc_alloc(ialloc_t *ia, uint64_t *id)
  *
  * @return 0 on success, -1 if index is invalid.
  */
-static inline int ialloc_free(ialloc_t *ia, uint64_t id)
+static inline int ialloc_free(ialloc_t *ia, uint32_t id)
 {
     if (id >= ia->size) {
         return -1;
@@ -81,14 +81,14 @@ static inline int ialloc_free(ialloc_t *ia, uint64_t id)
  * @param idxlist pointer to the linked list array storing the next free index.
  * @param size number of indices that can be allocated, also length of idxlist.
  */
-static void ialloc_init(ialloc_t *ia, uint64_t *idxlist, uint64_t size)
+static void ialloc_init(ialloc_t *ia, uint32_t *idxlist, uint32_t size)
 {
     ia->idxlist = idxlist;
     ia->size = size;
     ia->head = 0;
     ia->tail = size - 1;
     ia->num_free = size;
-    for (uint64_t i = 0; i < size - 1; i++) {
+    for (uint32_t i = 0; i < size - 1; i++) {
         ia->idxlist[i] = i + 1;
     }
     ia->idxlist[size - 1] = 0;


### PR DESCRIPTION
Currently both virtIO block and virtIO sound use this allocator. It doesn't need to be 64-bit as we will never need more than UINT32_MAX indices (currently we use at most 4096). Both sDDF ID fields are already 32-bit. I am updating the virtIO devices to reflect this change in https://github.com/au-ts/libvmm/pull/37