### PR TITLE
Makefile fixes

### DIFF
--- a/drivers/network/meson/eth_driver.mk
+++ b/drivers/network/meson/eth_driver.mk
@@ -24,6 +24,6 @@ eth_driver.elf: meson/ethernet.o
 
 meson/ethernet.o: ${ETHERNET_DRIVER_DIR}/ethernet.c ${CHECK_NETDRV_FLAGS}
 	mkdir -p meson
-	${CC} -c ${CFLAGS} ${CFLAGS_network} -I ${ETHERNET_DRIVER} -MF meson/ethernet.d -o $@ $<
+	${CC} -c ${CFLAGS} ${CFLAGS_network} -I ${ETHERNET_DRIVER_DIR} -o $@ $<
 
 -include meson/ethernet.d

--- a/examples/echo_server/echo.mk
+++ b/examples/echo_server/echo.mk
@@ -78,9 +78,11 @@ all: loader.img
 ${LWIP_OBJS}: ${CHECK_FLAGS_BOARD_MD5}
 lwip.elf: $(LWIP_OBJS) libsddf_util.a
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
-${LWIP_OBJS}: |${BUILD_DIR}/${LWIPDIR}
-${BUILD_DIR}/${LWIPDIR}:
-	mkdir -p $@/core/ipv4 $@/netif $@/api
+
+LWIPDIRS := $(addprefix ${LWIPDIR}/, core/ipv4 netif api)
+${LWIP_OBJS}: |${BUILD_DIR}/${LWIPDIRS}
+${BUILD_DIR}/${LWIPDIRS}:
+	mkdir -p $@
 
 # Need to build libsddf_util_debug.a because it's included in LIBS
 # for the unimplemented libc dependencies

--- a/examples/echo_server/echo.mk
+++ b/examples/echo_server/echo.mk
@@ -26,7 +26,7 @@ SYSTEM_FILE := ${ECHO_SERVER}/board/$(MICROKIT_BOARD)/echo_server.system
 IMAGE_FILE := loader.img
 REPORT_FILE := report.txt
 
-vpath %.c ${SDDF} ${ECHO_SERVER} ${NETWORK_COMPONENTS}
+vpath %.c ${SDDF} ${ECHO_SERVER}
 
 IMAGES := eth_driver.elf lwip.elf benchmark.elf idle.elf network_virt_rx.elf\
 	  network_virt_tx.elf copy.elf timer_driver.elf uart_driver.elf serial_tx_virt.elf

--- a/examples/i2c/i2c.mk
+++ b/examples/i2c/i2c.mk
@@ -68,6 +68,7 @@ client.elf: $(CLIENT_OBJS) libco.a
 $(IMAGE_FILE) $(REPORT_FILE): $(IMAGES) $(SYSTEM_FILE)
 	$(MICROKIT_TOOL) $(SYSTEM_FILE) --search-path $(BUILD_DIR) --board $(MICROKIT_BOARD) --config $(MICROKIT_CONFIG) -o $(IMAGE_FILE) -r $(REPORT_FILE)
 
+${IMAGES}: ${COMMONFILES}
 .PHONY: all compile clean
 
 clean::

--- a/examples/timer/timer.mk
+++ b/examples/timer/timer.mk
@@ -39,6 +39,11 @@ CLIENT_OBJS := client.o
 TIMER_DRIVER := $(SDDF)/drivers/clock/$(TIMER_DRIVER_DIR)
 
 all: $(IMAGE_FILE)
+CHECK_FLAGS_BOARD_MD5:=.board_cflags-$(shell echo -- ${CFLAGS} ${BOARD} ${MICROKIT_CONFIG} | shasum | sed 's/ *-//')
+
+${CHECK_FLAGS_BOARD_MD5}:
+	-rm -f .board_cflags-*
+	touch $@
 
 include ${TIMER_DRIVER}/timer_driver.mk
 include ${SDDF}/util/util.mk

--- a/libco/libco.mk
+++ b/libco/libco.mk
@@ -5,17 +5,18 @@
 #
 # Include this make snippet to buid libco,a, a simple coroutine library.
 
-CHECK_LIBCO_FLAGS_MD5:=.libco_cflags-$(shell echo -- ${CFLAGS} ${CFLAGS_network} | shasum | sed 's/ *-//')
+LIBCO_DIR := $(abspath $(dir $(lastword ${MAKEFILE_LIST})))
+CHECK_LIBCO_FLAGS_MD5:=.libco_cflags-$(shell echo -- ${CFLAGS} | shasum | sed 's/ *-//')
 
 ${CHECK_LIBCO_FLAGS_MD5}:
 	-rm -f .libco_cflags-*
 	touch $@
 
-libco.o: $(LIBCO)/libco.c ${CHECK_LIBCO_FLAGS_MD5}
+${LIBCO_DIR}/libco.o: $(LIBCO_DIR)/libco.c ${CHECK_LIBCO_FLAGS_MD5}
 	${CC} ${CFLAGS} -c -o $@ $<
 
-libco.a: libco.o
+libco.a: ${LIBCO_DIR}/libco.o
 	${AR} cr $@ $^
 	${RANLIB} $@
 
--include libco.d
+-include ${LIBCO_DIR}/libco.d

--- a/libco/libco.mk
+++ b/libco/libco.mk
@@ -6,13 +6,8 @@
 # Include this make snippet to buid libco,a, a simple coroutine library.
 
 LIBCO_DIR := $(abspath $(dir $(lastword ${MAKEFILE_LIST})))
-CHECK_LIBCO_FLAGS_MD5:=.libco_cflags-$(shell echo -- ${CFLAGS} | shasum | sed 's/ *-//')
 
-${CHECK_LIBCO_FLAGS_MD5}:
-	-rm -f .libco_cflags-*
-	touch $@
-
-libco/libco.o: $(LIBCO_DIR)/libco.c ${CHECK_LIBCO_FLAGS_MD5} |libco
+libco/libco.o: $(LIBCO_DIR)/libco.c ${CHECK_FLAGS_BOARD_MD5} |libco
 	${CC} ${CFLAGS} -c -o $@ $<
 
 libco.a: libco/libco.o

--- a/libco/libco.mk
+++ b/libco/libco.mk
@@ -12,11 +12,14 @@ ${CHECK_LIBCO_FLAGS_MD5}:
 	-rm -f .libco_cflags-*
 	touch $@
 
-${LIBCO_DIR}/libco.o: $(LIBCO_DIR)/libco.c ${CHECK_LIBCO_FLAGS_MD5}
+libco/libco.o: $(LIBCO_DIR)/libco.c ${CHECK_LIBCO_FLAGS_MD5} |libco
 	${CC} ${CFLAGS} -c -o $@ $<
 
-libco.a: ${LIBCO_DIR}/libco.o
+libco.a: libco/libco.o
 	${AR} cr $@ $^
 	${RANLIB} $@
 
--include ${LIBCO_DIR}/libco.d
+libco:
+	mkdir -p $@
+
+-include libco/libco.d

--- a/util/util.mk
+++ b/util/util.mk
@@ -13,25 +13,33 @@
 
 OBJS_LIBUTIL := cache.o sddf_printf.o newlibc.o assert.o
 
-${OBJS_LIBUTIL} putchar_debug.o putchar_serial.o: ${CHECK_FLAGS_BOARD_MD5}
+ALL_OBJS_LIBUTIL := $(addprefix util/, ${OBJS_LIBUTIL} putchar_debug.o putchar_serial.o)
 
-libsddf_util_debug.a: ${OBJS_LIBUTIL} putchar_debug.o
+BASE_OBJS_LIBUTIL := $(addprefix util/, ${OBJS_LIBUTIL})
+${ALL_OBJS_LIBUTIL}: ${CHECK_FLAGS_BOARD_MD5} |util
+
+libsddf_util_debug.a: ${BASE_OBJS_LIBUTIL} util/putchar_debug.o
 	${AR} rv $@ $^
 	${RANLIB} $@
 
-libsddf_util.a: ${OBJS_LIBUTIL} putchar_serial.o
+libsddf_util.a: ${BASE_OBJS_LIBUTIL} util/putchar_serial.o
 	${AR} rv $@ $^
 	${RANLIB} $@
 
-VPATH += ${SDDF}/util
-
-sddf_printf.o: ${SDDF}/util/printf.c
+util/sddf_printf.o: ${SDDF}/util/printf.c
 	${CC} ${CFLAGS} -c -o $@ $<
 
+util/%.o: ${SDDF}/util/%.c
+	${CC} ${CFLAGS} -c -o $@ $<
+
+util:
+	mkdir -p $@
+
 clean::
-	${RM} -f ${OBJS_LIBUTIL} ${OBJS_LIBUTIL:.o=.d} putchar_debug.[od] putchar_serial.[od]
+	${RM} -f ${ALL_OBJS_LIBUTIL} ${ALL_OBJS_LIBUTIL:.o=.d}
 
 clobber:: clean
 	${RM} -f libsddf_util.a libsddf_util_debug.a
+	rmdir util
 
--include ${OBJS_LIBUTIL:.o=.d} putchar_debug.d putchar_serial.d
+-include ${ALL_OBJS_LIBUTIL:.o=.d}


### PR DESCRIPTION
Various cleanups and fixes to enable the Kitty LionsOS example to use the sDDF, plus some others:
 -- Always build the CHECK_FLAGS_BOARD_MD5 file, so changes from DEBUG->Release or similar will force rebuilds.
 -- Hide object files in a named subdirectory of the build directory wherever possible, to allow conflicting-named files
 -- various consistency cleanups
 -- Reduce reliance on VPATH/vpath
 