### PR TITLE
Change blk queue to use offsets, and refactor to use blk_config.h

### DIFF
--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -297,7 +297,6 @@ static void handle_client(int cli_id)
 
             // Check if client request offset is within its allocated bounds and is aligned to transfer size
             if (cli_offset % BLK_TRANSFER_SIZE != 0 || (cli_offset + BLK_TRANSFER_SIZE * cli_count) > cli_data_region_size) {
-                // @ericc: Potentially use a new error code? ADDR_OUT_OF_BOUNDS
                 err = blk_enqueue_resp(&h, SEEK_ERROR, 0, cli_req_id);
                 assert(!err);
                 continue;

--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -266,7 +266,7 @@ static void handle_driver()
 static void handle_client(int cli_id)
 {
     blk_queue_handle_t h = clients[cli_id].queue_h;
-    uintptr_t cli_data_base = blk_virt_cli_data_region(blk_data, cli_id);
+    uintptr_t cli_data_base = blk_virt_cli_data_region(blk_client_data_start, cli_id);
     uint64_t cli_data_region_size = blk_virt_cli_data_region_size(cli_id);
 
     blk_request_code_t cli_code;

--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -22,8 +22,8 @@
 #define LOG_BLK_VIRT_ERR(...) do{ sddf_dprintf("BLK_VIRT|ERROR: "); sddf_dprintf(__VA_ARGS__); }while(0)
 
 
-#define DRIVER_CH 1
-#define CLI_CH_OFFSET 3
+#define DRIVER_CH 0
+#define CLI_CH_OFFSET 1
 
 #define BLK_NUM_BUFFERS_DRIV (BLK_DATA_REGION_SIZE_DRIV / BLK_TRANSFER_SIZE)
 
@@ -37,7 +37,8 @@ uintptr_t blk_data_driver;
 blk_storage_info_t *blk_config;
 blk_req_queue_t *blk_req_queue;
 blk_resp_queue_t *blk_resp_queue;
-uintptr_t blk_data;
+/* The start of client data regions. */
+uintptr_t blk_client_data_start;
 
 blk_queue_handle_t drv_h;
 

--- a/include/sddf/blk/queue.h
+++ b/include/sddf/blk/queue.h
@@ -10,7 +10,6 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <sddf/util/fence.h>
-#include <sddf/util/util.h>
 
 /* Size of a single block to be transferred */
 #define BLK_TRANSFER_SIZE 4096


### PR DESCRIPTION
This PR changes the addr field in the blk queues to use offsets instead of virtual addresses. It also refactors the virtualiser component to expect a blk_config header file supplied by each system that describes the size and layout of each memory region needed in the blk subsystem.