### PR TITLE
Remove cache clean

### DIFF
--- a/examples/echo_server/board/imx8mm_evk/echo_server.system
+++ b/examples/echo_server/board/imx8mm_evk/echo_server.system
@@ -8,7 +8,7 @@
     <memory_region name="hw_ring_buffer" size="0x10_000" />
 
     <!-- DMA and virtualised DMA regions -->
-    <memory_region name="net_rx_buffer_data_region" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="net_rx_buffer_data_region" size="0x200_000" page_size="0x200_000" /> <!-- Must be mapped read-only! -->
     <memory_region name="net_tx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="net_rx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="net_tx_buffer_data_region_cli1" size="0x200_000" page_size="0x200_000" />

--- a/examples/echo_server/board/maaxboard/echo_server.system
+++ b/examples/echo_server/board/maaxboard/echo_server.system
@@ -8,7 +8,7 @@
     <memory_region name="hw_ring_buffer" size="0x10_000" />
 
     <!-- DMA and virtualised DMA regions -->
-    <memory_region name="net_rx_buffer_data_region" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="net_rx_buffer_data_region" size="0x200_000" page_size="0x200_000" /> <!-- Must be mapped read-only! -->
     <memory_region name="net_tx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="net_rx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="net_tx_buffer_data_region_cli1" size="0x200_000" page_size="0x200_000" />

--- a/examples/echo_server/board/odroidc4/echo_server.system
+++ b/examples/echo_server/board/odroidc4/echo_server.system
@@ -8,7 +8,7 @@
     <memory_region name="hw_ring_buffer" size="0x10_000" />
 
     <!-- DMA and virtualised DMA regions -->
-    <memory_region name="net_rx_buffer_data_region" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="net_rx_buffer_data_region" size="0x200_000" page_size="0x200_000" /> <!-- Must be mapped read-only! -->
     <memory_region name="net_tx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="net_rx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="net_tx_buffer_data_region_cli1" size="0x200_000" page_size="0x200_000" />

--- a/examples/echo_server/board/qemu_arm_virt/echo_server.system
+++ b/examples/echo_server/board/qemu_arm_virt/echo_server.system
@@ -7,7 +7,7 @@
     <memory_region name="hw_ring_buffer" size="0x10_000" />
 
     <!-- DMA and virtualised DMA regions -->
-    <memory_region name="net_rx_buffer_data_region" size="0x200_000" page_size="0x200_000" />
+    <memory_region name="net_rx_buffer_data_region" size="0x200_000" page_size="0x200_000" /> <!-- Must be mapped read-only! -->
     <memory_region name="net_tx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="net_rx_buffer_data_region_cli0" size="0x200_000" page_size="0x200_000" />
     <memory_region name="net_tx_buffer_data_region_cli1" size="0x200_000" page_size="0x200_000" />

--- a/network/components/virt_rx.c
+++ b/network/components/virt_rx.c
@@ -202,6 +202,7 @@ void rx_provide(void)
     if (notify_drv && net_require_signal_free(&state.rx_queue_drv)) {
         net_cancel_signal_free(&state.rx_queue_drv);
         microkit_notify_delayed(DRIVER_CH);
+        notify_drv = false;
     }
 }
 


### PR DESCRIPTION
This pull request removes the additional `cache_clean` operation that was added in PR 73 in favour of always requiring that the receive DMA region be mapped into all address spaces as read only.

Since the Arp component has since been removed, and the Copy components and receive virtualisers are the only protection domains with the receive DMA region mapped in at all, all protection domains already had the receive DMA region mapped in read only prior to this PR, but I have added a few comments to indicate that this is now a necessity. 

The `cache_clean` that is removed by this PR was only necessary to prevent against cached writes being written to the region after the DMA write had occurred, corrupting the newly received data. To prevent the reading of stale cached data, as well as erroneous pre-fetching, there is still an additional `cache_clean_and_invalidate` that is performed by the receive virtualiser before packets are read (this is a clean and invalidate rather than straight invalidate as clean and invalidate can be performed at user level, and subsequently ends up being more performant than a syscall invalidate).

Removing the additional clean prior to DMA means that the DMA region must *only* be mapped in read only. For clients using a copier (which is the typical case), this places no additional restrictions since copied data can be mapped in read-write. For clients without a copier (which therefore must be trusted) who wish to write to the DMA region, they must now copy data into writeable region themselves (which likely ends up more performant than the additional cache clean anyway).

This PR improves performance notably, with graphed results for the IMX8MM, Maaxboard and Odroidc4 pictured below:

![CPU Util vs Requested Throughput](https://github.com/au-ts/sddf/assets/55342552/ba6cd4cb-5ab1-4e5f-a1da-65ac3355f749)

![Odroidc4 CPU Util vs Requested Throughput](https://github.com/au-ts/sddf/assets/55342552/08b054f8-5796-4a4f-876b-9d5d861a70b6)

Further numbers can be found here https://docs.google.com/spreadsheets/d/1d1hKhZVVbEvxm7ehs7sXc1KvGjfdJ0RHR4YiMPzR8O8/edit?usp=sharing in the Recent-Single-Core tab.
