### PR TITLE
Use appropriate size for i2c memory regions

### DIFF
--- a/examples/i2c/board/odroidc4/i2c.system
+++ b/examples/i2c/board/odroidc4/i2c.system
@@ -11,11 +11,15 @@
 
     <memory_region name="i2c_bus" size="0x1000" phys_addr="0xFFD1D000"/>
 
-    <memory_region name="client_request_region" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="client_response_region" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="driver_request_region" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="driver_response_region" size="0x200_000" page_size="0x200_000"/>
-    <memory_region name="data_region" size="0x200_000" page_size="0x200_000"/>
+    <!--
+	 This system transfers minimal data over I2C and so a data region size of
+	 0x1000 is more than enough for our use-case.
+    -->
+    <memory_region name="client_request_region" size="0x1_000"/>
+    <memory_region name="client_response_region" size="0x1_000"/>
+    <memory_region name="driver_request_region" size="0x1_000"/>
+    <memory_region name="driver_response_region" size="0x1_000"/>
+    <memory_region name="data_region" size="0x1_000"/>
 
     <memory_region name="timer_registers" size="0x1000" phys_addr="0xffd0f000" />
 

--- a/include/sddf/i2c/queue.h
+++ b/include/sddf/i2c/queue.h
@@ -9,8 +9,19 @@
 #include <stddef.h>
 #include <sddf/util/fence.h>
 
-#define I2C_MAX_DATA_SIZE 512
-#define NUM_QUEUE_ENTRIES 512
+/*
+ * Here we choose the default data size and queue entries. This means
+ * that by default the data region would need 4KiB of space (1 page on
+ * AArch64 for example). These defaults have worked for our example systems
+ * but are left configurable for the system designer if they are too small.
+ */
+#ifndef I2C_MAX_DATA_SIZE
+#define I2C_MAX_DATA_SIZE 128
+#endif
+
+#ifndef NUM_QUEUE_ENTRIES
+#define NUM_QUEUE_ENTRIES 32
+#endif
 
 #define RESPONSE_ERR 0
 #define RESPONSE_ERR_TOKEN 1


### PR DESCRIPTION
The I2C data region is currently bound to 12,800 bytes. The request/response regions are currently limited to 4008 bytes.
