### PR TITLE
Allow more concurrent TCP connections

### DIFF
--- a/examples/echo_server/include/lwip/lwipopts.h
+++ b/examples/echo_server/include/lwip/lwipopts.h
@@ -212,3 +212,10 @@
 #define IP_DEBUG LWIP_DBG_ON
 #define TCP_OUTPUT_DEBUG LWIP_DBG_ON
 #define TCP_INPUT_DEBUG LWIP_DBG_ON
+
+/*
+ * Streams can hang around in FIN_WAIT state for a
+ * while after closing.  Increase the max number of concurrent streams to allow
+ * for a few of these while 
+ */
+#define MEMP_NUM_TCP_PCB 10


### PR DESCRIPTION
To allow more than one echo client, we need to allow more concurrent TCP connections. The default is 5; we take one for the Utilisation socket, one per client, plus connections can hang around in FIN-WAIT state for a minute or so after a benchmark run completes.

Change from 5 to 10 to allow two concurrent connections.