### PR TITLE
examples/echo server: fix regressions

### DIFF
--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -29,8 +29,7 @@
 #define PD_COPY1_ID     5
 #define PD_LWIP_ID      6
 #define PD_LWIP1_ID     7
-#define PD_ARP_ID       8
-#define PD_TIMER_ID     9
+#define PD_TIMER_ID     8
 
 uintptr_t uart_base;
 uintptr_t cyclecounters_vaddr;
@@ -83,9 +82,6 @@ static void print_pdid_name(uint64_t pd_id)
         break;
     case PD_LWIP1_ID:
         sddf_printf(CLI1_NAME);
-        break;
-    case PD_ARP_ID:
-        sddf_printf(ARP_NAME);
         break;
     case PD_TIMER_ID:
         sddf_printf(TIMER_NAME);

--- a/examples/echo_server/board/imx8mm_evk/echo_server.system
+++ b/examples/echo_server/board/imx8mm_evk/echo_server.system
@@ -148,7 +148,7 @@
             <map mr="tx_buffer_data_region_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
         </protection_domain>
 
-        <protection_domain name="timer" priority="101" pp="true" id="9" passive="true">
+        <protection_domain name="timer" priority="101" pp="true" id="8" passive="true">
             <program_image path="timer.elf" />
             <map mr="timer" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
             <irq irq="87" id="0" /> <!-- timer interrupt -->

--- a/examples/echo_server/board/maaxboard/echo_server.system
+++ b/examples/echo_server/board/maaxboard/echo_server.system
@@ -148,7 +148,7 @@
             <map mr="tx_buffer_data_region_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
         </protection_domain>
 
-        <protection_domain name="timer" priority="101" pp="true" id="9" passive="true">
+        <protection_domain name="timer" priority="101" pp="true" id="8" passive="true">
             <program_image path="timer.elf" />
             <map mr="timer" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
             <irq irq="87" id="0" /> <!-- timer interrupt -->

--- a/examples/echo_server/board/odroidc4/echo_server.system
+++ b/examples/echo_server/board/odroidc4/echo_server.system
@@ -148,7 +148,7 @@
             <map mr="tx_buffer_data_region_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
         </protection_domain>
 
-        <protection_domain name="timer" priority="101" pp="true" id="9" passive="true">
+        <protection_domain name="timer" priority="101" pp="true" id="8" passive="true">
             <program_image path="timer.elf" />
             <map mr="timer" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
             <irq irq="42" id="0" trigger="edge" /> <!-- timer interrupt -->


### PR DESCRIPTION
f4e08e5408776ec6ea900c162506bea6a1f7ec35 needed to also make certain changes to the ethernet configuration header to account for the removal of the ARP component.