### PR TITLE
blk: add back data region globals

### DIFF
--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -39,6 +39,8 @@ blk_req_queue_t *blk_req_queue_driver;
 blk_resp_queue_t *blk_resp_queue_driver;
 uintptr_t blk_data_driver;
 
+uintptr_t blk_data;
+uintptr_t blk_data2;
 blk_storage_info_t *blk_config;
 blk_storage_info_t *blk_config2;
 blk_req_queue_t *blk_req_queue;


### PR DESCRIPTION
Removed in f1efff160a8eee65489df1baa8fc8a0824662332, but we need these still.

Ideally the virtualiser would not need access to the data, but that's a seperate issue that we intend to fix.