### PR TITLE
Fix mistake with setting flag in uart driver

### DIFF
--- a/drivers/serial/arm/uart.c
+++ b/drivers/serial/arm/uart.c
@@ -87,7 +87,7 @@ static void rx_return(void)
         if (!(uart_regs->fr & PL011_FR_RXFE) && serial_queue_full(&rx_queue_handle, rx_queue_handle.queue->tail)) {
             /* Disable rx interrupts until virtualisers queue is no longer empty. */
             uart_regs->imsc &= ~(PL011_IMSC_RX_TIMEOUT | PL011_IMSC_RX_INT);
-            serial_require_consumer_signal(&rx_queue_handle);
+            serial_request_consumer_signal(&rx_queue_handle);
         }
         reprocess = false;
 

--- a/drivers/serial/imx/uart.c
+++ b/drivers/serial/imx/uart.c
@@ -89,7 +89,7 @@ static void rx_return(void)
         if (!(uart_regs->ts & UART_TST_RX_FIFO_EMPTY) && serial_queue_full(&rx_queue_handle, rx_queue_handle.queue->tail)) {
             /* Disable rx interrupts until virtualisers queue is no longer empty. */
             uart_regs->cr1 &= ~UART_CR1_RX_READY_INT;
-            serial_require_consumer_signal(&rx_queue_handle);
+            serial_request_consumer_signal(&rx_queue_handle);
         }
         reprocess = false;
 

--- a/drivers/serial/meson/uart.c
+++ b/drivers/serial/meson/uart.c
@@ -112,7 +112,7 @@ static void rx_return(void)
         if (!(uart_regs->sr & AML_UART_RX_EMPTY) && serial_queue_full(&rx_queue_handle, rx_queue_handle.queue->tail)) {
             /* Disable rx interrupts until virtualisers queue is no longer empty. */
             uart_regs->cr &= ~AML_UART_RX_INT_EN;
-            serial_require_consumer_signal(&rx_queue_handle);
+            serial_request_consumer_signal(&rx_queue_handle);
         }
         reprocess = false;
 


### PR DESCRIPTION
I accidentally used the incorrect function in the uart driver which returns a boolean rather than setting a flag. This pull requests corrects this mistake.