### PR TITLE
Add emacs backups to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 *.d
 ci_build/
 *.orig
+*~
+.#*


### PR DESCRIPTION
Trival change to add Emacs backup files to the ones for git to ignore.