### PR TITLE
ci: uncomment accidentally commented examples

### DIFF
--- a/ci/examples.sh
+++ b/ci/examples.sh
@@ -160,10 +160,10 @@ serial() {
 }
 
 # Only run the examples that have been enabled
-# $NETWORK && network
+$NETWORK && network
 $I2C && i2c
-# $TIMER && timer
-# $SERIAL && serial
+$TIMER && timer
+$SERIAL && serial
 
 echo ""
 echo "CI|INFO: Passed all sDDF tests"


### PR DESCRIPTION
Accidentally commented these out in b4631a76bdacabd32583ff93c41be8d1efcc0983.