### PR TITLE
Support Zig build systems

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -26,6 +26,11 @@ jobs:
           wget -O aarch64-toolchain.tar.gz https://trustworthy.systems/Downloads/microkit/arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-elf.tar.xz%3Frev%3D73ff9780c12348b1b6772a1f54ab4bb3
           tar xf aarch64-toolchain.tar.gz
           echo "$(pwd)/arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+      - name: Install Zig
+        run: |
+          wget https://ziglang.org/builds/zig-linux-x86_64-0.13.0.tar.xz
+          tar xf zig-linux-x86_64-0.13.0.tar.xz
+          echo "${PWD}/zig-linux-x86_64-0.13.0/:$PATH" >> $GITHUB_PATH
       - name: Build and run examples
         run: ./ci/examples.sh ${PWD}/microkit-sdk-1.2.6
         shell: bash
@@ -44,6 +49,11 @@ jobs:
         run: |
           brew install llvm make
           echo "/usr/local/opt/llvm/bin:$PATH" >> $GITHUB_PATH
+      - name: Install Zig
+        run: |
+          wget https://ziglang.org/builds/zig-macos-x86_64-0.13.0.tar.xz
+          tar xf zig-macos-x86_64-0.13.0.tar.xz
+          echo "${PWD}/zig-macos-x86_64-0.13.0/:$PATH" >> $GITHUB_PATH
       - name: Download and install AArch64 GCC toolchain
         run: |
           wget -O aarch64-toolchain.tar.gz https://trustworthy.systems/Downloads/microkit/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf.tar.xz%3Frev%3D51c39c753f8c4a54875b7c5dccfb84ef

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ci_build/
 .#*
 zig-out/
 zig-cache/
+.zig-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ ci_build/
 *.orig
 *~
 .#*
+zig-out/
+zig-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ ci_build/
 *~
 .#*
 zig-out/
-zig-cache/
 .zig-cache/

--- a/build.zig
+++ b/build.zig
@@ -46,9 +46,6 @@ fn addUartDriver(
         .name = b.fmt("driver_uart_{s}.elf", .{ @tagName(class) }),
         .target = target,
         .optimize = optimize,
-        // Microkit expects and requires the symbol table to exist in the ELF,
-        // this means that even when building for release mode, we want to tell
-        // Zig not to strip symbols from the binary.
         .strip = false,
     });
     const source = b.fmt("drivers/serial/{s}/uart.c", .{ @tagName(class) });
@@ -111,9 +108,9 @@ pub fn build(b: *std.Build) void {
     };
 
     // Libmicrokit
-    libmicrokit = LazyPath{ .cwd_relative = b.fmt("{s}/lib/libmicrokit.a", .{ microkit_board_dir }) };
-    libmicrokit_linker_script = LazyPath{ .cwd_relative = b.fmt("{s}/lib/microkit.ld", .{ microkit_board_dir }) };
-    libmicrokit_include = LazyPath{ .cwd_relative = b.fmt("{s}/include", .{ microkit_board_dir }) };
+    libmicrokit = .{ .cwd_relative = b.fmt("{s}/lib/libmicrokit.a", .{ microkit_board_dir }) };
+    libmicrokit_linker_script = .{ .cwd_relative = b.fmt("{s}/lib/microkit.ld", .{ microkit_board_dir }) };
+    libmicrokit_include = .{ .cwd_relative = b.fmt("{s}/include", .{ microkit_board_dir }) };
 
     const printf = b.addObject(.{
         .name = "printf",
@@ -128,11 +125,9 @@ pub fn build(b: *std.Build) void {
         .name = "blk_virt.elf",
         .target = target,
         .optimize = optimize,
-        // Microkit expects and requires the symbol table to exist in the ELF,
-        // this means that even when building for release mode, we want to tell
-        // Zig not to strip symbols from the binary.
         .strip = false,
     });
+    // TODO: This flag -DBLK_NUM_CLIENTS needs to be configurable by the user of this dependency
     blk_virt.addCSourceFile(.{ .file = b.path("blk/components/virt.c"), .flags = &.{"-DBLK_NUM_CLIENTS=2"} });
     blk_virt.addCSourceFiles(.{ .files = &.{ "blk/util/bitarray.c", "blk/util/fsmalloc.c", "blk/util/util.c", "util/cache.c" } });
     blk_virt.addIncludePath(b.path("include"));
@@ -143,11 +138,9 @@ pub fn build(b: *std.Build) void {
         .name = "serial_virt_rx.elf",
         .target = target,
         .optimize = optimize,
-        // Microkit expects and requires the symbol table to exist in the ELF,
-        // this means that even when building for release mode, we want to tell
-        // Zig not to strip symbols from the binary.
         .strip = false,
     });
+    // TODO: This flag -DSERIAL_NUM_CLIENTS=3 needs to be configurable by the user of this dependency
     serial_virt_rx.addCSourceFile(.{
         .file = b.path("serial/components/virt_rx.c"),
         .flags = &.{"-DSERIAL_NUM_CLIENTS=3", "-fno-sanitize=undefined"}
@@ -160,11 +153,9 @@ pub fn build(b: *std.Build) void {
         .name = "serial_virt_tx.elf",
         .target = target,
         .optimize = optimize,
-        // Microkit expects and requires the symbol table to exist in the ELF,
-        // this means that even when building for release mode, we want to tell
-        // Zig not to strip symbols from the binary.
         .strip = false,
     });
+    // TODO: This flag -DSERIAL_NUM_CLIENTS=3 -DSERIAL_TRANSFER_WITH_COLOUR needs to be configurable by the user of this dependency
     serial_virt_tx.addCSourceFile(.{
         .file = b.path("serial/components/virt_tx.c"),
         .flags = &.{"-DSERIAL_NUM_CLIENTS=3", "-DSERIAL_TRANSFER_WITH_COLOUR", "-fno-sanitize=undefined"}
@@ -187,7 +178,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     sddf_util.addCSourceFiles(.{ 
-        .files = &(sddf_util_files)
+        .files = &sddf_util_files
     });
     sddf_util.addIncludePath(b.path("include"));
     sddf_util.addIncludePath(libmicrokit_include);

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,202 @@
+const std = @import("std");
+const LazyPath = std.Build.LazyPath;
+
+const MicrokitBoard = enum {
+    qemu_arm_virt,
+    odroidc4,
+    maaxboard
+};
+
+const ConfigOptions = enum {
+    debug,
+    release,
+    benchmark
+};
+
+const DriverUart = enum {
+    arm,
+    meson,
+    imx,
+};
+
+const sddf_util_files = [_][]const u8{
+    "util/newlibc.c",
+    "util/cache.c",
+    "util/printf.c",
+    "util/putchar_debug.c",
+    // TODO:
+    // should these device specific utils be here?
+    // or maybe move these into the outer util directory
+    "blk/util/fsmalloc.c",
+    "blk/util/bitarray.c",
+    "blk/util/util.c",
+};
+
+var libmicrokit: std.Build.LazyPath = undefined;
+var libmicrokit_linker_script: std.Build.LazyPath = undefined;
+var libmicrokit_include: std.Build.LazyPath = undefined;
+
+fn addUartDriver(
+    b: *std.Build,
+    class: DriverUart,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode
+) *std.Build.Step.Compile {
+    const driver = addPd(b, .{
+        .name = b.fmt("driver_uart_{s}.elf", .{ @tagName(class) }),
+        .target = target,
+        .optimize = optimize,
+        // Microkit expects and requires the symbol table to exist in the ELF,
+        // this means that even when building for release mode, we want to tell
+        // Zig not to strip symbols from the binary.
+        .strip = false,
+    });
+    const source = b.fmt("drivers/serial/{s}/uart.c", .{ @tagName(class) });
+    const driver_include = b.fmt("drivers/serial/{s}/include", .{ @tagName(class) });
+    driver.addCSourceFile(.{
+        .file = b.path(source),
+        .flags = &.{ "-fno-sanitize=undefined" }
+    });
+    driver.addIncludePath(b.path("include"));
+    driver.addIncludePath(b.path(driver_include));
+
+    return driver;
+}
+
+fn addPd(b: *std.Build, options: std.Build.ExecutableOptions) *std.Build.Step.Compile {
+    const pd = b.addExecutable(options);
+    pd.addObjectFile(libmicrokit);
+    pd.setLinkerScriptPath(libmicrokit_linker_script);
+    pd.addIncludePath(libmicrokit_include);
+
+    return pd;
+}
+
+pub fn build(b: *std.Build) void {
+    const optimize = b.standardOptimizeOption(.{});
+    const target = b.standardTargetOptions(.{});
+
+    // Microkit SDK option
+    const microkit_sdk_option_tmp = b.option([]const u8, "sdk", "Path to Microkit SDK");
+    if (microkit_sdk_option_tmp == null) {
+        std.log.err("Missing -Dsdk=/path/to/sdk argument being passed\n", .{});
+        std.posix.exit(1);
+    }
+    const microkit_sdk_option = microkit_sdk_option_tmp.?;
+    std.fs.cwd().access(microkit_sdk_option, .{}) catch |err| {
+        switch (err) {
+            error.FileNotFound => std.log.err("Path to SDK '{s}' does not exist\n", .{ microkit_sdk_option }),
+            else => std.log.err("Could not acccess SDK path '{s}', error is {any}\n", .{ microkit_sdk_option, err })
+        }
+        std.posix.exit(1);
+    };
+
+    // Microkit config option
+    const microkit_config_option = b.option(ConfigOptions, "config", "Microkit config to build for") orelse ConfigOptions.debug;
+
+    // Microkit board option
+    const microkit_board_option_tmp = b.option(MicrokitBoard, "board", "Microkit board to target");
+    if (microkit_board_option_tmp == null) {
+        std.log.err("Missing -Dboard=<BOARD> argument being passed\n", .{});
+        std.posix.exit(1);
+    }
+    const microkit_board_option = microkit_board_option_tmp.?;
+    const microkit_board_dir = b.fmt("{s}/board/{s}/{s}", .{ microkit_sdk_option, @tagName(microkit_board_option), @tagName(microkit_config_option) });
+    std.fs.cwd().access(microkit_board_dir, .{}) catch |err| {
+        switch (err) {
+            error.FileNotFound => std.log.err("Path to '{s}' does not exist\n", .{ microkit_board_dir }),
+            else => std.log.err("Could not acccess path '{s}', error is {any}\n", .{ microkit_board_dir, err })
+        }
+        std.posix.exit(1);
+    };
+
+    // Libmicrokit
+    libmicrokit = LazyPath{ .cwd_relative = b.fmt("{s}/lib/libmicrokit.a", .{ microkit_board_dir }) };
+    libmicrokit_linker_script = LazyPath{ .cwd_relative = b.fmt("{s}/lib/microkit.ld", .{ microkit_board_dir }) };
+    libmicrokit_include = LazyPath{ .cwd_relative = b.fmt("{s}/include", .{ microkit_board_dir }) };
+
+    const printf = b.addObject(.{
+        .name = "printf",
+        .target = target,
+        .optimize = optimize,
+    });
+    printf.addCSourceFiles(.{ .files = &.{ "util/printf.c", "util/putchar_debug.c" } });
+    printf.addIncludePath(b.path("include"));
+    printf.addIncludePath(libmicrokit_include);
+
+    const blk_virt = addPd(b, .{
+        .name = "blk_virt.elf",
+        .target = target,
+        .optimize = optimize,
+        // Microkit expects and requires the symbol table to exist in the ELF,
+        // this means that even when building for release mode, we want to tell
+        // Zig not to strip symbols from the binary.
+        .strip = false,
+    });
+    blk_virt.addCSourceFile(.{ .file = b.path("blk/components/virt.c"), .flags = &.{"-DBLK_NUM_CLIENTS=2"} });
+    blk_virt.addCSourceFiles(.{ .files = &.{ "blk/util/bitarray.c", "blk/util/fsmalloc.c", "blk/util/util.c", "util/cache.c" } });
+    blk_virt.addIncludePath(b.path("include"));
+    blk_virt.addObject(printf);
+    b.installArtifact(blk_virt);
+
+    const serial_virt_rx = addPd(b, .{
+        .name = "serial_virt_rx.elf",
+        .target = target,
+        .optimize = optimize,
+        // Microkit expects and requires the symbol table to exist in the ELF,
+        // this means that even when building for release mode, we want to tell
+        // Zig not to strip symbols from the binary.
+        .strip = false,
+    });
+    serial_virt_rx.addCSourceFile(.{
+        .file = b.path("serial/components/virt_rx.c"),
+        .flags = &.{"-DSERIAL_NUM_CLIENTS=3", "-fno-sanitize=undefined"}
+    });
+    serial_virt_rx.addIncludePath(b.path("include"));
+    serial_virt_rx.addObject(printf);
+    b.installArtifact(serial_virt_rx);
+
+    const serial_virt_tx = addPd(b, .{
+        .name = "serial_virt_tx.elf",
+        .target = target,
+        .optimize = optimize,
+        // Microkit expects and requires the symbol table to exist in the ELF,
+        // this means that even when building for release mode, we want to tell
+        // Zig not to strip symbols from the binary.
+        .strip = false,
+    });
+    serial_virt_tx.addCSourceFile(.{
+        .file = b.path("serial/components/virt_tx.c"),
+        .flags = &.{"-DSERIAL_NUM_CLIENTS=3", "-DSERIAL_TRANSFER_WITH_COLOUR", "-fno-sanitize=undefined"}
+    });
+    serial_virt_tx.addIncludePath(b.path("include"));
+    serial_virt_tx.addObject(printf);
+    b.installArtifact(serial_virt_tx);
+
+    // UART drivers
+    inline for (std.meta.fields(DriverUart)) |class| {
+        const driver = addUartDriver(b, @enumFromInt(class.value), target, optimize);
+        driver.addObject(printf);
+        b.installArtifact(driver);
+    }
+
+    // sDDF util library
+    const sddf_util = b.addStaticLibrary(.{
+        .name = "sddf_util",
+        .target = target,
+        .optimize = optimize,
+    });
+    sddf_util.addCSourceFiles(.{ 
+        .files = &(sddf_util_files)
+    });
+    sddf_util.addIncludePath(b.path("include"));
+    sddf_util.addIncludePath(libmicrokit_include);
+    sddf_util.installHeadersDirectory(b.path("include"), "", .{});
+    b.installArtifact(sddf_util);
+
+    // sDDF headers
+    // TODO: Investigate how to get this step to run when it is not an artifact/module/file
+    // Not sure how to when this is exposed as a dependency to another build file
+    // const sddf_headers = b.addInstallHeaderFile(b.path("include"), "sddf");
+    // b.getInstallStep().dependOn(&sddf_headers.step);
+}

--- a/build.zig
+++ b/build.zig
@@ -198,7 +198,7 @@ pub fn build(b: *std.Build) void {
     // TODO: This flag -DSERIAL_NUM_CLIENTS=3 needs to be configurable by the user of this dependency
     serial_virt_rx.addCSourceFile(.{
         .file = b.path("serial/components/virt_rx.c"),
-        .flags = &.{"-DSERIAL_NUM_CLIENTS=3", "-fno-sanitize=undefined"}
+        .flags = &.{"-fno-sanitize=undefined"}
     });
     serial_virt_rx.addIncludePath(serial_config_include);
     serial_virt_rx.addIncludePath(b.path("include"));
@@ -215,7 +215,7 @@ pub fn build(b: *std.Build) void {
     // TODO: This flag -DSERIAL_NUM_CLIENTS=3 -DSERIAL_TRANSFER_WITH_COLOUR needs to be configurable by the user of this dependency
     serial_virt_tx.addCSourceFile(.{
         .file = b.path("serial/components/virt_tx.c"),
-        .flags = &.{"-DSERIAL_NUM_CLIENTS=3", "-DSERIAL_TRANSFER_WITH_COLOUR", "-fno-sanitize=undefined"}
+        .flags = &.{"-fno-sanitize=undefined"}
     });
     serial_virt_tx.addIncludePath(serial_config_include);
     serial_virt_tx.addIncludePath(b.path("include"));

--- a/build.zig
+++ b/build.zig
@@ -108,9 +108,10 @@ pub fn build(b: *std.Build) void {
     };
 
     // Libmicrokit
-    libmicrokit = .{ .cwd_relative = b.fmt("{s}/lib/libmicrokit.a", .{ microkit_board_dir }) };
-    libmicrokit_linker_script = .{ .cwd_relative = b.fmt("{s}/lib/microkit.ld", .{ microkit_board_dir }) };
-    libmicrokit_include = .{ .cwd_relative = b.fmt("{s}/include", .{ microkit_board_dir }) };
+    // We're declaring explicitly here instead of with anonymous structs due to a bug. See https://github.com/ziglang/zig/issues/19832
+    libmicrokit = LazyPath{ .cwd_relative = b.fmt("{s}/lib/libmicrokit.a", .{ microkit_board_dir }) };
+    libmicrokit_linker_script = LazyPath{ .cwd_relative = b.fmt("{s}/lib/microkit.ld", .{ microkit_board_dir }) };
+    libmicrokit_include = LazyPath{ .cwd_relative = b.fmt("{s}/include", .{ microkit_board_dir }) };
 
     const printf = b.addObject(.{
         .name = "printf",

--- a/build.zig
+++ b/build.zig
@@ -153,7 +153,7 @@ pub fn build(b: *std.Build) void {
     libmicrokit_linker_script = LazyPath{ .cwd_relative = libmicrokit_linker_script_opt.? };
 
 
-    // util libraries
+    // Util libraries
     const util = b.addStaticLibrary(.{
         .name = "util",
         .target = target,
@@ -278,10 +278,4 @@ pub fn build(b: *std.Build) void {
         driver.linkLibrary(util_putchar_debug);
         b.installArtifact(driver);
     }
-
-    // sDDF headers
-    // TODO: Investigate how to get this step to run when it is not an artifact/module/file
-    // Not sure how to when this is exposed as a dependency to another build file
-    // const sddf_headers = b.addInstallHeaderFile(b.path("include"), "sddf");
-    // b.getInstallStep().dependOn(&sddf_headers.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -22,12 +22,8 @@ const DriverClass = struct {
 const util_src = [_][]const u8{
     "util/newlibc.c",
     "util/cache.c",
-    // TODO:
-    // should these device specific utils be here?
-    // or maybe move these into the outer util directory
-    "blk/util/fsmalloc.c",
-    "blk/util/bitarray.c",
-    // "blk/util/util.c",
+    "util/fsmalloc.c",
+    "util/bitarray.c",
     "util/assert.c",
 };
 
@@ -144,14 +140,17 @@ pub fn build(b: *std.Build) void {
     const blk_num_clients_opt = b.option(u32, "blk_num_clients", "Number of block clients") orelse 2;
     const serial_config_include_option = b.option([]const u8, "serial_config_include", "Include path to serial config header") orelse "";
 
-    // TODO: sort out
+    // TODO: Right now this is not super ideal. What's happening is that we do not
+    // always need a serial config include, but we must always specify it
+    // as a build option. What we do instead is just make the include path an
+    // empty string if it has not been provided, which could be an annoying to
+    // debug error if you do need a serial config but forgot to pass one in.
     const serial_config_include = LazyPath{ .cwd_relative = serial_config_include_option };
     // libmicrokit
     // We're declaring explicitly here instead of with anonymous structs due to a bug. See https://github.com/ziglang/zig/issues/19832
     libmicrokit = LazyPath{ .cwd_relative = libmicrokit_opt.? };
     libmicrokit_include = LazyPath{ .cwd_relative = libmicrokit_include_opt.? };
     libmicrokit_linker_script = LazyPath{ .cwd_relative = libmicrokit_linker_script_opt.? };
-
 
     // Util libraries
     const util = b.addStaticLibrary(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,21 @@
+.{
+    .name = "sddf",
+    .version = "0.1.0",
+
+    .paths = .{
+        "drivers",
+        "benchmark",
+        "blk",
+        "i2c",
+        "include",
+        "libco",
+        "network",
+        "serial",
+        "soubnd",
+        "util",
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md"
+    }
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,7 +11,7 @@
         "libco",
         "network",
         "serial",
-        "soubnd",
+        "sound",
         "util",
         "build.zig",
         "build.zig.zon",

--- a/ci/examples.sh
+++ b/ci/examples.sh
@@ -3,6 +3,7 @@
 set -e
 
 SDK_PATH=$1
+SDDF=$(pwd)
 
 # Number of threads/jobs to compile with, default to 1
 if [ "$#" -eq 1 ]; then
@@ -21,60 +22,90 @@ I2C=true
 SERIAL=true
 TIMER=true
 
-build_network_echo_server() {
+build_network_echo_server_make() {
     BOARD=$1
     CONFIG=$2
-    echo "CI|INFO: building echo server example with board: ${BOARD}, config: ${CONFIG}"
-    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/echo_server/${BOARD}/${CONFIG}"
+    echo "CI|INFO: building echo server example with Make, board: ${BOARD}, config: ${CONFIG}"
+    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/echo_server/make/${BOARD}/${CONFIG}"
     rm -rf ${BUILD_DIR}
     mkdir -p ${BUILD_DIR}
-    make -j${NUM_JOBS} -C examples/echo_server \
+    make -j${NUM_JOBS} -C ${SDDF}/examples/echo_server \
         BUILD_DIR=${BUILD_DIR} \
         MICROKIT_CONFIG=${CONFIG} \
         MICROKIT_SDK=${SDK_PATH} \
         MICROKIT_BOARD=${BOARD}
 }
 
-build_i2c() {
+build_i2c_make() {
     BOARD=$1
     CONFIG=$2
-    echo "CI|INFO: building I2C example with board: ${BOARD}, config: ${CONFIG}"
-    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/i2c/${BOARD}/${CONFIG}"
+    echo "CI|INFO: building I2C example with Make, board: ${BOARD}, config: ${CONFIG}"
+    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/i2c/make/${BOARD}/${CONFIG}"
     rm -rf ${BUILD_DIR}
     mkdir -p ${BUILD_DIR}
-    make -j${NUM_JOBS} -C examples/i2c \
+    make -j${NUM_JOBS} -C ${SDDF}/examples/i2c \
         BUILD_DIR=${BUILD_DIR} \
         MICROKIT_CONFIG=${CONFIG} \
         MICROKIT_SDK=${SDK_PATH} \
         MICROKIT_BOARD=${BOARD}
 }
 
-build_timer() {
+build_i2c_zig() {
     BOARD=$1
     CONFIG=$2
-    echo "CI|INFO: building timer example with board: ${BOARD}, config: ${CONFIG}"
-    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/timer/${BOARD}/${CONFIG}"
+    echo "CI|INFO: building I2C example with Zig, board: ${BOARD}, config: ${CONFIG}"
+    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/i2c/zig/${BOARD}/${CONFIG}"
+    rm -rf ${BUILD_DIR}
+    cd ${SDDF}/examples/i2c
+    zig build -Dsdk=${SDK_PATH} -Dboard=${BOARD} -Dconfig=${CONFIG} -p ${BUILD_DIR}
+}
+
+build_timer_make() {
+    BOARD=$1
+    CONFIG=$2
+    echo "CI|INFO: building timer example with Make, board: ${BOARD}, config: ${CONFIG}"
+    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/timer/make/${BOARD}/${CONFIG}"
     rm -rf ${BUILD_DIR}
     mkdir -p ${BUILD_DIR}
-    make -j${NUM_JOBS} -C examples/timer \
+    make -j${NUM_JOBS} -C ${SDDF}/examples/timer \
         BUILD_DIR=${BUILD_DIR} \
         MICROKIT_CONFIG=${CONFIG} \
         MICROKIT_SDK=${SDK_PATH} \
         MICROKIT_BOARD=${BOARD}
 }
 
-build_serial() {
+build_timer_zig() {
     BOARD=$1
     CONFIG=$2
-    echo "CI|INFO: building serial example with board: ${BOARD}, config: ${CONFIG}"
-    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/serial/${BOARD}/${CONFIG}"
+    echo "CI|INFO: building timer example with Zig, board: ${BOARD}, config: ${CONFIG}"
+    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/timer/zig/${BOARD}/${CONFIG}"
+    rm -rf ${BUILD_DIR}
+    cd ${SDDF}/examples/timer
+    zig build -Dsdk=${SDK_PATH} -Dboard=${BOARD} -Dconfig=${CONFIG} -p ${BUILD_DIR}
+}
+
+build_serial_make() {
+    BOARD=$1
+    CONFIG=$2
+    echo "CI|INFO: building serial example with Make, board: ${BOARD}, config: ${CONFIG}"
+    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/serial/make/${BOARD}/${CONFIG}"
     rm -rf ${BUILD_DIR}
     mkdir -p ${BUILD_DIR}
-    make -j${NUM_JOBS} -C examples/serial \
+    make -j${NUM_JOBS} -C ${SDDF}/examples/serial \
         BUILD_DIR=${BUILD_DIR} \
         MICROKIT_CONFIG=${CONFIG} \
         MICROKIT_SDK=${SDK_PATH} \
         MICROKIT_BOARD=${BOARD}
+}
+
+build_serial_zig() {
+    BOARD=$1
+    CONFIG=$2
+    echo "CI|INFO: building serial example with Zig, board: ${BOARD}, config: ${CONFIG}"
+    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/serial/zig/${BOARD}/${CONFIG}"
+    rm -rf ${BUILD_DIR}
+    cd ${SDDF}/examples/serial
+    zig build -Dsdk=${SDK_PATH} -Dboard=${BOARD} -Dconfig=${CONFIG} -p ${BUILD_DIR}
 }
 
 network() {
@@ -84,7 +115,7 @@ network() {
     do
       for CONFIG in "${CONFIGS[@]}"
       do
-         build_network_echo_server ${BOARD} ${CONFIG}
+         build_network_echo_server_make ${BOARD} ${CONFIG}
        done
     done
 }
@@ -96,7 +127,8 @@ i2c() {
     do
       for CONFIG in "${CONFIGS[@]}"
       do
-         build_i2c ${BOARD} ${CONFIG}
+         build_i2c_make ${BOARD} ${CONFIG}
+         build_i2c_zig ${BOARD} ${CONFIG}
        done
     done
 }
@@ -108,7 +140,8 @@ timer() {
     do
       for CONFIG in "${CONFIGS[@]}"
       do
-         build_timer ${BOARD} ${CONFIG}
+         build_timer_make ${BOARD} ${CONFIG}
+         build_timer_zig ${BOARD} ${CONFIG}
        done
     done
 }
@@ -120,16 +153,17 @@ serial() {
     do
       for CONFIG in "${CONFIGS[@]}"
       do
-         build_serial ${BOARD} ${CONFIG}
+         build_serial_make ${BOARD} ${CONFIG}
+         build_serial_zig ${BOARD} ${CONFIG}
        done
     done
 }
 
 # Only run the examples that have been enabled
-$NETWORK && network
+# $NETWORK && network
 $I2C && i2c
-$TIMER && timer
-$SERIAL && serial
+# $TIMER && timer
+# $SERIAL && serial
 
 echo ""
 echo "CI|INFO: Passed all sDDF tests"

--- a/examples/echo_server/board/imx8mm_evk/echo_server.system
+++ b/examples/echo_server/board/imx8mm_evk/echo_server.system
@@ -92,7 +92,7 @@
         </protection_domain>
 
         <protection_domain name="serial_virt_tx" priority="99" id="10">
-            <program_image path="serial_tx_virt.elf" />
+            <program_image path="serial_virt_tx.elf" />
             <map mr="serial_tx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
             <map mr="serial_tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
             <map mr="serial_tx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>

--- a/examples/echo_server/board/maaxboard/echo_server.system
+++ b/examples/echo_server/board/maaxboard/echo_server.system
@@ -92,7 +92,7 @@
         </protection_domain>
 
         <protection_domain name="serial_virt_tx" priority="99" id="10">
-            <program_image path="serial_tx_virt.elf" />
+            <program_image path="serial_virt_tx.elf" />
             <map mr="serial_tx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
             <map mr="serial_tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
             <map mr="serial_tx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>

--- a/examples/echo_server/board/odroidc4/echo_server.system
+++ b/examples/echo_server/board/odroidc4/echo_server.system
@@ -92,7 +92,7 @@
         </protection_domain>
 
         <protection_domain name="serial_virt_tx" priority="99" id="10">
-            <program_image path="serial_tx_virt.elf" />
+            <program_image path="serial_virt_tx.elf" />
             <map mr="serial_tx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
             <map mr="serial_tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
             <map mr="serial_tx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>

--- a/examples/echo_server/board/qemu_arm_virt/echo_server.system
+++ b/examples/echo_server/board/qemu_arm_virt/echo_server.system
@@ -91,7 +91,7 @@
         </protection_domain>
 
         <protection_domain name="serial_virt_tx" priority="99" id="10">
-            <program_image path="serial_tx_virt.elf" />
+            <program_image path="serial_virt_tx.elf" />
             <map mr="serial_tx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
             <map mr="serial_tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
             <map mr="serial_tx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>

--- a/examples/echo_server/echo.mk
+++ b/examples/echo_server/echo.mk
@@ -29,7 +29,7 @@ REPORT_FILE := report.txt
 vpath %.c ${SDDF} ${ECHO_SERVER}
 
 IMAGES := eth_driver.elf lwip.elf benchmark.elf idle.elf network_virt_rx.elf\
-	  network_virt_tx.elf copy.elf timer_driver.elf uart_driver.elf serial_tx_virt.elf
+	  network_virt_tx.elf copy.elf timer_driver.elf uart_driver.elf serial_virt_tx.elf
 
 CFLAGS := -mcpu=$(CPU) \
 	  -mstrict-align \

--- a/examples/i2c/README.md
+++ b/examples/i2c/README.md
@@ -12,12 +12,23 @@ be found [here](https://github.com/elechouse/PN532/).
 
 ## Building
 
+### Make
+
 To build the image, run the following command:
 ```sh
 make MICROKIT_SDK=/path/to/sdk
 ```
 
 The final bootable image will be in `build/loader.img`.
+
+### Zig
+
+You can also build this example with the Zig build system:
+```sh
+zig build -Dsdk=/path/to/sdk -Dboard=odroidc4
+```
+
+The final bootable image will be in `zig-out/bin/loader.img`.
 
 ## Running
 

--- a/examples/i2c/build.zig
+++ b/examples/i2c/build.zig
@@ -1,0 +1,139 @@
+const std = @import("std");
+
+const MicrokitBoard = enum {
+    odroidc4
+};
+
+const Target = struct {
+    board: MicrokitBoard,
+    zig_target: std.Target.Query,
+};
+
+const targets = [_]Target{
+    .{
+        .board = MicrokitBoard.odroidc4,
+        .zig_target = std.Target.Query{
+            .cpu_arch = .aarch64,
+            .cpu_model = .{ .explicit = &std.Target.arm.cpu.cortex_a55 },
+            .os_tag = .freestanding,
+            .abi = .none,
+        },
+    },
+};
+
+fn findTarget(board: MicrokitBoard) std.Target.Query {
+    for (targets) |target| {
+        if (board == target.board) {
+            return target.zig_target;
+        }
+    }
+
+    std.log.err("Board '{}' is not supported\n", .{board});
+    std.posix.exit(1);
+}
+
+const ConfigOptions = enum { debug, release, benchmark };
+
+pub fn build(b: *std.Build) void {
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Getting the path to the Microkit SDK before doing anything else
+    const microkit_sdk_arg = b.option([]const u8, "sdk", "Path to Microkit SDK");
+    if (microkit_sdk_arg == null) {
+        std.log.err("Missing -Dsdk=/path/to/sdk argument being passed\n", .{});
+        std.posix.exit(1);
+    }
+    const microkit_sdk = microkit_sdk_arg.?;
+
+    const microkit_config_option = b.option(ConfigOptions, "config", "Microkit config to build for") orelse ConfigOptions.debug;
+    const microkit_config = @tagName(microkit_config_option);
+
+    // Get the Microkit SDK board we want to target
+    const microkit_board_option = b.option(MicrokitBoard, "board", "Microkit board to target");
+
+    if (microkit_board_option == null) {
+        std.log.err("Missing -Dboard=<BOARD> argument being passed\n", .{});
+        std.posix.exit(1);
+    }
+    const target = b.resolveTargetQuery(findTarget(microkit_board_option.?));
+    const microkit_board = @tagName(microkit_board_option.?);
+
+    const microkit_board_dir = b.fmt("{s}/board/{s}/{s}", .{ microkit_sdk, microkit_board, microkit_config });
+    const microkit_tool = b.fmt("{s}/bin/microkit", .{microkit_sdk});
+    const libmicrokit = b.fmt("{s}/lib/libmicrokit.a", .{microkit_board_dir});
+    const libmicrokit_include = b.fmt("{s}/include", .{microkit_board_dir});
+    const libmicrokit_linker_script = b.fmt("{s}/lib/microkit.ld", .{microkit_board_dir});
+
+    const sddf_dep = b.dependency("sddf", .{
+        .target = target,
+        .optimize = optimize,
+        .libmicrokit = @as([]const u8, libmicrokit),
+        .libmicrokit_include = @as([]const u8, libmicrokit_include),
+        .libmicrokit_linker_script = @as([]const u8, libmicrokit_linker_script),
+    });
+
+    const i2c_driver_class = switch (microkit_board_option.?) {
+        .odroidc4 => "meson",
+    };
+
+    const timer_driver_class = switch (microkit_board_option.?) {
+        .odroidc4 => "meson",
+    };
+
+    const timer_driver = sddf_dep.artifact(b.fmt("driver_timer_{s}.elf", .{ timer_driver_class }));
+    // This is required because the SDF file is expecting a different name to the artifact we
+    // are dealing with.
+    const timer_driver_install = b.addInstallArtifact(timer_driver, .{ .dest_sub_path = "timer_driver.elf" });
+
+    const i2c_driver = sddf_dep.artifact(b.fmt("driver_i2c_{s}.elf", .{ i2c_driver_class }));
+    // This is required because the SDF file is expecting a different name to the artifact we
+    // are dealing with.
+    const i2c_driver_install = b.addInstallArtifact(i2c_driver, .{ .dest_sub_path = "i2c_driver.elf" });
+
+    const client = b.addExecutable(.{
+        .name = "client.elf",
+        .target = target,
+        .optimize = optimize,
+        .strip = false,
+    });
+
+    client.addCSourceFiles(.{
+        .files = &.{ "client.c", "pn532.c" },
+        .flags = &.{ "-fno-sanitize=undefined" }
+    });
+    client.addIncludePath(sddf_dep.path("include"));
+    client.linkLibrary(sddf_dep.artifact("util"));
+    client.linkLibrary(sddf_dep.artifact("util_putchar_debug"));
+
+    // Here we compile libco. Right now this is the only example that uses libco and so
+    // we just compile it here instead of in a separate build.zig
+    client.addIncludePath(sddf_dep.path("libco"));
+    client.addCSourceFile(.{ .file = sddf_dep.path("libco/libco.c") });
+
+    client.addIncludePath(.{ .cwd_relative = libmicrokit_include });
+    client.addObjectFile(.{ .cwd_relative = libmicrokit });
+    client.setLinkerScriptPath(.{ .cwd_relative = libmicrokit_linker_script });
+
+    b.installArtifact(client);
+
+    b.installArtifact(sddf_dep.artifact("i2c_virt.elf"));
+
+    const system_description_path = b.fmt("board/{s}/i2c.system", .{microkit_board});
+    const final_image_dest = b.getInstallPath(.bin, "./loader.img");
+    const microkit_tool_cmd = b.addSystemCommand(&[_][]const u8{
+        microkit_tool,
+        system_description_path,
+        "--search-path", b.getInstallPath(.bin, ""),
+        "--board", microkit_board,
+        "--config", microkit_config,
+        "-o", final_image_dest,
+        "-r", b.getInstallPath(.prefix, "./report.txt")
+    });
+    microkit_tool_cmd.step.dependOn(b.getInstallStep());
+    microkit_tool_cmd.step.dependOn(&i2c_driver_install.step);
+    microkit_tool_cmd.step.dependOn(&timer_driver_install.step);
+    const microkit_step = b.step("microkit", "Compile and build the final bootable image");
+    microkit_step.dependOn(&microkit_tool_cmd.step);
+    b.default_step = microkit_step;
+}
+

--- a/examples/i2c/build.zig.zon
+++ b/examples/i2c/build.zig.zon
@@ -1,0 +1,16 @@
+
+.{
+    .name = "sddf_i2c_example",
+    .version = "1.0.0",
+
+    .dependencies = .{
+        .sddf = .{
+            .path = "../../"
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+    }
+}
+

--- a/examples/serial/README.md
+++ b/examples/serial/README.md
@@ -4,6 +4,8 @@ This is an example to show multiple clients being used with a UART driver.
 
 ## Building
 
+### Make
+
 ```sh
 make MICROKIT_SDK=<path/to/sdk> MICROKIT_BOARD=<board> MICROKIT_CONFIG=<debug/release/benchmark>
 ```
@@ -18,6 +20,22 @@ After building, the system image to load will be `build/loader.img`.
 
 If you wish to simulate on the QEMU ARM virt platform, you can append `qemu` to your make command
 after building for qemu_arm_virt.
+
+### Zig
+
+You can also build this example with the Zig build system:
+```sh
+zig build -Dsdk=/path/to/sdk -Dboard=<board>
+```
+
+The options for `<board>` are the same as the Makefile.
+
+You can simulate QEMU with:
+```sh
+zig build -Dsdk=/path/to/sdk -Dboard=qemu_arm_virt qemu
+```
+
+The final bootable image will be in `zig-out/bin/loader.img`.
 
 ## Configuration
 

--- a/examples/serial/board/imx8mm_evk/serial.system
+++ b/examples/serial/board/imx8mm_evk/serial.system
@@ -49,7 +49,7 @@
     </protection_domain>
 
     <protection_domain name="serial_virt_tx" priority="99">
-        <program_image path="serial_tx_virt.elf" />
+        <program_image path="serial_virt_tx.elf" />
         <map mr="tx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
         <map mr="tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
         <map mr="tx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>
@@ -60,7 +60,7 @@
     </protection_domain>
 
     <protection_domain name="serial_virt_rx" priority="98">
-        <program_image path="serial_rx_virt.elf" />
+        <program_image path="serial_virt_rx.elf" />
         <map mr="rx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue_drv" />
         <map mr="rx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="rx_queue_cli0" />
         <map mr="rx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>

--- a/examples/serial/board/maaxboard/serial.system
+++ b/examples/serial/board/maaxboard/serial.system
@@ -50,7 +50,7 @@
     </protection_domain>
 
     <protection_domain name="serial_virt_tx" priority="99">
-        <program_image path="serial_tx_virt.elf" />
+        <program_image path="serial_virt_tx.elf" />
         <map mr="tx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
         <map mr="tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
         <map mr="tx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>
@@ -61,7 +61,7 @@
     </protection_domain>
 
     <protection_domain name="serial_virt_rx" priority="98">
-        <program_image path="serial_rx_virt.elf" />
+        <program_image path="serial_virt_rx.elf" />
         <map mr="rx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue_drv" />
         <map mr="rx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="rx_queue_cli0" />
         <map mr="rx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>

--- a/examples/serial/board/odroidc4/serial.system
+++ b/examples/serial/board/odroidc4/serial.system
@@ -49,7 +49,7 @@
     </protection_domain>
 
     <protection_domain name="serial_virt_tx" priority="99">
-        <program_image path="serial_tx_virt.elf" />
+        <program_image path="serial_virt_tx.elf" />
         <map mr="tx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
         <map mr="tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
         <map mr="tx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>
@@ -60,7 +60,7 @@
     </protection_domain>
 
     <protection_domain name="serial_virt_rx" priority="98">
-        <program_image path="serial_rx_virt.elf" />
+        <program_image path="serial_virt_rx.elf" />
         <map mr="rx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue_drv" />
         <map mr="rx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="rx_queue_cli0" />
         <map mr="rx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>

--- a/examples/serial/board/qemu_arm_virt/serial.system
+++ b/examples/serial/board/qemu_arm_virt/serial.system
@@ -49,7 +49,7 @@
     </protection_domain>
 
     <protection_domain name="serial_virt_tx" priority="99">
-        <program_image path="serial_tx_virt.elf" />
+        <program_image path="serial_virt_tx.elf" />
         <map mr="tx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
         <map mr="tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
         <map mr="tx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>
@@ -60,7 +60,7 @@
     </protection_domain>
 
     <protection_domain name="serial_virt_rx" priority="98">
-        <program_image path="serial_rx_virt.elf" />
+        <program_image path="serial_virt_rx.elf" />
         <map mr="rx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue_drv" />
         <map mr="rx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="rx_queue_cli0" />
         <map mr="rx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>

--- a/examples/serial/build.zig
+++ b/examples/serial/build.zig
@@ -79,15 +79,15 @@ pub fn build(b: *std.Build) void {
     const microkit_board_dir = b.fmt("{s}/board/{s}/{s}", .{ microkit_sdk, microkit_board, microkit_config });
     const microkit_tool = b.fmt("{s}/bin/microkit", .{microkit_sdk});
     const libmicrokit = b.fmt("{s}/lib/libmicrokit.a", .{microkit_board_dir});
-    const libmicrokit_linker_script = b.fmt("{s}/lib/microkit.ld", .{microkit_board_dir});
     const libmicrokit_include = b.fmt("{s}/include", .{microkit_board_dir});
+    const libmicrokit_linker_script = b.fmt("{s}/lib/microkit.ld", .{microkit_board_dir});
 
     const sddf_dep = b.dependency("sddf", .{
         .target = target,
         .optimize = optimize,
-        .sdk = microkit_sdk,
-        .config = @as([]const u8, microkit_config),
-        .board = @as([]const u8, microkit_board),
+        .libmicrokit = @as([]const u8, libmicrokit),
+        .libmicrokit_include = @as([]const u8, libmicrokit_include),
+        .libmicrokit_linker_script = @as([]const u8, libmicrokit_linker_script),
         .serial_config_include = @as([]const u8, "include/serial_config"),
     });
 

--- a/examples/serial/build.zig
+++ b/examples/serial/build.zig
@@ -1,0 +1,176 @@
+const std = @import("std");
+
+const MicrokitBoard = enum { qemu_arm_virt, odroidc4, maaxboard };
+
+const Target = struct {
+    board: MicrokitBoard,
+    zig_target: std.zig.CrossTarget,
+};
+
+const targets = [_]Target{
+    .{
+        .board = MicrokitBoard.qemu_arm_virt,
+        .zig_target = std.zig.CrossTarget{
+            .cpu_arch = .aarch64,
+            .cpu_model = .{ .explicit = &std.Target.arm.cpu.cortex_a53 },
+            .os_tag = .freestanding,
+            .abi = .none,
+        },
+    },
+    .{
+        .board = MicrokitBoard.odroidc4,
+        .zig_target = std.zig.CrossTarget{
+            .cpu_arch = .aarch64,
+            .cpu_model = .{ .explicit = &std.Target.arm.cpu.cortex_a55 },
+            .os_tag = .freestanding,
+            .abi = .none,
+        },
+    },
+    .{
+        .board = MicrokitBoard.maaxboard,
+        .zig_target = std.zig.CrossTarget{
+            .cpu_arch = .aarch64,
+            .cpu_model = .{ .explicit = &std.Target.arm.cpu.cortex_a53 },
+            .os_tag = .freestanding,
+            .abi = .none,
+        },
+    }
+};
+
+fn findTarget(board: MicrokitBoard) std.zig.CrossTarget {
+    for (targets) |target| {
+        if (board == target.board) {
+            return target.zig_target;
+        }
+    }
+
+    std.log.err("Board '{}' is not supported\n", .{board});
+    std.posix.exit(1);
+}
+
+const ConfigOptions = enum { debug, release, benchmark };
+
+pub fn build(b: *std.Build) void {
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Getting the path to the Microkit SDK before doing anything else
+    const microkit_sdk_arg = b.option([]const u8, "sdk", "Path to Microkit SDK");
+    if (microkit_sdk_arg == null) {
+        std.log.err("Missing -Dsdk=/path/to/sdk argument being passed\n", .{});
+        std.posix.exit(1);
+    }
+    const microkit_sdk = microkit_sdk_arg.?;
+
+    const microkit_config_option = b.option(ConfigOptions, "config", "Microkit config to build for") orelse ConfigOptions.debug;
+    const microkit_config = @tagName(microkit_config_option);
+
+    // Get the Microkit SDK board we want to target
+    const microkit_board_option = b.option(MicrokitBoard, "board", "Microkit board to target");
+
+    if (microkit_board_option == null) {
+        std.log.err("Missing -Dboard=<BOARD> argument being passed\n", .{});
+        std.posix.exit(1);
+    }
+    const target = b.resolveTargetQuery(findTarget(microkit_board_option.?));
+    const microkit_board = @tagName(microkit_board_option.?);
+
+    // Since we are relying on Zig to produce the final ELF, it needs to do the
+    // linking step as well.
+    const microkit_board_dir = b.fmt("{s}/board/{s}/{s}", .{ microkit_sdk, microkit_board, microkit_config });
+    const microkit_tool = b.fmt("{s}/bin/microkit", .{microkit_sdk});
+    const libmicrokit = b.fmt("{s}/lib/libmicrokit.a", .{microkit_board_dir});
+    const libmicrokit_linker_script = b.fmt("{s}/lib/microkit.ld", .{microkit_board_dir});
+    const libmicrokit_include = b.fmt("{s}/include", .{microkit_board_dir});
+
+    const sddf_dep = b.dependency("sddf", .{
+        .target = target,
+        .optimize = optimize,
+        .sdk = microkit_sdk,
+        .config = @as([]const u8, microkit_config),
+        .board = @as([]const u8, microkit_board),
+    });
+    
+    const driver_class = switch (microkit_board_option.?) {
+        .qemu_arm_virt => "arm",
+        .odroidc4 => "meson",
+        .maaxboard => "imx",
+    };
+
+    const driver = sddf_dep.artifact(b.fmt("driver_uart_{s}.elf", .{ driver_class }));
+    b.installArtifact(driver);
+
+    const virt_rx = sddf_dep.artifact("serial_component_virt_rx.elf");
+    b.installArtifact(virt_rx);
+
+    const virt_tx = sddf_dep.artifact("serial_component_virt_tx.elf");
+    b.installArtifact(virt_tx);
+
+    const serial_server_1 = b.addExecutable(.{
+        .name = "serial_server_1.elf",
+        .target = target,
+        .optimize = optimize,
+        .strip = false,
+    });
+
+    serial_server_1.addCSourceFile(.{ .file = b.path("serial_server.c"), .flags = &.{ "-DSERIAL_SERVER_NUMBER=1", "-fno-sanitize=undefined" } });
+    serial_server_1.addIncludePath(.{ .path = libmicrokit_include });
+    serial_server_1.addIncludePath(sddf_dep.path("include"));
+    serial_server_1.addObjectFile(.{ .path = libmicrokit });
+    serial_server_1.setLinkerScriptPath(.{ .path = libmicrokit_linker_script });
+
+    const serial_server_2 = b.addExecutable(.{
+        .name = "serial_server_2.elf",
+        .target = target,
+        .optimize = optimize,
+        .strip = false,
+    });
+
+    serial_server_2.addCSourceFile(.{ .file = b.path("serial_server.c"), .flags = &.{ "-DSERIAL_SERVER_NUMBER=2", "-fno-sanitize=undefined" } });
+    serial_server_2.addIncludePath(.{ .path = libmicrokit_include });
+    serial_server_2.addIncludePath(sddf_dep.path("include"));
+    serial_server_2.addObjectFile(.{ .path = libmicrokit });
+    serial_server_2.setLinkerScriptPath(.{ .path = libmicrokit_linker_script });
+
+    b.installArtifact(serial_server_1);
+    b.installArtifact(serial_server_2);
+
+    const system_description_path = b.fmt("board/{s}/serial.system", .{microkit_board});
+    const final_image_dest = b.getInstallPath(.bin, "./loader.img");
+    const microkit_tool_cmd = b.addSystemCommand(&[_][]const u8{
+        microkit_tool,
+        system_description_path,
+        "--search-path", b.getInstallPath(.bin, ""),
+        "--board", microkit_board,
+        "--config", microkit_config,
+        "-o", final_image_dest,
+        "-r", b.getInstallPath(.prefix, "./report.txt")
+    });
+    microkit_tool_cmd.step.dependOn(b.getInstallStep());
+    // Add the "microkit" step, and make it the default step when we execute `zig build`>
+    const microkit_step = b.step("microkit", "Compile and build the final bootable image");
+    microkit_step.dependOn(&microkit_tool_cmd.step);
+    b.default_step = microkit_step;
+
+    // This is setting up a `qemu` command for running the system using QEMU,
+    // which we only want to do when we have a board that we can actually simulate.
+    const loader_arg = b.fmt("loader,file={s},addr=0x70000000,cpu-num=0", .{final_image_dest});
+    if (std.mem.eql(u8, microkit_board, "qemu_arm_virt")) {
+        const qemu_cmd = b.addSystemCommand(&[_][]const u8{
+            "qemu-system-aarch64",
+            "-machine",
+            "virt,virtualization=on,highmem=off,secure=off",
+            "-cpu",
+            "cortex-a53",
+            "-serial",
+            "mon:stdio",
+            "-device",
+            loader_arg,
+            "-m",
+            "2G",
+            "-nographic",
+        });
+        qemu_cmd.step.dependOn(b.default_step);
+        const simulate_step = b.step("qemu", "Simulate the image using QEMU");
+        simulate_step.dependOn(&qemu_cmd.step);
+    }
+}

--- a/examples/serial/build.zig.zon
+++ b/examples/serial/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "simple",
+    .name = "sddf_serial_example",
     .version = "1.0.0",
 
     .dependencies = .{

--- a/examples/serial/build.zig.zon
+++ b/examples/serial/build.zig.zon
@@ -1,0 +1,14 @@
+.{
+    .name = "simple",
+    .version = "1.0.0",
+
+    .dependencies = .{
+        .sddf = .{
+            .path = "../../"
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+    }
+}

--- a/examples/serial/include/serial_config/serial_config.h
+++ b/examples/serial/include/serial_config/serial_config.h
@@ -5,6 +5,8 @@
 #include <sddf/serial/queue.h>
 #include <stdint.h>
 
+#define SERIAL_NUM_CLIENTS 2
+
 /* Only support transmission and not receive. */
 #define SERIAL_TX_ONLY 0
 

--- a/examples/serial/serial.mk
+++ b/examples/serial/serial.mk
@@ -61,7 +61,7 @@ SYSTEM_FILE := ${TOP}/board/$(MICROKIT_BOARD)/serial.system
 
 IMAGES := uart_driver.elf \
 	  serial_server.elf \
-	  serial_tx_virt.elf serial_rx_virt.elf
+	  serial_virt_tx.elf serial_virt_rx.elf
 CFLAGS := -mcpu=$(CPU)\
 	  -mstrict-align \
 	  -ffreestanding \

--- a/examples/serial/serial_server.c
+++ b/examples/serial/serial_server.c
@@ -1,4 +1,3 @@
-#include <ctype.h>
 #include <microkit.h>
 #include <sddf/serial/queue.h>
 #include <sddf/util/printf.h>

--- a/examples/timer/build.zig
+++ b/examples/timer/build.zig
@@ -1,0 +1,151 @@
+const std = @import("std");
+
+const MicrokitBoard = enum {
+    qemu_arm_virt,
+    odroidc4
+};
+
+const Target = struct {
+    board: MicrokitBoard,
+    zig_target: std.Target.Query,
+};
+
+const targets = [_]Target{
+    .{
+        .board = MicrokitBoard.qemu_arm_virt,
+        .zig_target = std.Target.Query{
+            .cpu_arch = .aarch64,
+            .cpu_model = .{ .explicit = &std.Target.arm.cpu.cortex_a53 },
+            .os_tag = .freestanding,
+            .abi = .none,
+        },
+    },
+    .{
+        .board = MicrokitBoard.odroidc4,
+        .zig_target = std.Target.Query{
+            .cpu_arch = .aarch64,
+            .cpu_model = .{ .explicit = &std.Target.arm.cpu.cortex_a55 },
+            .os_tag = .freestanding,
+            .abi = .none,
+        },
+    },
+};
+
+fn findTarget(board: MicrokitBoard) std.Target.Query {
+    for (targets) |target| {
+        if (board == target.board) {
+            return target.zig_target;
+        }
+    }
+
+    std.log.err("Board '{}' is not supported\n", .{board});
+    std.posix.exit(1);
+}
+
+const ConfigOptions = enum { debug, release, benchmark };
+
+pub fn build(b: *std.Build) void {
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Getting the path to the Microkit SDK before doing anything else
+    const microkit_sdk_arg = b.option([]const u8, "sdk", "Path to Microkit SDK");
+    if (microkit_sdk_arg == null) {
+        std.log.err("Missing -Dsdk=/path/to/sdk argument being passed\n", .{});
+        std.posix.exit(1);
+    }
+    const microkit_sdk = microkit_sdk_arg.?;
+
+    const microkit_config_option = b.option(ConfigOptions, "config", "Microkit config to build for") orelse ConfigOptions.debug;
+    const microkit_config = @tagName(microkit_config_option);
+
+    // Get the Microkit SDK board we want to target
+    const microkit_board_option = b.option(MicrokitBoard, "board", "Microkit board to target");
+
+    if (microkit_board_option == null) {
+        std.log.err("Missing -Dboard=<BOARD> argument being passed\n", .{});
+        std.posix.exit(1);
+    }
+    const target = b.resolveTargetQuery(findTarget(microkit_board_option.?));
+    const microkit_board = @tagName(microkit_board_option.?);
+
+    const microkit_board_dir = b.fmt("{s}/board/{s}/{s}", .{ microkit_sdk, microkit_board, microkit_config });
+    const microkit_tool = b.fmt("{s}/bin/microkit", .{microkit_sdk});
+    const libmicrokit = b.fmt("{s}/lib/libmicrokit.a", .{microkit_board_dir});
+    const libmicrokit_include = b.fmt("{s}/include", .{microkit_board_dir});
+    const libmicrokit_linker_script = b.fmt("{s}/lib/microkit.ld", .{microkit_board_dir});
+
+    const sddf_dep = b.dependency("sddf", .{
+        .target = target,
+        .optimize = optimize,
+        .libmicrokit = @as([]const u8, libmicrokit),
+        .libmicrokit_include = @as([]const u8, libmicrokit_include),
+        .libmicrokit_linker_script = @as([]const u8, libmicrokit_linker_script),
+    });
+
+    const driver_class = switch (microkit_board_option.?) {
+        .qemu_arm_virt => "arm",
+        .odroidc4 => "meson",
+    };
+
+    const driver = sddf_dep.artifact(b.fmt("driver_timer_{s}.elf", .{ driver_class }));
+    // This is required because the SDF file is expecting a different name to the artifact we
+    // are dealing with.
+    const driver_install = b.addInstallArtifact(driver, .{ .dest_sub_path = "timer_driver.elf" });
+
+    const client = b.addExecutable(.{
+        .name = "client.elf",
+        .target = target,
+        .optimize = optimize,
+        .strip = false,
+    });
+
+    client.addCSourceFile(.{ .file = b.path("client.c"), .flags = &.{ "-fno-sanitize=undefined" } });
+    client.addIncludePath(sddf_dep.path("include"));
+    client.linkLibrary(sddf_dep.artifact("util"));
+    client.linkLibrary(sddf_dep.artifact("util_putchar_debug"));
+
+    client.addIncludePath(.{ .cwd_relative = libmicrokit_include });
+    client.addObjectFile(.{ .cwd_relative = libmicrokit });
+    client.setLinkerScriptPath(.{ .cwd_relative = libmicrokit_linker_script });
+
+    b.installArtifact(client);
+
+    const system_description_path = b.fmt("board/{s}/timer.system", .{microkit_board});
+    const final_image_dest = b.getInstallPath(.bin, "./loader.img");
+    const microkit_tool_cmd = b.addSystemCommand(&[_][]const u8{
+        microkit_tool,
+        system_description_path,
+        "--search-path", b.getInstallPath(.bin, ""),
+        "--board", microkit_board,
+        "--config", microkit_config,
+        "-o", final_image_dest,
+        "-r", b.getInstallPath(.prefix, "./report.txt")
+    });
+    microkit_tool_cmd.step.dependOn(b.getInstallStep());
+    microkit_tool_cmd.step.dependOn(&driver_install.step);
+    const microkit_step = b.step("microkit", "Compile and build the final bootable image");
+    microkit_step.dependOn(&microkit_tool_cmd.step);
+    b.default_step = microkit_step;
+
+    const loader_arg = b.fmt("loader,file={s},addr=0x70000000,cpu-num=0", .{final_image_dest});
+    if (std.mem.eql(u8, microkit_board, "qemu_arm_virt")) {
+        const qemu_cmd = b.addSystemCommand(&[_][]const u8{
+            "qemu-system-aarch64",
+            "-machine",
+            "virt,virtualization=on,highmem=off,secure=off",
+            "-cpu",
+            "cortex-a53",
+            "-serial",
+            "mon:stdio",
+            "-device",
+            loader_arg,
+            "-m",
+            "2G",
+            "-nographic",
+        });
+        qemu_cmd.step.dependOn(b.default_step);
+        const simulate_step = b.step("qemu", "Simulate the image using QEMU");
+        simulate_step.dependOn(&qemu_cmd.step);
+    }
+}
+

--- a/examples/timer/build.zig.zon
+++ b/examples/timer/build.zig.zon
@@ -1,0 +1,15 @@
+.{
+    .name = "sddf_timer_example",
+    .version = "1.0.0",
+
+    .dependencies = .{
+        .sddf = .{
+            .path = "../../"
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+    }
+}
+

--- a/serial/components/serial_components.mk
+++ b/serial/components/serial_components.mk
@@ -7,7 +7,7 @@
 # it should be included into your project Makefile
 #
 # NOTES:
-#  Generates serial_rx_virt.elf serial_tx_virt.elf
+#  Generates serial_virt_rx.elf serial_virt_tx.elf
 #  It relies on the variable SERIAL_NUM_CLIENTS as a C compiler flag
 #  to configure the virtualisers
 #
@@ -16,7 +16,7 @@ ifeq ($(strip $(SERIAL_NUM_CLIENTS)),)
 $(error Specify the number of clients for the serial virtualisers.  Expect -DSERIAL_NUM_CLIENTS=3 or similar)
 endif
 
-SERIAL_IMAGES:= serial_rx_virt.elf serial_tx_virt.elf
+SERIAL_IMAGES:= serial_virt_rx.elf serial_virt_tx.elf
 
 CFLAGS_serial := -I ${SDDF}/include ${SERIAL_NUM_CLIENTS}
 
@@ -27,7 +27,7 @@ ${CHECK_SERIAL_FLAGS_MD5}:
 	touch $@
 
 
-serial_%_virt.elf: virt_%.o
+serial_virt_%.elf: virt_%.o
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 virt_tx.o virt_rx.o: ${CHECK_SERIAL_FLAGS_MD5}

--- a/serial/components/virt_tx.c
+++ b/serial/components/virt_tx.c
@@ -146,7 +146,7 @@ void tx_return(void)
 void tx_provide(microkit_channel ch)
 {
     if (ch > SERIAL_NUM_CLIENTS) {
-        sddf_dprintf("VIRT_TX|LOG: Received notification from unkown channel %u\n", ch);
+        sddf_dprintf("VIRT_TX|LOG: Received notification from unknown channel %u\n", ch);
         return;
     }
 


### PR DESCRIPTION
A preliminary zig build system for sDDF. This exposes the sddf headers to be included by dependent systems, and also components and drivers as artifacts.