### PR TITLE
i2c: fixes, improvements and expanding the example

### DIFF
--- a/drivers/i2c/meson/README.md
+++ b/drivers/i2c/meson/README.md
@@ -15,51 +15,85 @@ The initial scope of this driver is to supply an interface to the EE domain i2c 
 * M2: EE domain
 * M3: EE domain
 
-All interfaces can operate both in controller (formerly master) and target (formerly slave) mode. We choose to only expose two interfaces as m2 and m3 since the others are not available via external GPIO on the ODROID C4.
+All interfaces can operate both in controller (formerly master) and target (formerly slave) mode. We choose to only expose two interfaces as m2 and m3 since the others are not available via external GPIO on the ODROID C4. We chose to only allow the interfaces to operate in master mode as well.
 
 Initially, we effectively ignore the AO domain option for homogeneity (we also will never run this code with EE disabled). This driver is intended to operate the demo system for the [KISS OS](https://github.com/au-ts/kiss) where it will operate the touchscreen and NFC devices.
 
 ## Design
 
-This repository presents a multi-driver multi-server structure (split driver) for handling the i2c interfaces on a device, assuming a homogeneous set of i2c interfaces.
+* **Each server corresponds to exactly one driver, and the pair represents one logical i2c interface.**
+* **Drivers only interface to one explicit i2c bus line interface.**
+* **Virtualisers can have many clients.**
 
-### Server
+Uses custom GPIO and PINMUX configuration.
+
+### Shared Data Region
+
+Clients and Drivers share a mapped data region so the driver and client can communcaite with request and response buffers.
+The virtualiser doesnt have access to this data region.
+
+### Shared Request and Response Queues
+
+```
+struct i2c_queue_entry {
+    /* Offset into the data region for where to look for the request data or
+     * where to put the response data */
+    size_t offset;
+    /* Size of request/response data */
+    unsigned int len;
+    /* I2C bus address to operate on */
+    size_t bus_address;
+}
+```
+Above is the queue structure used for the ring queus.
+Each client has a shared response and request queue memory region between each virtualiser they communicate with (N:N relationship).
+Each driver has a shared response and request queue memory region to a specific virtualiser (1:1 relationship).
+
+### Clients
+
+Clients must first claim an unclaimed bus address (done using a Protected Procedure Call) in order to communicate with the driver. This is managed by the virtualiser.
+Clients build request buffers which the driver has access too and notify the driver by first sending IRQ to virtualiser to authenticate.
+
+### Server (Virtulaiser)
 
 The servers act as the target for API calls from clients and has two responsibilites:
 
-* Multiplexing: given various client requests, delegate them to the appropriate driver and return results back to the correct caller.
+* Demultiplexing: given various client requests, delegate them to the appropriate driver and return results back to the correct caller.
 * Security: i2c devices are a colossal security risk if not protected. The driver ensures that the requesting client has been provisioned access to the requested bus and address.
+It also maps client specific offsets to driver specific offsets represented in the queue structure.
 
-The server accepts requests in the form of a chain of 8-bit tokens, prepended with the address the clients wishes to target. **Each transaction chain can only target a single address** - this is adequate for a majority of i2c perpipherals however; very few require multi-address calls in a single transaction. This constraint is to guarantee O(1) rejection of inauthentic requests.
+Each transaction chain can only target a single address - this is adequate for a majority of i2c perpipherals however; very few require multi-address calls in a single transaction. This constraint is to guarantee O(1) rejection of inauthentic requests.
 
-Clients interface with the server via a shared memory region, passing data into and out of ring buffers. The server determines if these requests are authentic before copying data into the server<=>driver transport layer. Client requests are put into a queue to guarantee "first-come-first-serve" operation.
+So the server determines if client requests are authentic before enqueuing request into the server <=> driver request queue.
+Client requests are put into a queue to guarantee "first-come-first-serve" operation.
 
-**Each server corresponds to exactly one driver, and the pair represents one logical i2c interface.**
+The virtualiser maps client specific offsets into driver specific offsets with security checks so clients dont access other clients data.
+More details in the virtualiser file.
 
 ### Driver
 
-The driver is responsible for hardware interaction. It directly interacts with the i2c hardware via DMA and is responsible for disassembling the requests from the server into a format which is appropriate for hardware. The token-chain abstraction is very friendly however and as a result translation is minimal. This driver can support many different separate interfaces, each with:
+The driver is responsible for hardware interaction. It directly interacts with the i2c hardware via DMA of MMIO registers and is responsible for disassembling the requests from the server into a format which is appropriate for hardware. The token-chain abstraction is very friendly however and as a result translation is minimal. This driver can support many different separate interfaces, each with:
 
-* A unique I2C list processor / data FIFO,
-* A unique interrupt path for data completion.
+* A unique I2C request list processor / data FIFO.
+* A unique interrupt path for data transaction completion from device.
+* A unique timer interrupt path from device.
 
-Since each interface is effectively a unique device, a set of ring buffers for RX and TX is required **per interface** between the driver and server. These operate completely independently.
+Transactions are broken into the maximum unit acceptable by hardware before yielding.
+```
+  while (tk_offset < 16 && wdata_offset < 8 && rdata_offset < 8 && request_data_offset < i2c_ifState.curr_request_len) {...};
+```
 
-Transactions are broken into the maximum unit acceptable by hardware before yielding. E.g. for the ODROID C4 16 tokens can be processed at any time, so the driver splits a list of n tokens into ceil(n/16) operations. Upon receiving a "processing complete" IRQ the next unit is processed.
+Upon receiving a "processing complete" IRQ the next unit is processed if theres no error.
 
 Once the full transaction has been processed, the server is notified to return data to the client.
 
-Upon each invokation of the driver, ring buffers for all interfaces are processed before sleeping to avoid multiplying context switches.
+Upon each invokation of the driver, all requests in the queue are processed before sleeping to avoid multiplying context switches.
 
-**Important note**: This driver does not implement a polling mode. For extremely long i2c transactions, a polling mode driver (or extending this one to switch) may be preferable.
+**Important note**: This driver does not implement a polling mode. For extremely long i2c transactions, a polling mode driver (or extending this one to switch) may be preferable. I.e. its potentially more costly to receive lots of IRQs rather then poll.
 
 ### Security
 
 Security is currently enforced in a "first-come-first-serve" mode - clients can claim or release an address on a particular bus via a protected procedure call (PPC) to the server. Presently, only one device is allowed access to each address and the server can accept up to 128 claims per interface (allowing one device for every 7-bit address).
-
-### Transport layer
-
-Communication between clients and the server, as well as the server and the clients, is implemented using [libsharedringbuffer](https://github.com/au-ts/sDDF/tree/restructure/network/libethsharedringbuffer) from the sDDF (also in this repo) but simplified to remove cookies and other DMA specific features. The modified version is `sw_shared_ringbuffer.h` - "software" ring buffer, constrasting with the DMA ring buffers in the original library.
 
 ### Tokenisation
 
@@ -69,17 +103,32 @@ In transport all i2c operations are decomposed into a list of tokens for more co
 * Read n bytes to an address on the bus,
 * Variations upon the above which do not terminate the transaction.
 
-All i2c transactions begin with a START bit followed by an address + R/W bit sent on the bus. The most significant bit of the address determines R/W. Once the target acknowledges the address call, succeeding bytes are treated as DATA until an END condition is signalled, a repeated start condition + new address is sent, or a NACK is sent to terminate a read preceding another read or write.
+A token-based abstraction is already used in the ODROID C4 hardware, but we take it a step further by flattening data sent over the bus/request buffers into the token stream too, for easier buffering. The tokens are defined as follows:
 
-A token-based abstraction is already used in the ODROID C4 hardware, but we take it a step further by flattening data into the token stream too, for easier buffering. The tokens are defined as follows:
-
-* `I2C_TOKEN_END` - Terminator for token lists; has no effect besides to indicate further bytes are invalid.
+* `I2C_TOKEN_END` - Terminator for token lists; has no effect besides to indicate further bytes are invalid (used to represent a certain state of the registers).
 * `I2C_TOKEN_START` - Triggers hardware to signal the START condition on the bus, claiming it.
 * `I2C_TOKEN_ADDRW` - Transmit a 7 bit address with a WRITE condition.
 * `I2C_TOKEN_ADDRR` - Transmit a 7 bit address with a READ condition.
-* `I2C_TOKEN_DATA_END` - Transmit a NACK to indicate to the target that we are done reading, if a read was in effect. Required to prevent target from staying in read mode.
+* `I2C_TOKEN_DATA_END` - Transmit a NACK to indicate to the target that we are done reading, if a read was in effect. Required to prevent target from staying in read mode. This is also equivalent to a I2C_TOKEN_DATA token in that is also request a byte of data.
 * `I2C_TOKEN_STOP` - Triggers hardware to signal the END condition on the bus, releasing it.
 * `I2C_TOKEN_DATA` - Transmits or receives a byte of data - the next byte after this token is treated as the payload to send under a WRITE condition, otherwise under a READ condition the subsequent byte should be another token which is processed normally.
+
+Note: a token is represented as a byte of data.
+
+The format of all request buffers is as follows:
+- Begins with a I2C_TOKEN_START.
+- Ends with a I2C_TOKEN_STOP.
+
+For a WRITE operation of n bytes within the request:
+- Begins with a I2C_TOKEN_ADDRW.
+- Followed by n * (I2C_TOKEN_DATA + payload data).
+
+For a READ operation of n bytes within the request:
+- Begins with a I2C_TOKEN_ADDRR.
+- Followed by (n - 1) * I2C_TOKEN_DATA.
+- Concludes with 1 I2C_TOKEN_DATA_END.
+
+A sequence of WRITE and/or READ operations is separated by another I2C_TOKEN_START in a single request, indicating a repeated start condition.
 
 ### Error handling and transaction buffer format
 
@@ -88,27 +137,46 @@ The transport layer handles two types of buffers:
 * Request buffers: generated by a client to represent a requested transaction.
 * Return buffers: generated by the driver to encapsulate returned information from a transaction.
 
+Both these buffers occupy the same space in memory. Ie the return buffer overwrites the request buffer.
+There is enough room for this as for READ requests there is a 1:1 ratio almost of amount of request tokens (bytes) to response tokens (bytes).
+So what essentially happens is one unit of the request gets overwridden by the respective response received for that transaction.
+More details below.
+
 #### Return buffer
 
-The return buffers between the driver and server are used for both data and errors. The first two bytes are returned for an ERROR and TOKEN, the third and fourth are reserved for PD and ADDR. The two former fields are used for demultiplexing. All remaining fields are arbitrary tokens or their corresponding payloads.
-
-```
-| 0x0 | 0x1 | 0x2 | 0x3 | 0x4 | ... | 0xN |
-| ERR | TOK | PD  | ADR | DAT | DAT | DAT |
-```
-
-ERR is zero for no error, otherwise it is an error code depending on the particular failure. TOK contains the index of the token in this transaction that caused the issue. The number of bytes read is encoded by the `sz` field in the ring buffer entry.
+The return buffers between the driver and server are used for both data and errors. The first two bytes are returned for an ERROR and TOKEN. All remaining fields are arbitrary tokens or their corresponding payloads for only READs as writes dont return payloads except the error bytes at the start. ERROR is zero for no error, otherwise it is an error code depending on the particular failure. TOKEN contains the index of the token in this transaction that caused the issue. PAY is the payload.
 
 #### Request buffer
 
-The request buffers are used between the clients, server and drivers to represent a complete request. They are passed from the client to the server where they are validated and moved to the driver if authentic. The driver then decomposes the request buffer into some number of hardware operations. The first three bytes are used for the PD, i2c address and i2c bus for multiplexing.
+The request buffers are used between the clients, server and drivers to represent a complete request. They are passed from the client to the server where they are validated and moved to the driver if authentic. The driver then decomposes the request buffer into some number of hardware operations and placed accordingly in the registers. The format details are already covered above.
+
+#### Example
+
+For READS the request of tokens could be:
+```
+| 0x0   | 0x1   | 0x2  | 0x3  | 0x4      | 0x5  |
+| START | ADDRR | DATA | DATA | DATA_END | STOP |
+```
+and the repsonse to this will be:
 
 ```
-| 0x0 | 0x1 | 0x2 | 0x3 | ... | 0xN |
-| PD  | ADR | BUS | DAT | DAT | DAT |
+| 0x0 | 0x1 | 0x2 | 0x3 | 0x4 |
+| ERR | TOK | PAY | PAY | PAY |
 ```
 
-Note: the `BUS` field is only requred between the client and the server. We leave it as is in the other stages for the sake of simplicity.
+For WRITES the request of tokens could be:
+```
+| 0x0   | 0x1   | 0x2  | 0x3 | 0x4  | 0x5 | 0x6  |
+| START | ADDRW | DATA | PAY | DATA | PAY | STOP |
+```
+
+and the repsonse to this will be:
+```
+| 0x0 | 0x1 |
+| ERR | TOK |
+```
+
+Check out the device drivers like PN532 or DS3231 for actual implementations.
 
 ## ODROID C4 i2c specifications
 
@@ -119,7 +187,6 @@ For this iteration of this driver:
 * Toggle between standard and fast speeds
 
 The [SOC](https://dn.odroid.com/S905X3/ODROID-C4/Docs/S905X3_Public_Datasheet_Hardkernel.pdf) exposes the i2c hardware via a set of registers. It can operate i2c in software mode (i.e. bit bashing) or using a finite state machine in the hardware which traverses a token list to operate.
-
 
 ### Interface registers
 There are a set of registers for each:
@@ -139,9 +206,22 @@ Pair of registers containing write data for use with the DATA token. Not at all 
 **TOKEN_RDATA 0/1**
 Pair of registers which are exactly the same as WDATA, but act as a read buffer.
 
+```
+struct i2c_regs {
+    uint32_t ctl;           // control register
+    uint32_t addr;          // slave address and other fields
+    uint32_t tk_list0;      // where to put the meson i2c instructions (4 bits long)
+    uint32_t tk_list1;      // where to put the meson i2c instructions (4 bits long)
+    uint32_t wdata0;        // where to put the write payload from supplied buffer
+    uint32_t wdata1;        // where to put the write payload from supplied buffer
+    uint32_t rdata0;        // where read data gets put for a response by i2c
+    uint32_t rdata1;        // where read data gets put for a response by i2c
+};
+```
+
 ### Transaction token values
 
-Note that the token values are as follows:
+Note that the meson token list values (4 bits) are as follows:
 ```
 0x0 | END    | Marks end of token list
 0x1 | START  | Captures bus for start of transaction
@@ -162,7 +242,7 @@ Offset: 0x7400
 **M2_SLAVE_ADDR**
 ```
 Offset: 0x7401
- paddr: 0xFF822004 
+ paddr: 0xFF822004
 ```
 **M2_TOKEN_LIST_0**
 ```
@@ -205,7 +285,7 @@ Offset: 0x7000
 **M3_SLAVE_ADDR**
 ```
 Offset: 0x7001
- paddr: 0xFF821004 
+ paddr: 0xFF821004
 ```
 **M3_TOKEN_LIST_0**
 ```

--- a/drivers/i2c/meson/driver.h
+++ b/drivers/i2c/meson/driver.h
@@ -10,8 +10,7 @@
 // Matt Rossouw (matthew.rossouw@unsw.edu.au)
 // 08/2023
 
-#ifndef I2C_DRIVER_H
-#define I2C_DRIVER_H
+#pragma once
 
 #include <stdint.h>
 #include <sddf/util/printf.h>
@@ -27,16 +26,20 @@ enum data_direction {
 
 // Driver state
 typedef struct _i2c_ifState {
-    /* Pointer to current request being handled */
-    uint8_t *curr_request_data; // Pointer to current request.
-    /* Pointer to current response being handled */
-    uint8_t *curr_response_data;
-    /* Number of bytes in request */
-    int curr_request_len;        // Number of bytes in current request.
-    int curr_response_len;        // Number of bytes in current response.
-    size_t remaining;              // Number of bytes remaining to dispatch.
-    bool notified;               // Flag indicating that there is more work waiting.
-    enum data_direction data_direction;                    // Data direction. 0 = write, 1 = read.
+    /* Pointer to current request/response data being handled */
+    /* Due to the way the token chain abstraction is done in the request buffer
+     * there will always be at least 1 more byte of request data then response data. */
+    uint8_t *curr_data;
+    /* Number of bytes in current request (number of tokens) */
+    int curr_request_len;
+    /* Number of bytes in current response (only the data) and not the error tokens at the start */
+    int curr_response_len;
+    /* Number of bytes remaining to dispatch in the current request.*/
+    size_t remaining;
+    /* Flag indicating that there is more independent requests waiting on the queue_handle.request. */
+    bool notified;
+
+    enum data_direction data_direction;
     /* I2C bus address of the current request being handled */
     size_t addr;
 } i2c_ifState_t;
@@ -66,18 +69,15 @@ typedef struct _i2c_ifState {
 #define REG_ADDR_SCLFILTER          (BIT(11) | BIT(12) | BIT(13))
 #define REG_ADDR_SCLDELAY_ENABLE    (BIT(28))
 
-#define MESON_I2C_TOKEN_END      (0x0)   // END: Terminator for token list, has no meaning to hardware otherwise
-#define MESON_I2C_TOKEN_START    (0x1)   // START: Begin an i2c transfer. Causes master device to capture bus.
-#define MESON_I2C_TOKEN_ADDR_WRITE    (0x2)   // ADDRESS WRITE: Used to wake up the target device on the bus. Sets up
-                                    //                any following DATA tokens to be writes.
-#define MESON_I2C_TOKEN_ADDR_READ    (0x3)   // ADDRESS READ: Same as ADDRW but sets up DATA tokens as reads.
-#define MESON_I2C_TOKEN_DATA     (0x4)   // DATA: Causes hardware to either read or write a byte to/from the read/write buffers.
-#define MESON_I2C_TOKEN_DATA_END (0x5)   // DATA_LAST: Used for read transactions to write a NACK to alert the slave device
-                                    //            that the read is now over.
-#define MESON_I2C_TOKEN_STOP     (0x6)   // STOP: Used to send the STOP condition on the bus to end a transaction.
-                                    //       Causes master to release the bus.
+#define MESON_I2C_TOKEN_END      (0x0)          // END: Terminator for token list, has no meaning to hardware otherwise
+#define MESON_I2C_TOKEN_START    (0x1)          // START: Begin an i2c transfer. Causes master device to capture bus.
+#define MESON_I2C_TOKEN_ADDR_WRITE    (0x2)     // ADDRESS WRITE: Used to wake up the target device on the bus. Sets up
+// any following DATA tokens to be writes.
+#define MESON_I2C_TOKEN_ADDR_READ    (0x3)      // ADDRESS READ: Same as ADDRW but sets up DATA tokens as reads.
+#define MESON_I2C_TOKEN_DATA     (0x4)          // DATA: Causes hardware to either read or write a byte to/from the read/write buffers.
+#define MESON_I2C_TOKEN_DATA_END (0x5)          // DATA_LAST: Used to indicate the last 8-bit byte transfer is a byte transfer of a READ
+#define MESON_I2C_TOKEN_STOP     (0x6)          // STOP: Used to send the STOP condition on the bus to end a transaction.
+// Causes master to release the bus.
 
 /* The client cannot attach or use a bus address greater than 7-bits. */
 #define MESON_I2C_MAX_BUS_ADDRESS (0x7f)
-
-#endif

--- a/drivers/i2c/meson/i2c.c
+++ b/drivers/i2c/meson/i2c.c
@@ -22,7 +22,7 @@
 #define IRQ_CH 1
 #define IRQ_TIMEOUT_CH 2
 
-// #define DEBUG_DRIVER
+//#define DEBUG_DRIVER
 
 #ifdef DEBUG_DRIVER
 #define LOG_DRIVER(...) do{ sddf_dprintf("I2C DRIVER|INFO: "); sddf_dprintf(__VA_ARGS__); }while(0)
@@ -33,14 +33,14 @@
 #define LOG_DRIVER_ERR(...) do{ sddf_printf("I2C DRIVER|ERROR: "); sddf_printf(__VA_ARGS__); }while(0)
 
 struct i2c_regs {
-    uint32_t ctl;
-    uint32_t addr;
-    uint32_t tk_list0;
-    uint32_t tk_list1;
-    uint32_t wdata0;
-    uint32_t wdata1;
-    uint32_t rdata0;
-    uint32_t rdata1;
+    uint32_t ctl;           // control register
+    uint32_t addr;          // slave address and other fields
+    uint32_t tk_list0;      // where to put the meson i2c instructions (4 bits long)
+    uint32_t tk_list1;      // where to put the meson i2c instructions (4 bits long)
+    uint32_t wdata0;        // where to put the write payload from supplied buffer
+    uint32_t wdata1;        // where to put the write payload from supplied buffer
+    uint32_t rdata0;        // where read data gets put for a response by i2c
+    uint32_t rdata1;        // where read data gets put for a response by i2c
 };
 
 // Hardware memory
@@ -56,28 +56,33 @@ i2c_queue_handle_t queue_handle;
 uintptr_t request_region;
 uintptr_t response_region;
 
-char *meson_token_to_str(uint8_t token) {
+char *meson_token_to_str(uint8_t token)
+{
     switch (token) {
-        case MESON_I2C_TOKEN_END:
-            return "MESON_I2C_TOKEN_END";
-        case MESON_I2C_TOKEN_START:
-            return "MESON_I2C_TOKEN_START";
-        case MESON_I2C_TOKEN_ADDR_WRITE:
-            return "MESON_I2C_TOKEN_ADDR_WRITE";
-        case MESON_I2C_TOKEN_ADDR_READ:
-            return "MESON_I2C_TOKEN_ADDR_READ";
-        case MESON_I2C_TOKEN_DATA:
-            return "MESON_I2C_TOKEN_DATA";
-        case MESON_I2C_TOKEN_DATA_END:
-            return "MESON_I2C_TOKEN_DATA_END";
-        case MESON_I2C_TOKEN_STOP:
-            return "MESON_I2C_TOKEN_STOP";
-        default:
-            return "Unknown token!";
+    case MESON_I2C_TOKEN_END:
+        return "MESON_I2C_TOKEN_END";
+    case MESON_I2C_TOKEN_START:
+        return "MESON_I2C_TOKEN_START";
+    case MESON_I2C_TOKEN_ADDR_WRITE:
+        return "MESON_I2C_TOKEN_ADDR_WRITE";
+    case MESON_I2C_TOKEN_ADDR_READ:
+        return "MESON_I2C_TOKEN_ADDR_READ";
+    case MESON_I2C_TOKEN_DATA:
+        return "MESON_I2C_TOKEN_DATA";
+    case MESON_I2C_TOKEN_DATA_END:
+        return "MESON_I2C_TOKEN_DATA_END";
+    case MESON_I2C_TOKEN_STOP:
+        return "MESON_I2C_TOKEN_STOP";
+    default:
+        return "Unknown token!";
     }
 }
 
-static inline void i2c_dump(volatile struct i2c_regs *regs) {
+/**
+ * Prints the registers of the i2c interface
+ */
+static inline void i2c_dump(volatile struct i2c_regs *regs)
+{
 #ifdef DEBUG_DRIVER
     LOG_DRIVER("dumping interface state...\n");
 
@@ -145,22 +150,23 @@ static inline void i2c_dump(volatile struct i2c_regs *regs) {
 /**
  * Initialise the i2c master interfaces.
 */
-static inline void i2c_setup() {
+static inline void i2c_setup()
+{
     LOG_DRIVER("initialising i2c master interfaces...\n");
 
     volatile struct i2c_regs *regs = (volatile struct i2c_regs *) i2c_regs;
 
     // Note: this is hacky - should do this using a GPIO driver.
     // Set up pinmux
-    volatile uint32_t *gpio_mem = (void*)(gpio_regs + GPIO_OFFSET);
+    volatile uint32_t *gpio_mem = (void *)(gpio_regs + GPIO_OFFSET);
 
-    volatile uint32_t *pinmux5_ptr      = ((void*)gpio_mem + GPIO_PINMUX_5*4);
+    volatile uint32_t *pinmux5_ptr      = ((void *)gpio_mem + GPIO_PINMUX_5 * 4);
     // volatile uint32_t *pinmuxE_ptr      = ((void*)gpio_mem + GPIO_PINMUX_E*4);
-    volatile uint32_t *pad_ds2b_ptr     = ((void*)gpio_mem + GPIO_DS_2B*4);
+    volatile uint32_t *pad_ds2b_ptr     = ((void *)gpio_mem + GPIO_DS_2B * 4);
     // volatile uint32_t *pad_ds5a_ptr     = ((void*)gpio_mem + GPIO_DS_5A*4);
-    volatile uint32_t *pad_bias2_ptr    = ((void*)gpio_mem + GPIO_BIAS_2_EN*4);
+    volatile uint32_t *pad_bias2_ptr    = ((void *)gpio_mem + GPIO_BIAS_2_EN * 4);
     // volatile uint32_t *pad_bias5_ptr    = ((void*)gpio_mem + GPIO_BIAS_5_EN*4);
-    volatile uint32_t *clk81_ptr        = ((void*)clk_regs + I2C_CLK_OFFSET);
+    volatile uint32_t *clk81_ptr        = ((void *)clk_regs + I2C_CLK_OFFSET);
 
     // Read existing register values
     uint32_t pinmux5 = *pinmux5_ptr;
@@ -186,11 +192,11 @@ static inline void i2c_setup() {
     // Set GPIO drive strength
     *pad_ds2b_ptr &= ~(GPIO_DS_2B_X17 | GPIO_DS_2B_X18);
     *pad_ds2b_ptr |= ((ds << GPIO_DS_2B_X17_SHIFT) |
-                    (ds << GPIO_DS_2B_X18_SHIFT));
+                      (ds << GPIO_DS_2B_X18_SHIFT));
 
     // Check register updated
     if ((*pad_ds2b_ptr & (GPIO_DS_2B_X17 | GPIO_DS_2B_X18)) != ((ds << GPIO_DS_2B_X17_SHIFT) |
-                    (ds << GPIO_DS_2B_X18_SHIFT))) {
+                                                                (ds << GPIO_DS_2B_X18_SHIFT))) {
         LOG_DRIVER_ERR("failed to set drive strength for m2!\n");
     }
 
@@ -215,11 +221,11 @@ static inline void i2c_setup() {
     // Set GPIO drive strength
     *pad_ds5a_ptr &= ~(GPIO_DS_5A_A14 | GPIO_DS_5A_A15);
     *pad_ds5a_ptr |= ((ds << GPIO_DS_5A_A14_SHIFT) |
-                    (ds << GPIO_DS_5A_A15_SHIFT));
+                      (ds << GPIO_DS_5A_A15_SHIFT));
 
     // Check register updated
     if ((*pad_ds5a_ptr & (GPIO_DS_5A_A14 | GPIO_DS_5A_A15)) != ((ds << GPIO_DS_5A_A14_SHIFT) |
-                    (ds << GPIO_DS_5A_A15_SHIFT))) {
+                                                                (ds << GPIO_DS_5A_A15_SHIFT))) {
         LOG_DRIVER_ERR("failed to set drive strength for m3!\n");
     }
 
@@ -252,7 +258,7 @@ static inline void i2c_setup() {
     * According to I2C-BUS Spec 2.1, in FAST-MODE, LOW period should be at
     * least 1.3uS, and HIGH period should be at lease 0.6. HIGH to LOW
     * ratio as 2 to 5 is more safe.
-    * Duty  = H/(H + L) = 2/5	-- duty 40%%   H/L = 2/3
+    * Duty  = H/(H + L) = 2/5   -- duty 40%%   H/L = 2/3
     * Fast Mode : 400k
     * High Mode : 3400k
     */
@@ -260,8 +266,8 @@ static inline void i2c_setup() {
     // const uint32_t freq = 400000; // 400kHz
     // const uint32_t delay_adjust = 0;
     // uint32_t div_temp = (clk_rate * 2)/(freq * 5);
-	// uint32_t div_h = div_temp - delay_adjust;
-	// uint32_t div_l = (clk_rate * 3)/(freq * 10);
+    // uint32_t div_h = div_temp - delay_adjust;
+    // uint32_t div_l = (clk_rate * 3)/(freq * 10);
 
     // Duty cycle slightly high with this - should adjust (47% instead of 40%)
     // TODO: add clock driver logic here to dynamically set speed. This is a hack.
@@ -292,23 +298,25 @@ static inline void i2c_setup() {
 }
 
 /**
- * Given a bus number, retrieve the error code stored in the control register
- * associated.
- * @param bus i2c EE-domain master interface to check
- * @return int error number - non-negative numbers are a success with n. bytes read / 0 if writing,
- *         while a negative value corresponds to a bus NACK at a token of value -(ret).
- *         e.g. if NACK on a ADDRW (0x3) the return value will be -3.
+ * Given a bus interface, retrieve the error code stored in the control register associated.
+ * Also gets bytes read and curr token (curr token can be used to find the error location)
+ * @return error bit - if the i2c device generates a NACK during writing
  */
-static inline int i2c_get_error(volatile struct i2c_regs *regs, uint8_t *bytes_read, uint8_t *curr_token) {
+static inline bool i2c_get_error(volatile struct i2c_regs *regs, uint8_t *bytes_read, uint8_t *curr_token)
+{
     volatile uint32_t ctl = regs->ctl;
-    uint8_t err = ctl & (1 << 3);   // bit 3 -> set if error
-    *bytes_read = (ctl & 0xF00) >> 8; // bits 8-11 -> number of bytes read
+    bool err = ctl & (1 << 3);   // bit 3 -> set if error
+    *bytes_read = (ctl & 0xF00) >> 8; // bits 8-11 -> number of bytes to read from rdata registers
     *curr_token = (ctl & 0xF0) >> 4; // bits 4-7 -> curr token
 
     return err;
 }
 
-static inline int i2c_start(volatile struct i2c_regs *regs) {
+/**
+ * Restarts the list processor
+ */
+static inline int i2c_start(volatile struct i2c_regs *regs)
+{
     LOG_DRIVER("LIST PROCESSOR START\n");
     regs->ctl &= ~0x1;
     regs->ctl |= 0x1;
@@ -319,7 +327,11 @@ static inline int i2c_start(volatile struct i2c_regs *regs) {
     return 0;
 }
 
-static inline int i2c_halt(volatile struct i2c_regs *regs) {
+/**
+ * Aborts the current operation by generating an I2C STOP command on the I2C bus
+ */
+static inline int i2c_halt(volatile struct i2c_regs *regs)
+{
     LOG_DRIVER("LIST PROCESSOR HALT\n");
     regs->ctl &= ~0x1;
     if ((regs->ctl & 0x1)) {
@@ -329,66 +341,50 @@ static inline int i2c_halt(volatile struct i2c_regs *regs) {
     return 0;
 }
 
-static inline int i2c_flush(volatile struct i2c_regs *regs) {
-    LOG_DRIVER("LIST PROCESSOR FLUSH\n");
-    // Clear token list
-    regs->tk_list0 = 0x0;
-    regs->tk_list1 = 0x0;
-
-    // // Clear wdata
-    // regs->wdata0 = 0x0;
-    // regs->wdata1 = 0x0;
-
-    // // Clear rdata
-    // regs->rdata0 = 0x0;
-    // regs->rdata1 = 0x0;
-
-    // // Clear address
-    // regs->addr = 0x0;
-    return 0;
-}
-
-static inline uint8_t i2c_token_convert(i2c_token_t token) {
+/**
+ * Converts our token abstraction into meson compatible tokens
+ */
+static inline uint8_t i2c_token_convert(i2c_token_t token)
+{
     switch (token) {
-        case I2C_TOKEN_END:
-            return MESON_I2C_TOKEN_END;
-        case I2C_TOKEN_START:
-            return MESON_I2C_TOKEN_START;
-        case I2C_TOKEN_ADDR_WRITE:
-            i2c_ifState.data_direction = DATA_DIRECTION_WRITE;
-            return MESON_I2C_TOKEN_ADDR_WRITE;
-        case I2C_TOKEN_ADDR_READ:
-            i2c_ifState.data_direction = DATA_DIRECTION_READ;
-            return MESON_I2C_TOKEN_ADDR_READ;
-        case I2C_TOKEN_DATA:
-            return MESON_I2C_TOKEN_DATA;
-        case I2C_TOKEN_DATA_END:
-            return MESON_I2C_TOKEN_DATA_END;
-        case I2C_TOKEN_STOP:
-            return MESON_I2C_TOKEN_STOP;
-        default:
-            LOG_DRIVER_ERR("invalid data token in request! \"0x%x\"\n", token);
-            return -1;
+    case I2C_TOKEN_END:
+        return MESON_I2C_TOKEN_END;
+    case I2C_TOKEN_START:
+        return MESON_I2C_TOKEN_START;
+    case I2C_TOKEN_ADDR_WRITE:
+        i2c_ifState.data_direction = DATA_DIRECTION_WRITE;
+        return MESON_I2C_TOKEN_ADDR_WRITE;
+    case I2C_TOKEN_ADDR_READ:
+        i2c_ifState.data_direction = DATA_DIRECTION_READ;
+        return MESON_I2C_TOKEN_ADDR_READ;
+    case I2C_TOKEN_DATA:
+        return MESON_I2C_TOKEN_DATA;
+    case I2C_TOKEN_DATA_END:
+        return MESON_I2C_TOKEN_DATA_END;
+    case I2C_TOKEN_STOP:
+        return MESON_I2C_TOKEN_STOP;
+    default:
+        LOG_DRIVER_ERR("invalid data token in request! \"0x%x\"\n", token);
+        return -1;
     }
 }
 
-static inline bool i2c_load_tokens(volatile struct i2c_regs *regs) {
+/**
+ * Loads tokens onto specified i2c interface registers
+ * This function resets interface registers before uploading data
+ */
+static inline void i2c_load_tokens(volatile struct i2c_regs *regs)
+{
     LOG_DRIVER("starting token load\n");
-    i2c_token_t *tokens = i2c_ifState.curr_request_data;
+    i2c_token_t *tokens = i2c_ifState.curr_data;
     LOG_DRIVER("Tokens remaining in this req: %zu\n", i2c_ifState.remaining);
-
-    /* Check that a valid address on the I2C bus was passed in */
-    if (i2c_ifState.addr > MESON_I2C_MAX_BUS_ADDRESS) {
-        LOG_DRIVER_ERR("attempted to write to address > 7-bit range!\n");
-        return false;
-    }
-
-    i2c_flush(regs);
 
     // Load address into address register
     // Address goes into low 7 bits of address register
-    regs->addr &= ~(0x7f);
-    regs->addr = regs->addr | ((i2c_ifState.addr & 0x7f) << 1);  // i2c hardware expects that the 7-bit address is shifted left by 1
+    // First clear all address bits (bits 0:7 inclusive)
+    regs->addr &= ~(0xff);
+    // Device expects that the 7-bit address is shifted left by 1 bit
+    regs->addr |= ((i2c_ifState.addr & 0x7f) << 1);
 
     LOG_DRIVER("regs->addr 0x%lx\n", regs->addr);
 
@@ -398,33 +394,32 @@ static inline bool i2c_load_tokens(volatile struct i2c_regs *regs) {
     regs->wdata0 = 0x0;
     regs->wdata1 = 0x0;
 
-    // Offset into token registers
+    // Offset into token list registers
     uint32_t tk_offset = 0;
 
     // Offset into wdata registers
-    uint32_t wdat_offset = 0;
+    uint32_t wdata_offset = 0;
 
     // Offset into rdata registers
     uint32_t rdata_offset = 0;
 
     // Offset into supplied buffer
-    int i = i2c_ifState.curr_request_len - i2c_ifState.remaining;
-    while (tk_offset < 16 && wdat_offset < 8 && rdata_offset < 8) {
-        LOG_DRIVER("i is 0x%lx, tk_offset: 0x%lx, wdat_offset: 0x%lx, rdat_offset\n", i, tk_offset, wdat_offset, rdata_offset);
-        // Explicitly pad END tokens for empty space
-        if (i >= i2c_ifState.curr_request_len) {
-            if (tk_offset < 8) {
-                regs->tk_list0 |= (MESON_I2C_TOKEN_END << (tk_offset * 4));
-            } else {
-                regs->tk_list1 = regs->tk_list1 | (MESON_I2C_TOKEN_END << ((tk_offset % 8) * 4));
-            }
-            tk_offset++;
-            i++;
-            continue;
-        }
+    int request_data_offset = i2c_ifState.curr_request_len - i2c_ifState.remaining;
 
-        /* Get the SoC specific token */
-        uint8_t meson_token = i2c_token_convert(tokens[i]);
+    // basically loops all available space in the registers until one has not more room or request is finished and in the process:
+    // - add meson_token equivalent to token list register
+    // - if read or write increment wdata or rdata offset
+    // - if write add buffer data into wdata
+    // It should be noted that we do not explicitly add the MESON_I2C_TOKEN_END to the token list register as
+    // we have already cleared the registers and it has a value of zero.
+
+    while (tk_offset < 16 && wdata_offset < 8 && rdata_offset < 8 && request_data_offset < i2c_ifState.curr_request_len) {
+        // Get the SoC specific token
+        uint8_t meson_token = i2c_token_convert(tokens[request_data_offset]);
+
+        LOG_DRIVER("meson_token: 0x%lx, request_data_offset : 0x%lx, tk_offset: 0x%lx, wdata_offset: 0x%lx, rdata_offset: 0x%lx\n",
+                   meson_token, request_data_offset, tk_offset, wdata_offset, rdata_offset);
+
 
         if (tk_offset < 8) {
             regs->tk_list0 |= (meson_token << (tk_offset * 4));
@@ -435,44 +430,49 @@ static inline bool i2c_load_tokens(volatile struct i2c_regs *regs) {
 
         // If data token and we are writing, load data into wbuf registers
         if (meson_token == MESON_I2C_TOKEN_DATA && i2c_ifState.data_direction == DATA_DIRECTION_WRITE) {
-            if (wdat_offset < 4) {
-                regs->wdata0 = regs->wdata0 | (tokens[2 + i + 1] << (wdat_offset * 8));
-                wdat_offset++;
+            // the + 1 is because tokens[request_data_offset] = MESON_I2C_TOKEN_DATA but we want to store the token the come after
+            if (wdata_offset < 4) {
+                regs->wdata0 |= (tokens[request_data_offset + 1] << (wdata_offset *
+                                                                     8));
             } else {
-                regs->wdata1 = regs->wdata1 | (tokens[2 + i + 1] << ((wdat_offset - 4) * 8));
-                wdat_offset++;
+                regs->wdata1 |= (tokens[request_data_offset + 1] << ((wdata_offset - 4) *
+                                                                     8));
             }
             // Since we grabbed the next token in the chain, increment offset
-            i++;
+            wdata_offset++;
+            /* Skip over I2C_TOKEN_DATA token */
+            request_data_offset++;
         }
 
         /* If data token and we are reading, increment counter of rdata */
-        if (meson_token == MESON_I2C_TOKEN_DATA && i2c_ifState.data_direction == DATA_DIRECTION_READ) {
+        if ((meson_token == MESON_I2C_TOKEN_DATA || meson_token == MESON_I2C_TOKEN_DATA_END)
+            && i2c_ifState.data_direction == DATA_DIRECTION_READ) {
             rdata_offset++;
         }
 
-        i++;
+        request_data_offset++;
     }
+    LOG_DRIVER("data loaded into registers!!\n");
+    LOG_DRIVER("request_data_offset : 0x%lx, tk_offset: 0x%lx, wdata_offset: 0x%lx, rdata_offset: 0x%lx\n",
+               request_data_offset, tk_offset, wdata_offset, rdata_offset);
 
-    // Data loaded. Update remaining tokens indicator and start list processor
-    i2c_ifState.remaining = (i2c_ifState.curr_request_len - i > 0)
-                                 ? i2c_ifState.curr_request_len - i : 0;
+    // Update remaining tokens indicator and start list processor
+    i2c_ifState.remaining = i2c_ifState.curr_request_len - request_data_offset;
 
     LOG_DRIVER("Tokens loaded. %zu remain for this request\n", i2c_ifState.remaining);
     i2c_dump(regs);
+
     // Start list processor
     i2c_start(regs);
-
-    return true;
 }
 
-void init(void) {
+void init(void)
+{
     i2c_setup();
     queue_handle = i2c_queue_init((i2c_queue_t *) request_region, (i2c_queue_t *) response_region);
-    // i2cTransportInit(0);
+
     // Set up driver state
-    i2c_ifState.curr_request_data = NULL;
-    i2c_ifState.curr_response_data = NULL;
+    i2c_ifState.curr_data = NULL;
     i2c_ifState.curr_request_len = 0;
     i2c_ifState.curr_response_len = 0;
     i2c_ifState.remaining = 0;
@@ -482,20 +482,20 @@ void init(void) {
     microkit_dbg_puts("Driver initialised.\n");
 }
 
-static inline void handle_request(void) {
+static inline void handle_request(void)
+{
     LOG_DRIVER("handling request\n");
     volatile struct i2c_regs *regs = (volatile struct i2c_regs *) i2c_regs;
     if (!i2c_queue_empty(queue_handle.request)) {
         // If this interface is busy, skip notification and
         // set notified flag for later processing
-        if (i2c_ifState.curr_request_data) {
-            microkit_dbg_puts("driver: request in progress, deferring notification\n");
+        if (i2c_ifState.curr_data) {
+            LOG_DRIVER("driver: request in progress, deferring notification until later\n");
             i2c_ifState.notified = 1;
             return;
         }
-        // microkit_dbg_puts("driver: starting work for bus\n");
-        // Otherwise, begin work. Start by extracting the request
 
+        // Otherwise, begin work. Start by extracting the request
         size_t bus_address = 0;
         size_t offset = 0;
         unsigned int size = 0;
@@ -505,23 +505,23 @@ static inline void handle_request(void) {
             return;
         }
 
-        // Load bookkeeping data into return buffer
-        // Set client PD
-
-        LOG_DRIVER("Loading request from client %u to address 0x%x of sz %zu\n", req[0], req[1], size);
-
         if (size > I2C_MAX_DATA_SIZE) {
             LOG_DRIVER_ERR("Invalid request size: %u!\n", size);
             return;
         }
-        i2c_ifState.curr_request_data = (i2c_token_t *) DATA_REGIONS_START + offset;
+        if (bus_address > MESON_I2C_MAX_BUS_ADDRESS) {
+            LOG_DRIVER_ERR("attempted to write to address > 7-bit range!\n");
+            return;
+        }
+
+        LOG_DRIVER("Loading request for bus address 0x%x of size %zu\n", bus_address, size);
+
+        i2c_ifState.curr_data = (i2c_token_t *) DATA_REGIONS_START + offset;
         i2c_ifState.addr = bus_address;
         i2c_ifState.curr_request_len = size;
-        i2c_ifState.remaining = size;    // Ignore client PD and address
+        i2c_ifState.remaining = size;
         i2c_ifState.notified = 0;
 
-        // Trigger work start
-        // @ivanv: check return value
         i2c_load_tokens(regs);
     } else {
         LOG_DRIVER("called but no work available: resetting notified flag\n");
@@ -530,141 +530,131 @@ static inline void handle_request(void) {
     }
 }
 
-/**
- * IRQ handler for an i2c interface.
- * @param timeout Whether the IRQ was triggered by a timeout. 0 if not, 1 if so.
-*/
-static void handle_irq(bool timeout) {
+/* Right now we do not do anything to handle a response timeout, even though we should
+ * be. More investigation is required.
+ * We observed very frequent timeout IRQs in our example system using an I2C card reader,
+ * we believe the source of this problem is a misconfiguration with the clocks, and will
+ * hopefully be resovled once we have an actual clock driver.
+ * See https://github.com/au-ts/sddf/issues/212 for more details.
+ */
+static void handle_response_timeout(void)
+{
+    LOG_DRIVER("handling timeout IRQ\n");
+    return;
+}
+
+
+static void handle_response(void)
+{
+    LOG_DRIVER("handling transfer complete IRQ\n");
     volatile struct i2c_regs *regs = (volatile struct i2c_regs *)i2c_regs;
 
-    if (timeout) {
-        LOG_DRIVER("handling timeout IRQ\n");
-    } else {
-        // @ivanv: not sure if completion IRQ is the right term
-        LOG_DRIVER("handling completion IRQ\n");
-    }
-    // printf("notified = %d\n", i2c_ifState.notified);
-
-    if (timeout) {
-        return;
-    }
-
-    // IRQ landed: i2c transaction has either completed or timed out.
-    // if (timeout) {
-    //     i2c_halt();
-    //     if (i2c_ifState.curr_reseponse_data) {
-    //         i2c_ifState.curr_reseponse_data[RESPONSE_ERR] = I2C_ERR_TIMEOUT;
-    //         i2c_ifState.curr_reseponse_data[RESPONSE_ERR_TOKEN] = 0x0;
-    //         pushRetBuf(i2c_ifState.curr_reseponse_data, i2c_ifState.curr_request_len);
-    //         // @ivanv: not sure whether or not we should be notifying here
-    //         // microkit_notify(SERVER_NOTIFY_ID);
-    //     }
-    //     if (i2c_ifState.curr_request_data) {
-    //         releaseReqBuf(i2c_ifState.curr_request_data);
-    //     }
-    //     // i2c_ifState.curr_reseponse_data = NULL;
-    //     // i2c_ifState.curr_request_data = 0x0;
-    //     // i2c_ifState.curr_request_len = 0;
-    //     // i2c_ifState.remaining = 0;
-    //     return;
-    // }
-
     i2c_dump(regs);
-    i2c_halt(regs);
 
     // Get result
     uint8_t curr_token = 0;
     uint8_t bytes_read = 0;
-    uint8_t error = i2c_get_error(regs, &bytes_read, &curr_token);
-    // If error is 0, successful write. If error >0, successful read of err bytes.
+    bool write_error = i2c_get_error(regs, &bytes_read, &curr_token);
+
     // Prepare to extract data from the interface.
-    i2c_token_t *ret = i2c_ifState.curr_request_data;
+    // Due to the way the token chain abstraction is done in the request buffer there will always be
+    // at least 1 more byte of request data then response data.
+    i2c_token_t *return_buffer = i2c_ifState.curr_data;
 
     // If there was an error, cancel the rest of this transaction and load the
     // error information into the return buffer.
-    if (error) {
+    if (write_error) {
         LOG_DRIVER("error!\n");
-        if (timeout) {
-            ret[RESPONSE_ERR] = I2C_ERR_TIMEOUT;
-        } else if (curr_token == I2C_TOKEN_ADDR_READ) {
-            ret[RESPONSE_ERR] = I2C_ERR_NOREAD;
+        // handle_response_timeout already has error logic for timeout
+        if (curr_token == I2C_TOKEN_ADDR_READ) {
+            return_buffer[RESPONSE_ERR] = I2C_ERR_NOREAD;
+            LOG_DRIVER("I2C_ERR_NOREAD!\n");
         } else {
-            ret[RESPONSE_ERR] = I2C_ERR_NACK;
+            return_buffer[RESPONSE_ERR] = I2C_ERR_NACK;
+            LOG_DRIVER("I2C_ERR_NACK!\n");
         }
         // Token that caused the error
-        ret[RESPONSE_ERR_TOKEN] = curr_token;
+        return_buffer[RESPONSE_ERR_TOKEN] = curr_token;
+        LOG_DRIVER("token that caused error: %d!\n", curr_token);
+
     } else {
-        // Get read data
+        // Get bytes_read amount of read data
+
         // Copy data into return buffer
         for (int i = 0; i < bytes_read; i++) {
             size_t index = RESPONSE_DATA_OFFSET + i2c_ifState.curr_response_len;
             if (i < 4) {
                 uint8_t value = (regs->rdata0 >> (i * 8)) & 0xFF;
-                ret[index] = value;
-                LOG_DRIVER("loading into ret at %d value 0x%lx\n", index, value);
+                return_buffer[index] = value;
+                LOG_DRIVER("loading into return_buffer at %d value 0x%lx\n", index, value);
             } else if (i < 8) {
                 uint8_t value = (regs->rdata1 >> ((i - 4) * 8)) & 0xFF;
-                ret[index] = value;
-                LOG_DRIVER("loading into ret at %d value 0x%lx\n", index, value);
+                return_buffer[index] = value;
+                LOG_DRIVER("loading into return_buffer at %d value 0x%lx\n", index, value);
             }
             i2c_ifState.curr_response_len++;
         }
 
         LOG_DRIVER("I2C_ERR_OK\n");
-        ret[RESPONSE_ERR] = I2C_ERR_OK;    // Error code
-        ret[RESPONSE_ERR_TOKEN] = 0x0;        // Token that caused error
+        return_buffer[RESPONSE_ERR] = I2C_ERR_OK;
+        // Token that caused error (could be anything since we set error code to no error anyway)
+        return_buffer[RESPONSE_ERR_TOKEN] = 0x0;
     }
 
     // If request is completed or there was an error, return data to server and notify.
-    if (error || !i2c_ifState.remaining) {
-        LOG_DRIVER("request completed or error, returning to server\n");
-        LOG_DRIVER("pushing return buffer with addr 0x%lx and size 0x%lx\n", ret, i2c_ifState.curr_request_len);
-
-        // @alwin: why is size here curr_request_len and not curr_response_len?
-        int ret = i2c_enqueue_response(queue_handle, i2c_ifState.addr, (size_t) i2c_ifState.curr_request_data - DATA_REGIONS_START, i2c_ifState.curr_request_len);
+    if (write_error || !i2c_ifState.remaining) {
+        LOG_DRIVER("request completed or error, hence returning response to server\n");
+        LOG_DRIVER("curr_response_len : 0x%lx, curr_request_len : 0x%lx, return address is 0x%lx\n",
+                   i2c_ifState.curr_response_len, i2c_ifState.curr_request_len, i2c_ifState.addr);
+        LOG_DRIVER("enguing response with size: %d\n\n", i2c_ifState.curr_response_len + RESPONSE_DATA_OFFSET);
+        // response length is + 2 (RESPONSE_DATA_OFFSET = 2) because of the error tokens at the start
+        int ret = i2c_enqueue_response(queue_handle, i2c_ifState.addr,
+                                       (size_t) i2c_ifState.curr_data - DATA_REGIONS_START,
+                                       i2c_ifState.curr_response_len + RESPONSE_DATA_OFFSET);
         if (ret) {
             LOG_DRIVER_ERR("Failed to enqueue response\n");
         }
-        i2c_ifState.curr_response_data = NULL;
+
+        // reset driver state for another request
+        // load tokens resets the interface registers so no need here
         i2c_ifState.curr_response_len = 0;
-        i2c_ifState.curr_request_data = 0x0;
+        i2c_ifState.curr_data = NULL;
         i2c_ifState.curr_request_len = 0;
         i2c_ifState.remaining = 0;
+        i2c_ifState.addr = 0;
+
         microkit_notify(VIRTUALISER_CH);
-        // Reset hardware
-        i2c_halt(regs);
+
+        i2c_halt(regs); // stop condition
     }
 
     // If the driver was notified while this transaction was in progress, immediately start working on the next one.
-    // OR if there is still work to do, crack on with it.
-    // NOTE: this incurs more stack depth than needed; could use flag instead?
-    if (i2c_ifState.notified || i2c_ifState.remaining) {
-        if (i2c_ifState.notified) {
-            LOG_DRIVER("notified while processing IRQ, starting next request\n");
-        } else {
-            LOG_DRIVER("still work to do, starting next batch\n");
-        }
-        // @ivanv: check return value
-        i2c_load_tokens(regs);
+    // OR if there is still more work to do in current request, crack on with it.
+    if (i2c_ifState.remaining) {
+        LOG_DRIVER("Still work to do, starting next batch of tokens in request\n");
+        i2c_load_tokens(regs); // results in a repeated start condition
+    } else if (i2c_ifState.notified) {
+        LOG_DRIVER("Was notified during transaction. Starting next client request immediately!\n");
+        handle_request();
     }
-    LOG_DRIVER("END OF IRQ HANDLER - notified=%d\n", i2c_ifState.notified);
 }
 
-void notified(microkit_channel ch) {
+void notified(microkit_channel ch)
+{
     switch (ch) {
-        case VIRTUALISER_CH:
-            handle_request();
-            break;
-        case IRQ_CH:
-            handle_irq(false);
-            microkit_irq_ack(ch);
-            break;
-        case IRQ_TIMEOUT_CH:
-            handle_irq(true);
-            microkit_irq_ack(ch);
-            break;
+    case VIRTUALISER_CH:
+        handle_request();
+        break;
+    case IRQ_CH:
+        handle_response();
+        microkit_irq_ack(ch);
+        break;
+    case IRQ_TIMEOUT_CH:
+        handle_response_timeout();
+        microkit_irq_ack(ch);
+        break;
 
-        default:
-            microkit_dbg_puts("DRIVER|ERROR: unexpected notification!\n");
+    default:
+        microkit_dbg_puts("DRIVER|ERROR: unexpected notification!\n");
     }
 }

--- a/drivers/i2c/meson/i2c_driver.mk
+++ b/drivers/i2c/meson/i2c_driver.mk
@@ -17,10 +17,10 @@
 
 I2C_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-i2c_driver.elf: i2c/i2c_driver.o 
+i2c_driver.elf: i2c/i2c_driver.o
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
-i2c/i2c_driver.o: CFLAGS+=-I${I2C_DRIVER_DIR} -DI2C_BUS_NUM=${I2C_BUS_NUM} 
+i2c/i2c_driver.o: CFLAGS+=-I${I2C_DRIVER_DIR} -DI2C_BUS_NUM=${I2C_BUS_NUM}
 i2c/i2c_driver.o: ${I2C_DRIVER_DIR}/i2c.c |i2c
 	${CC} ${CFLAGS} -c -o $@ $<
 

--- a/examples/i2c/README.md
+++ b/examples/i2c/README.md
@@ -6,15 +6,16 @@
 
 # I<sup>2</sup>C example
 
-This example makes use of the NXP PN532 card-reader. This example was developed and tested using
-the PN532 NFC RFID Module V3. Documentation on the card-reader itself can be found
-on the [NXP website](https://www.nxp.com/docs/en/user-guide/141520.pdf).
+This example makes use of the DS3231 RTC and NXP PN532 card-reader.
+Documentation and more specific infomation about each can be found below.
 
 This example is intended to run on an Odroid-C4 using the I2C connected via GPIO pins 3 and 5
 for SDA and SCL respectively.
 
-The client code for dealing with the card-reader is based on an Arduino PN532 library, it can
-be found [here](https://github.com/elechouse/PN532/).
+## Before compiling
+
+The I2C virtualiser (currently) hard-codes the number of clients and so depending on the configuration
+of the system, you may have to change `sddf/i2c/components/virt.c`.
 
 ## Building
 
@@ -36,13 +37,12 @@ zig build -Dsdk=/path/to/sdk -Dboard=odroidc4
 
 The final bootable image will be in `zig-out/bin/loader.img`.
 
-## Running
+## Running PN532
+Make sure PN_532_ON is defined.
 
 Running the example will show the following output after the system has booted:
 ```
-PN532|ERROR: read_response - length was less than zero
 CLIENT|ERROR: Timed out waiting for a card
-PN532|ERROR: read_response - length was less than zero
 CLIENT|ERROR: Timed out waiting for a card
 ```
 
@@ -57,7 +57,52 @@ UID Length: 4 bytes
 UID Value:  0x9c 0x1b 0xb4 0x1
 ```
 
-where the card UID is being read and printed out.
+Where the card UID is being read and printed out.
 
 Note that for MiFare Ultra Light cards or cards that have encryption, you may
 see timeouts between each UID card read, this is expected.
+
+**There is a video in this directory of the card reader working.**
+
+## Running DS3231
+Make sure DS_3231_ON is defined.
+
+Running the example will show the following output after the system has booted:
+```
+Set Date and Time on DS3231 to: 31-12-23 23:59:40 (Sunday)
+Date and Time: 31-12-23 23:59:40 (Sunday)
+Date and Time: 31-12-23 23:59:40 (Sunday)
+Date and Time: 31-12-23 23:59:41 (Sunday)
+Date and Time: 31-12-23 23:59:41 (Sunday)
+Date and Time: 31-12-23 23:59:42 (Sunday)
+Date and Time: 31-12-23 23:59:42 (Sunday)
+```
+
+## Running DS3231 and PN532
+
+Running the example will show similar to the following output after the system has booted:
+Basically it is a mix between output from the PN532 and the DS3231:
+
+```
+Set Date and Time on DS3231 to: 31-12-23 23:59:42 (Sunday)
+Date and Time: 31-12-23 23:59:42 (Sunday)
+Date and Time: 31-12-23 23:59:42 (Sunday)
+CLIENT|ERROR: Timed out waiting for a card
+Date and Time: 31-12-23 23:59:43 (Sunday)
+Date and Time: 31-12-23 23:59:43 (Sunday)
+CLIENT|ERROR: Timed out waiting for a card
+Date and Time: 31-12-23 23:59:44 (Sunday)
+Date and Time: 31-12-23 23:59:44 (Sunday)
+UID Length: 7 bytes
+UID Value:  0x4 0x4d 0x27 0x8a 0x25 0x10 0x90
+Date and Time: 31-12-23 23:59:45 (Sunday)
+Date and Time: 31-12-23 23:59:45 (Sunday)
+CLIENT|ERROR: Timed out waiting for a card
+Date and Time: 31-12-23 23:59:46 (Sunday)
+Date and Time: 31-12-23 23:59:46 (Sunday)
+UID Length: 7 bytes
+UID Value:  0x4 0x4d 0x27 0x8a 0x25 0x10 0x90
+Date and Time: 31-12-23 23:59:47 (Sunday)
+Date and Time: 31-12-23 23:59:47 (Sunday)
+CLIENT|ERROR: Timed out waiting for a card
+```

--- a/examples/i2c/board/odroidc4/i2c.system
+++ b/examples/i2c/board/odroidc4/i2c.system
@@ -15,14 +15,22 @@
     <memory_region name="i2c_bus" size="0x1000" phys_addr="0xFFD1D000"/>
 
     <!--
-	 This system transfers minimal data over I2C and so a data region size of
-	 0x1000 is more than enough for our use-case.
+	    This system transfers minimal data over I2C and so a data region size of
+        0x1000 is more than enough for our use-case.
     -->
-    <memory_region name="client_request_region" size="0x1_000"/>
-    <memory_region name="client_response_region" size="0x1_000"/>
+
+    <memory_region name="client_ds3231_request_region" size="0x1_000"/>
+    <memory_region name="client_ds3231_response_region" size="0x1_000"/>
+
+    <memory_region name="client_pn532_request_region" size="0x1_000"/>
+    <memory_region name="client_pn532_response_region" size="0x1_000"/>
+
     <memory_region name="driver_request_region" size="0x1_000"/>
     <memory_region name="driver_response_region" size="0x1_000"/>
-    <memory_region name="data_region" size="0x1_000"/>
+
+    <memory_region name="client_ds3231_data_region" size="0x1_000"/>
+    <memory_region name="client_pn532_data_region" size="0x1_000"/>
+
 
     <memory_region name="timer_registers" size="0x1000" phys_addr="0xffd0f000" />
 
@@ -37,7 +45,9 @@
         <map mr="gpio" vaddr="0x3_100_000" perms="rw" setvar_vaddr="gpio_regs" cached="false" />
         <map mr="clk" vaddr="0x3_200_000" perms="rw" setvar_vaddr="clk_regs" cached="false" />
 
-        <map mr="data_region" vaddr="0x10_000_000" perms="rw" />
+        <map mr="client_ds3231_data_region" vaddr="0x10_000_000" perms="rw" />
+        <map mr="client_pn532_data_region" vaddr="0x10_001_000" perms="rw" />
+
 
         <!-- IRQs for the particular I2C bus we are using -->
         <!-- Main interrupt -->
@@ -49,19 +59,30 @@
     <protection_domain name="virt" priority="99" pp="true">
         <program_image path="i2c_virt.elf" />
 
-        <map mr="client_request_region" vaddr="0x4_000_000" perms="rw" />
-        <map mr="client_response_region" vaddr="0x5_000_000" perms="rw" />
+        <map mr="client_ds3231_request_region" vaddr="0x4_000_000" perms="rw" />
+        <map mr="client_ds3231_response_region" vaddr="0x5_000_000" perms="rw" />
+
+        <map mr="client_pn532_request_region" vaddr="0x4_001_000" perms="rw" />
+        <map mr="client_pn532_response_region" vaddr="0x5_001_000" perms="rw" />
 
         <map mr="driver_request_region" vaddr="0x6_000_000" perms="rw" setvar_vaddr="driver_request_region" />
         <map mr="driver_response_region" vaddr="0x7_000_000" perms="rw" setvar_vaddr="driver_response_region" />
     </protection_domain>
 
-    <protection_domain name="client" priority="1">
-        <program_image path="client.elf" />
+    <protection_domain name="client_ds3231" priority="1">
+        <program_image path="client_ds3231.elf" />
 
-        <map mr="client_request_region" vaddr="0x4_000_000" perms="rw" setvar_vaddr="request_region" />
-        <map mr="client_response_region" vaddr="0x5_000_000" perms="rw" setvar_vaddr="response_region" />
-        <map mr="data_region" vaddr="0x6_000_000" perms="rw" setvar_vaddr="data_region" />
+        <map mr="client_ds3231_request_region" vaddr="0x4_000_000" perms="rw" setvar_vaddr="request_region" />
+        <map mr="client_ds3231_response_region" vaddr="0x5_000_000" perms="rw" setvar_vaddr="response_region" />
+        <map mr="client_ds3231_data_region" vaddr="0x6_000_000" perms="rw" setvar_vaddr="data_region" />
+    </protection_domain>
+
+    <protection_domain name="client_pn532" priority="1">
+        <program_image path="client_pn532.elf" />
+
+        <map mr="client_pn532_request_region" vaddr="0x4_000_000" perms="rw" setvar_vaddr="request_region" />
+        <map mr="client_pn532_response_region" vaddr="0x5_000_000" perms="rw" setvar_vaddr="response_region" />
+        <map mr="client_pn532_data_region" vaddr="0x6_000_000" perms="rw" setvar_vaddr="data_region" />
     </protection_domain>
 
     <protection_domain name="timer" priority="254" pp="true" passive="true">
@@ -71,17 +92,27 @@
     </protection_domain>
 
     <channel>
-        <end pd="client" id="0" />
+        <end pd="client_ds3231" id="0" />
         <end pd="virt" id="0" />
     </channel>
 
     <channel>
-        <end pd="driver" id="0" />
+        <end pd="client_pn532" id="0" />
         <end pd="virt" id="1" />
     </channel>
 
     <channel>
+        <end pd="driver" id="0" />
+        <end pd="virt" id="2" />
+    </channel>
+
+    <channel>
+        <end pd="timer" id="2" />
+        <end pd="client_ds3231" id="1" />
+    </channel>
+
+    <channel>
         <end pd="timer" id="1" />
-        <end pd="client" id="1" /> <!-- Should this number change, so should TIMER_CH in timer.h -->
+        <end pd="client_pn532" id="1" />
     </channel>
 </system>

--- a/examples/i2c/client_ds3231.c
+++ b/examples/i2c/client_ds3231.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <microkit.h>
+#include <libco.h>
+#include <sddf/util/printf.h>
+#include <sddf/timer/client.h>
+#include <sddf/i2c/queue.h>
+#include <sddf/i2c/client.h>
+#include <sddf/i2c/devices/ds3231/ds3231.h>
+#include "client.h"
+
+// #define DEBUG_CLIENT
+
+#ifdef DEBUG_CLIENT
+#define LOG_CLIENT(...) do{ sddf_dprintf("DS3231_CLIENT|INFO: "); sddf_printf(__VA_ARGS__); }while(0)
+#else
+#define LOG_CLIENT(...) do{}while(0)
+#endif
+#define LOG_CLIENT_ERR(...) do{ sddf_printf("DS3231_CLIENT|ERROR: "); sddf_printf(__VA_ARGS__); }while(0)
+
+
+#define DS_3231_ON
+
+#ifdef DS_3231_ON
+#define USING_HALT(...) do{}while(0)
+#else
+#define USING_HALT(...) do{ while(1); }while(0)
+#endif
+
+uintptr_t data_region;
+uintptr_t request_region;
+uintptr_t response_region;
+i2c_queue_handle_t queue;
+
+cothread_t t_event;
+cothread_t t_main;
+
+#define DEFAULT_READ_RESPONSE_RETRIES (256)
+#define DEFAULT_READ_ACK_FRAME_RETRIES (20)
+
+#define STACK_SIZE (4096)
+static char t_client_main_stack[STACK_SIZE];
+
+// weeks bits are from 1 - 7 so remember to index correctly (subtract 1)
+static const char *day_of_week_strings[] = {
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday"
+};
+
+void client_main(void)
+{
+    USING_HALT();
+
+    LOG_CLIENT("client_main: started\n");
+
+    LOG_CLIENT("see if ds3231 responds with ACK\n");
+    uint8_t write_fail = ds3231_write(NULL, 0, DEFAULT_READ_ACK_FRAME_RETRIES);
+    if (write_fail) {
+        LOG_CLIENT_ERR("failed to find DS3231 on bus!\n");
+        while (1) {};
+    }
+
+    if (ds3231_set_time(42, 59, 23, 7, 31, 12, 23)) {
+        LOG_CLIENT_ERR("failed to set time on DS3231!\n");
+        while (1) {};
+    }
+    sddf_printf("Set Date and Time on DS3231 to: %02d-%02d-%02d %02d:%02d:%02d (%s)\n", 31, 12, 23, 23, 59, 42,
+                day_of_week_strings[7 - 1]);
+
+    LOG_CLIENT("Starting to ask for the time!\n");
+    while (true) {
+        uint8_t second;
+        uint8_t minute;
+        uint8_t hour;
+        uint8_t day_of_week;
+        uint8_t day;
+        uint8_t month;
+        uint8_t year;
+        if (ds3231_get_time(&second, &minute, &hour, &day_of_week, &day, &month, &year)) {
+            LOG_CLIENT_ERR("failed to get time from DS3231!\n");
+            while (1) {};
+        }
+
+        sddf_printf("Date and Time: %02d-%02d-%02d %02d:%02d:%02d (%s)\n", day, month, year, hour, minute, second,
+                    day_of_week_strings[day_of_week - 1]);
+
+        delay_ms(500);
+    }
+}
+
+bool delay_ms(size_t milliseconds)
+{
+    size_t time_ns = milliseconds * NS_IN_MS;
+
+    /* Detect potential overflow */
+    if (milliseconds != 0 && time_ns / milliseconds != NS_IN_MS) {
+        LOG_CLIENT_ERR("overflow detected in delay_ms");
+        return false;
+    }
+
+    sddf_timer_set_timeout(TIMER_CH, time_ns);
+    co_switch(t_event);
+
+    return true;
+}
+
+void init(void)
+{
+    LOG_CLIENT("init\n");
+
+    queue = i2c_queue_init((i2c_queue_t *) request_region, (i2c_queue_t *) response_region);
+
+    bool claimed = i2c_bus_claim(I2C_VIRTUALISER_CH, DS3231_I2C_BUS_ADDRESS);
+    if (!claimed) {
+        LOG_CLIENT_ERR("failed to claim DS3231 bus\n");
+        return;
+    }
+    LOG_CLIENT("claimed DS3231 bus!\n");
+
+    /* Define the event loop/notified thread as the active co-routine */
+    t_event = co_active();
+
+    /* derive main entry point */
+    t_main = co_derive((void *)t_client_main_stack, STACK_SIZE, client_main);
+
+    co_switch(t_main);
+}
+
+void notified(microkit_channel ch)
+{
+    switch (ch) {
+    case I2C_VIRTUALISER_CH:
+        co_switch(t_main);
+        break;
+    case TIMER_CH:
+        co_switch(t_main);
+        break;
+    default:
+        LOG_CLIENT_ERR("Unknown channel 0x%x!\n", ch);
+    }
+}

--- a/examples/i2c/i2c.mk
+++ b/examples/i2c/i2c.mk
@@ -38,8 +38,10 @@ TOP := ${SDDF}/examples/i2c
 I2C := $(SDDF)/i2c
 I2C_DRIVER := $(SDDF)/drivers/i2c/${PLATFORM}
 TIMER_DRIVER := $(SDDF)/drivers/timer/${PLATFORM}
+PN532_DRIVER := $(SDDF)/i2c/devices/pn532
+DS3231_DRIVER := $(SDDF)/i2c/devices/ds3231
 
-IMAGES := i2c_virt.elf i2c_driver.elf client.elf timer_driver.elf
+IMAGES := i2c_virt.elf i2c_driver.elf client_pn532.elf client_ds3231.elf timer_driver.elf
 CFLAGS := -mcpu=$(CPU) -mstrict-align -ffreestanding -g3 -O3 -Wall -Wno-unused-function -I${TOP}
 LDFLAGS := -L$(BOARD_DIR)/lib -L$(SDDF)/lib -L${LIBC}
 LIBS := --start-group -lmicrokit -Tmicrokit.ld -lc libsddf_util_debug.a --end-group
@@ -56,13 +58,19 @@ CFLAGS += -I$(BOARD_DIR)/include \
 
 COMMONFILES=libsddf_util_debug.a
 
-CLIENT_OBJS :=  pn532.o client.o
-DEPS := $(CLIENT_OBJS:.o=.d)
+CLIENT_PN532_OBJS :=  pn532.o client_pn532.o
+DEPS_PN532 := $(CLIENT_PN532_OBJS:.o=.d)
+
+CLIENT_DS3231_OBJS :=  ds3231.o client_ds3231.o
+DEPS_DS3231 := $(CLIENT_DS3231_OBJS:.o=.d)
 
 VPATH:=${TOP}
 all: $(IMAGE_FILE)
 
-client.elf: $(CLIENT_OBJS) libco.a
+client_pn532.elf: $(CLIENT_PN532_OBJS) libco.a
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+client_ds3231.elf: $(CLIENT_DS3231_OBJS) libco.a
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 $(IMAGE_FILE) $(REPORT_FILE): $(IMAGES) $(SYSTEM_FILE)
@@ -83,4 +91,7 @@ include ${I2C}/components/i2c_virt.mk
 include ${TIMER_DRIVER}/timer_driver.mk
 include ${LIBCO}/libco.mk
 include ${I2C_DRIVER}/i2c_driver.mk
--include $(DEPS)
+include ${PN532_DRIVER}/pn532.mk
+include ${DS3231_DRIVER}/ds3231.mk
+-include $(DEPS_DS3231)
+-include $(DEPS_PN532)

--- a/i2c/devices/ds3231/README.md
+++ b/i2c/devices/ds3231/README.md
@@ -1,0 +1,9 @@
+<!--
+   Copyright 2022, UNSW
+   SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# DS3231
+
+This example makes use of the Analog Devices DS3231 RTC.
+Documentaion can be found [here](https://www.analog.com/media/en/technical-documentation/data-sheets/ds3231.pdf).

--- a/i2c/devices/ds3231/ds3231.c
+++ b/i2c/devices/ds3231/ds3231.c
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2024, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <libco.h>
+#include <sddf/util/printf.h>
+#include <sddf/timer/client.h>
+#include <sddf/i2c/queue.h>
+#include <sddf/i2c/client.h>
+#include <client.h>
+#include <sddf/i2c/devices/ds3231/ds3231.h>
+
+// #define DEBUG_DS3231
+
+#ifdef DEBUG_DS3231
+#define LOG_DS3231(...) do{ sddf_dprintf("DS3231|INFO: "); sddf_dprintf(__VA_ARGS__); }while(0)
+#else
+#define LOG_DS3231(...) do{}while(0)
+#endif
+
+#define LOG_DS3231_ERR(...) do{ sddf_printf("DS3231|ERROR: "); sddf_printf(__VA_ARGS__); }while(0)
+
+
+extern cothread_t t_event;
+extern cothread_t t_main;
+
+struct request {
+    uint8_t *buffer;
+    /* Maximum amount of data the buffer can hold */
+    size_t buffer_size;
+    /* How many I2C tokens for processing we have enqueued */
+    size_t data_offset_len;
+    /* Bus address we are sending to */
+    size_t bus_address;
+};
+
+struct response {
+    /* Client-side address for buffer to be used as response */
+    uint8_t *buffer;
+    size_t data_size;
+    size_t read_idx;
+};
+
+/* These are defined in the client code. It is more convenient for these
+   to be global variables than constantly pass them around. */
+extern i2c_queue_handle_t queue;
+extern uintptr_t data_region;
+
+/* Below is a simple API for quickly making requests and sending them off as well
+ * as reading from the responses.
+ * It should be noted that this code has a big assumption right now which is fine
+ * for this system but perhaps not all systems that would make use of I2C.
+ * The assumption is that we only have one request at a time until we get a response.
+ * This assumption lets us use the same region of memory within the data region for
+ * all of our requests and responses, as since it is one-by-one it will never be
+ * over-written.
+ */
+
+void response_init(struct response *response)
+{
+    uintptr_t offset = 0;
+    unsigned int buffer_len = 0;
+    size_t bus_address = 0;
+    int ret = i2c_dequeue_response(queue, &bus_address, &offset, &buffer_len);
+    if (ret) {
+        LOG_DS3231_ERR("response_init could not dequeue used response buffer!\n");
+        return;
+    }
+
+    response->buffer = (uint8_t *) data_region + offset;
+    response->data_size = buffer_len;
+    response->read_idx = 0;
+}
+
+uint8_t response_read(struct response *response)
+{
+    if (response->read_idx >= response->data_size) {
+        LOG_DS3231_ERR("trying to read more data than exists in response (buffer: %p)\n", response->buffer);
+        return 0;
+    }
+
+    uint8_t value = response->buffer[RESPONSE_DATA_OFFSET + response->read_idx];
+    response->read_idx++;
+
+    return value;
+}
+
+void response_finish(struct response *response)
+{
+    // Do nothing
+}
+
+void request_init(struct request *req, uint8_t bus_address)
+{
+    req->data_offset_len = 0;
+    req->buffer = (uint8_t *)data_region;
+    req->buffer_size = I2C_MAX_DATA_SIZE;
+    req->bus_address = bus_address;
+}
+
+void request_add(struct request *req, uint8_t data)
+{
+    size_t index = req->data_offset_len;
+    if (index >= req->buffer_size) {
+        LOG_DS3231_ERR("request buffer is full (size is 0x%lx)\n", req->buffer_size);
+        return;
+    }
+    req->buffer[index] = data;
+    req->data_offset_len++;
+}
+
+void request_send(struct request *req)
+{
+    int err = i2c_enqueue_request(queue, req->bus_address, (size_t) req->buffer - data_region, req->data_offset_len);
+    if (err) {
+        LOG_DS3231_ERR("failed to enqueue request buffer!\n");
+    }
+
+    microkit_notify(I2C_VIRTUALISER_CH);
+}
+
+static uint8_t process_return_buffer(struct response *response)
+{
+    LOG_DS3231("processing return buffer\n");
+
+    if (RESPONSE_ERR >= response->data_size) {
+        LOG_DS3231_ERR("trying to read more data than exists in response (buffer: %p).\n", response->buffer);
+        return I2C_ERR_OTHER;
+    }
+
+    uint8_t error = response->buffer[RESPONSE_ERR];
+
+    if (error) {
+        LOG_DS3231_ERR("Previous request failed where RESPONSE_ERR is 0x%x\n", error);
+    }
+
+    return error;
+}
+
+bool ds3231_write(uint8_t *buffer, uint8_t buffer_len, size_t retries)
+{
+    size_t attempts = 1;
+    while (true) {
+        struct request req = {};
+        request_init(&req, DS3231_I2C_BUS_ADDRESS);
+        request_add(&req, I2C_TOKEN_START);
+        request_add(&req, I2C_TOKEN_ADDR_WRITE);
+
+        for (int i = 0; i < buffer_len; i++) {
+            request_add(&req, I2C_TOKEN_DATA);
+            request_add(&req, buffer[i]);
+        }
+
+        request_add(&req, I2C_TOKEN_STOP);
+        request_add(&req, I2C_TOKEN_END);
+
+        request_send(&req);
+
+        co_switch(t_event);
+
+        struct response response = {};
+        response_init(&response);
+
+        uint8_t error = process_return_buffer(&response);
+
+        response_finish(&response);
+
+        if (!error || attempts == retries) {
+            return error;
+        }
+
+        attempts++;
+        delay_ms(1);
+    }
+}
+
+bool ds3231_read(uint8_t *buffer, uint8_t buffer_len, size_t retries)
+{
+    size_t attempts = 1;
+    while (true) {
+        struct request req = {};
+        request_init(&req, DS3231_I2C_BUS_ADDRESS);
+
+        request_add(&req, I2C_TOKEN_START);
+        request_add(&req, I2C_TOKEN_ADDR_READ);
+
+        for (int i = 0; i < buffer_len - 1; i++) {
+            request_add(&req, I2C_TOKEN_DATA);
+        }
+
+        request_add(&req, I2C_TOKEN_DATA_END);
+
+        request_add(&req, I2C_TOKEN_STOP);
+
+        request_send(&req);
+
+        co_switch(t_event);
+
+        struct response response = {};
+        response_init(&response);
+        uint8_t error = process_return_buffer(&response);
+        if (!error) {
+            for (int i = 0; i < buffer_len; i++) {
+                buffer[i] = response_read(&response);
+            }
+
+            response_finish(&response);
+            return error;
+
+        } else if (attempts == retries) {
+            return error;
+        }
+        attempts++;
+        delay_ms(1);
+    }
+}
+
+bool ds3231_get_time(uint8_t *second, uint8_t *minute, uint8_t *hour, uint8_t *day_of_week, uint8_t *day,
+                     uint8_t *month, uint8_t *year)
+{
+    uint8_t start_register_write_buffer[1];
+    start_register_write_buffer[0] = DS3231_REGISTER_SECONDS; // to tell ds3231 to start reading at register 0
+    uint8_t write_fail = ds3231_write(start_register_write_buffer, 1, DEFAULT_READ_ACK_FRAME_RETRIES);
+    if (write_fail) {
+        return true;
+    }
+
+    uint8_t time_response_buffer[7];
+    uint8_t read_fail = ds3231_read(time_response_buffer, 7, DEFAULT_READ_RESPONSE_RETRIES);
+    if (read_fail) {
+        return true;
+    }
+
+    *second = bcd_to_dec(time_response_buffer[0]);
+    *minute = bcd_to_dec(time_response_buffer[1]);
+    *hour = bcd_to_dec(time_response_buffer[2]);
+    *day_of_week = bcd_to_dec(time_response_buffer[3]);
+    *day = bcd_to_dec(time_response_buffer[4]);
+    *month = bcd_to_dec(time_response_buffer[5] & (~(1 << DS3231_BIT_CENTURY))); // mask out the century
+    *year = bcd_to_dec(time_response_buffer[6]);
+
+    return false;
+}
+
+bool ds3231_set_time(uint8_t second, uint8_t minute, uint8_t hour, uint8_t day_of_week, uint8_t day, uint8_t month,
+                     uint8_t year)
+{
+    uint8_t set_time_buffer[8];
+    set_time_buffer[0] = DS3231_REGISTER_SECONDS; // Address to start writing at
+    set_time_buffer[1] = dec_to_bcd(second);
+    set_time_buffer[2] = dec_to_bcd(minute);
+    set_time_buffer[3] = dec_to_bcd(hour);
+    set_time_buffer[4] = dec_to_bcd(day_of_week);
+    set_time_buffer[5] = dec_to_bcd(day);
+    set_time_buffer[6] = dec_to_bcd(month);
+    set_time_buffer[7] = dec_to_bcd(year);
+
+    uint8_t write_fail = ds3231_write(set_time_buffer, 8, DEFAULT_READ_ACK_FRAME_RETRIES);
+    return write_fail;
+}
+
+// Function to convert decimal to BCD
+uint8_t dec_to_bcd(uint8_t val)
+{
+    return ((val / 10 * 16) + (val % 10));
+}
+
+// Function to convert BCD to decimal
+uint8_t bcd_to_dec(uint8_t val)
+{
+    return ((val / 16 * 10) + (val % 16));
+}

--- a/i2c/devices/ds3231/ds3231.mk
+++ b/i2c/devices/ds3231/ds3231.mk
@@ -1,0 +1,9 @@
+#
+# Copyright 2023, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+DS3231_DRIVER := $(SDDF)/i2c/devices/ds3231
+
+ds3231.o: ${DS3231_DRIVER}/ds3231.c
+	${CC} ${CFLAGS} -c -o $@ $<

--- a/i2c/devices/pn532/README.md
+++ b/i2c/devices/pn532/README.md
@@ -1,0 +1,13 @@
+<!--
+   Copyright 2022, UNSW
+   SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# PN532
+
+This example makes use of the NXP PN532 card-reader. This example was developed and tested using
+the PN532 NFC RFID Module V3. Documentation on the card-reader itself can be found
+on the [NXP website](https://www.nxp.com/docs/en/user-guide/141520.pdf).
+
+The client code for dealing with the card-reader is based on an Arduino PN532 library, it can
+be found [here](https://github.com/elechouse/PN532/).

--- a/i2c/devices/pn532/pn532.c
+++ b/i2c/devices/pn532/pn532.c
@@ -8,10 +8,10 @@
 #include <sddf/util/printf.h>
 #include <sddf/timer/client.h>
 #include <sddf/i2c/queue.h>
-#include "pn532.h"
+#include <sddf/i2c/devices/pn532/pn532.h>
 #include "client.h"
 
-// #define DEBUG_PN532
+//#define DEBUG_PN532
 
 #ifdef DEBUG_PN532
 #define LOG_PN532(...) do{ sddf_dprintf("PN532|INFO: "); sddf_dprintf(__VA_ARGS__); }while(0)
@@ -19,7 +19,13 @@
 #define LOG_PN532(...) do{}while(0)
 #endif
 
+// #define INCLUDE_ERROR_PN532
+
+#ifdef INCLUDE_ERROR_PN532
 #define LOG_PN532_ERR(...) do{ sddf_printf("PN532|ERROR: "); sddf_printf(__VA_ARGS__); }while(0)
+#else
+#define LOG_PN532_ERR(...) do{}while(0)
+#endif
 
 extern cothread_t t_event;
 extern cothread_t t_main;
@@ -86,18 +92,6 @@ uint8_t response_read(struct response *response)
     return value;
 }
 
-uint8_t response_read_idx(struct response *response, uint8_t idx)
-{
-    if (idx >= response->data_size) {
-        LOG_PN532_ERR("trying to read more data than exists in response (buffer: %p)\n", response->buffer);
-        return 0;
-    }
-
-    uint8_t value = response->buffer[RESPONSE_DATA_OFFSET + idx];
-
-    return value;
-}
-
 void response_finish(struct response *response)
 {
     // Do nothing
@@ -124,7 +118,6 @@ void request_add(struct request *req, uint8_t data)
 
 void request_send(struct request *req)
 {
-    /* Here we add two to account for the REQ_BUF_CLIENT and REQ_BUF_ADDR */
     int err = i2c_enqueue_request(queue, req->bus_address, (size_t) req->buffer - data_region, req->data_offset_len);
     if (err) {
         LOG_PN532_ERR("failed to enqueue request buffer!\n");
@@ -133,16 +126,35 @@ void request_send(struct request *req)
     microkit_notify(I2C_VIRTUALISER_CH);
 }
 
+static uint8_t process_return_buffer(struct response *response)
+{
+    LOG_PN532("processing return buffer\n");
+
+    if (RESPONSE_ERR >= response->data_size) {
+        LOG_PN532_ERR("trying to read more data than exists in response (buffer: %p).\n", response->buffer);
+        return I2C_ERR_OTHER;
+    }
+
+    uint8_t error = response->buffer[RESPONSE_ERR];
+
+    if (error) {
+        LOG_PN532_ERR("Previous request failed where RESPONSE_ERR is 0x%lx\n", error);
+    }
+
+    return error;
+}
+
 #define ACK_FRAME_SIZE (7)
 
-int8_t read_ack_frame(size_t retries)
+/*
+* Read ACK frame has two parts, the first is to make the *request*
+* to read the frame. Then we need to process the response to that
+* request where we can actually check the data.
+*/
+uint8_t read_ack_frame(size_t retries)
 {
-    /*
-     * Read ACK frame has two parts, the first is to make the *request*
-     * to read the frame. Then we need to process the response to that
-     * request where we can actually check the data.
-     */
-
+    LOG_PN532("reading ack frame\n");
+    uint8_t error;
     size_t attempts = 0;
     while (attempts < retries) {
         struct request req = {};
@@ -150,73 +162,62 @@ int8_t read_ack_frame(size_t retries)
 
         request_add(&req, I2C_TOKEN_START);
         request_add(&req, I2C_TOKEN_ADDR_READ);
-        for (int i = 0; i < ACK_FRAME_SIZE; i++) {
+        for (int i = 0; i < ACK_FRAME_SIZE - 1; i++) {
             request_add(&req, I2C_TOKEN_DATA);
         }
         request_add(&req, I2C_TOKEN_DATA_END);
         request_add(&req, I2C_TOKEN_STOP);
-        request_add(&req, I2C_TOKEN_END);
 
         request_send(&req);
 
-        /* Now we need to wait for the return data of the ACK frame */
         co_switch(t_event);
+        assert(i2c_queue_length(queue.response) == 1);
 
         const uint8_t PN532_ACK[] = {0, 0, 0xFF, 0, 0xFF, 0};
-        if (i2c_queue_length(queue.response) != 1) {
-            LOG_PN532_ERR("response queue size is not 1, actual size is %d\n", i2c_queue_length(queue.response));
-            return -1;
-        }
+
         struct response response = {};
+
         response_init(&response);
 
-        if (response_read(&response) & 1) {
+        uint8_t error = process_return_buffer(&response);
+        if (error) {
+            LOG_PN532_ERR("return buffer error");
+            response_finish(&response);
+            attempts++;
+            continue;
+        }
+
+        if (response_read(&response) & 1) { // to see if response is ready
             /* Minus one because the first byte is for the device ready status */
             for (int i = 0; i < ACK_FRAME_SIZE - 1; i++) {
                 uint8_t value = response_read(&response);
                 if (value != PN532_ACK[i]) {
                     LOG_PN532_ERR("ACK malformed at index PN532_ACK[%d], value is %d!\n", i, value);
                     response_finish(&response);
-                    return -1;
+                    error = I2C_ERR_OTHER;
+                    attempts++;
+                    continue;
                 }
             }
 
             response_finish(&response);
-            return 0;
+            return I2C_ERR_OK;
         }
-
         attempts++;
+        error = I2C_ERR_OTHER;
         response_finish(&response);
-
-        delay_ms(1);
     }
 
-    /* If we get to here we have exhausted the number of times to try read the ack frame successfully */
     LOG_PN532_ERR("read_ack_frame: device is not ready yet!\n");
-
-    return -1;
+    return error;
 }
 
-static void process_return_buffer()
+uint8_t pn532_write_command(uint8_t *header, uint8_t hlen, const uint8_t *body, uint8_t blen, size_t retries)
 {
-    struct response response = {};
-    response_init(&response);
-
-    uint8_t err = response_read_idx(&response, RESPONSE_ERR);
-    if (err != I2C_ERR_OK) {
-        LOG_PN532("Previous request failed where RESPONSE_ERR is 0x%lx\n", err);
-    }
-
-    response_finish(&response);
-}
-
-int8_t pn532_write_command(uint8_t *header, uint8_t hlen, const uint8_t *body, uint8_t blen, size_t retries)
-{
-    /* Setup command */
-
-    /* First dequeue a fresh request buffer */
+    LOG_PN532("writing command\n");
     struct request req = {};
     request_init(&req, PN532_I2C_BUS_ADDRESS);
+
     request_add(&req, I2C_TOKEN_START);
     request_add(&req, I2C_TOKEN_ADDR_WRITE);
 
@@ -228,10 +229,12 @@ int8_t pn532_write_command(uint8_t *header, uint8_t hlen, const uint8_t *body, u
 
     request_add(&req, I2C_TOKEN_DATA);
     request_add(&req, PN532_STARTCODE2);
+
     /* Put length of PN532 data */
     size_t length = hlen + blen + 1;
     request_add(&req, I2C_TOKEN_DATA);
     request_add(&req, length);
+
     /* Put checksum of length of PN532 data */
     request_add(&req, I2C_TOKEN_DATA);
     request_add(&req, ~length + 1);
@@ -260,64 +263,99 @@ int8_t pn532_write_command(uint8_t *header, uint8_t hlen, const uint8_t *body, u
     request_add(&req, PN532_POSTAMBLE);
 
     request_add(&req, I2C_TOKEN_STOP);
-    request_add(&req, I2C_TOKEN_END);
 
     request_send(&req);
 
     /* Now we need to wait for the response */
     co_switch(t_event);
+    assert(i2c_queue_length(queue.response) == 1);
 
-    process_return_buffer();
+    struct response response = {};
+    response_init(&response);
 
-    return read_ack_frame(retries);
+    uint8_t error = process_return_buffer(&response);
+
+    response_finish(&response);
+
+    if (!error) {
+        error = read_ack_frame(retries);
+        return error;
+    }
+    return error;
 }
 
-int8_t read_response_length(size_t retries)
+#define NACK_SIZE (6)
+
+uint8_t read_response_length(int8_t *length, size_t retries)
 {
-    size_t length;
+    LOG_PN532("reading response length\n");
+
+    struct response response = {};
+
     size_t attempts = 0;
-
-    delay_ms(1);
-
-    while (true) {
+    uint8_t error = I2C_ERR_OK;
+    while (attempts < retries) {
         struct request req = {};
         request_init(&req, PN532_I2C_BUS_ADDRESS);
 
         request_add(&req, I2C_TOKEN_START);
         request_add(&req, I2C_TOKEN_ADDR_READ);
-        for (int i = 0; i < 6; i++) {
+        for (int i = 0; i < NACK_SIZE - 1; i++) {
             request_add(&req, I2C_TOKEN_DATA);
         }
         request_add(&req, I2C_TOKEN_DATA_END);
         request_add(&req, I2C_TOKEN_STOP);
-        request_add(&req, I2C_TOKEN_END);
 
         request_send(&req);
-        co_switch(t_event);
 
-        if (i2c_queue_length(queue.response) > 1) {
-            LOG_PN532_ERR("response queue size is more than 1, actual size is %d\n", i2c_queue_length(queue.response));
-            return -1;
-        }
-        struct response response = {};
+        co_switch(t_event);
+        assert(i2c_queue_length(queue.response) == 1);
+
         response_init(&response);
 
-        if (response_read(&response) & 1) {
-            length = response_read_idx(&response, 4);
+        uint8_t error = process_return_buffer(&response);
+        if (error) {
             response_finish(&response);
-            break;
-        } else {
-            if (attempts == retries) {
-                LOG_PN532("device was not ready when reading the response length!\n");
-                response_finish(&response);
-                return -1;
-            }
+            attempts++;
+            continue;
         }
 
-        response_finish(&response);
-        attempts++;
-        delay_ms(1);
+        if (!(response_read(&response) & 1)) {
+            LOG_PN532_ERR("device was not ready when reading the response length!\n");
+            response_finish(&response);
+            error = I2C_ERR_OTHER;
+            attempts++;
+        } else {
+            break;
+        }
     }
+
+    if (attempts == retries) {
+        return error;
+    }
+
+    if (response_read(&response) != PN532_PREAMBLE) {
+        LOG_PN532_ERR("preamble incorrect!\n");
+        response_finish(&response);
+        return I2C_ERR_OTHER;
+    }
+
+    if (response_read(&response) != PN532_STARTCODE1) {
+        LOG_PN532_ERR("startcode1 incorrect!\n");
+        response_finish(&response);
+        return I2C_ERR_OTHER;
+    }
+
+    if (response_read(&response) != PN532_STARTCODE2) {
+        LOG_PN532_ERR("startcode2 incorrect!\n");
+        response_finish(&response);
+        return I2C_ERR_OTHER;
+    }
+
+    *length = response_read(&response);
+    response_finish(&response);
+
+    LOG_PN532("checking nack for reading response length\n");
 
     /* Check nack */
     const uint8_t PN532_NACK[] = {0, 0, 0xFF, 0xFF, 0, 0};
@@ -326,103 +364,120 @@ int8_t read_response_length(size_t retries)
 
     request_add(&nack_req, I2C_TOKEN_START);
     request_add(&nack_req, I2C_TOKEN_ADDR_WRITE);
-    for (int i = 0; i < sizeof(PN532_NACK); i++) {
+    for (int i = 0; i < NACK_SIZE; i++) {
         request_add(&nack_req, I2C_TOKEN_DATA);
         request_add(&nack_req, PN532_NACK[i]);
     }
     request_add(&nack_req, I2C_TOKEN_STOP);
-    request_add(&nack_req, I2C_TOKEN_END);
     request_send(&nack_req);
 
     co_switch(t_event);
+    assert(i2c_queue_length(queue.response) == 1);
 
-    process_return_buffer();
+    struct response response2 = {};
+    response_init(&response2);
 
-    return length;
+    error = process_return_buffer(&response2);
+
+    response_finish(&response2);
+
+    return error;
 }
 
-bool pn532_read_response(uint8_t *buffer, uint8_t buffer_len, size_t retries)
+uint8_t pn532_read_response(uint8_t *buffer, uint8_t buffer_len, size_t retries)
 {
-    int8_t length = read_response_length(retries);
-    if (length < 0) {
+    int8_t length;
+    uint8_t error = read_response_length(&length, retries);
+    if (error != I2C_ERR_OK) {
+        LOG_PN532_ERR("error trying to read response length\n");
+        return error;
+    } else if (length < 0) {
         LOG_PN532_ERR("read_response - length was less than zero\n");
-        return false;
-    } else {
+        return I2C_ERR_OTHER;
     }
 
+    LOG_PN532("reading response\n");
+    LOG_PN532("length is : %d\n", length);
 
-    size_t attempts = 0;
     struct response response = {};
 
-    while (true) {
-        struct request req = {};
-        request_init(&req, PN532_I2C_BUS_ADDRESS);
+    size_t attempts = 0;
+    while (attempts < retries) {
+        struct request request = {};
+        request_init(&request, PN532_I2C_BUS_ADDRESS);
 
-        size_t num_data_tokens = 7 + length + 2;
+        size_t num_data_tokens = 6 + length + 2;
 
-        request_add(&req, I2C_TOKEN_START);
-        request_add(&req, I2C_TOKEN_ADDR_READ);
+        request_add(&request, I2C_TOKEN_START);
+        request_add(&request, I2C_TOKEN_ADDR_READ);
 
-        if (num_data_tokens > req.buffer_size) {
-            LOG_PN532_ERR("number of request data tokens (0x%lx) exceeds buffer size (0x%lx)\n", num_data_tokens, req.buffer_size);
-            return false;
+        if (num_data_tokens > request.buffer_size) {
+            LOG_PN532_ERR("number of request data tokens (0x%lx) exceeds buffer size (0x%lx)\n", num_data_tokens,
+                          request.buffer_size);
+            return I2C_ERR_OTHER;
         }
 
-        for (int i = 0; i < num_data_tokens; i++) {
-            request_add(&req, I2C_TOKEN_DATA);
+        for (int i = 0; i < num_data_tokens - 1; i++) {
+            request_add(&request, I2C_TOKEN_DATA);
         }
 
-        request_add(&req, I2C_TOKEN_DATA_END);
-        request_add(&req, I2C_TOKEN_STOP);
-        request_add(&req, I2C_TOKEN_END);
+        request_add(&request, I2C_TOKEN_DATA_END);
+        request_add(&request, I2C_TOKEN_STOP);
 
-        request_send(&req);
+        request_send(&request);
 
-        // LOG_PN532("read_response: sent request of size %d\n", num_data_tokens);
+        LOG_PN532("read_response: sent request of size %d\n", num_data_tokens);
         co_switch(t_event);
+        assert(i2c_queue_length(queue.response) == 1);
 
         response_init(&response);
-        if ((response_read(&response) & 1)) {
-            break;
+        error = process_return_buffer(&response);
+        if (error) {
+            response_finish(&response);
+            attempts++;
+            continue;
         }
 
-        response_finish(&response);
-        if (attempts == retries) {
-            LOG_PN532_ERR("device was not ready when reading the response length!\n");
-            return false;
+        if (!(response_read(&response) & 1)) {
+            response_finish(&response);
+            LOG_PN532_ERR("not ready yet\n");
+            error = I2C_ERR_OTHER;
+            attempts++;
+            continue;
+        } else {
+            break;
         }
-        attempts++;
-        delay_ms(1);
     }
 
     // Read PREAMBLE
     if (response_read(&response) != PN532_PREAMBLE) {
         LOG_PN532_ERR("read_response: PREAMBLE check failed\n");
         response_finish(&response);
-        return false;
+        return I2C_ERR_OTHER;
     }
     // Read STARTCODE1
     if (response_read(&response) != PN532_STARTCODE1) {
         LOG_PN532_ERR("read_response: STARTCODE1 check failed\n");
         response_finish(&response);
-        return false;
+        return I2C_ERR_OTHER;
     }
     // Read STARTCODE2
     if (response_read(&response) != PN532_STARTCODE2) {
         LOG_PN532_ERR("read_response: STARTCODE2 check failed\n");
         response_finish(&response);
-        return false;
+        return I2C_ERR_OTHER;
     }
     // Read length
     size_t data_length = response_read(&response);
     if (data_length != length) {
         LOG_PN532_ERR("Received data_length of 0x%lx, was expecting 0x%x\n", data_length, length);
         response_finish(&response);
-        return false;
+        return I2C_ERR_OTHER;
     }
 
     // Read checksum of length
     response_read(&response);
+
     // Read response command
     response_read(&response);
 
@@ -432,18 +487,20 @@ bool pn532_read_response(uint8_t *buffer, uint8_t buffer_len, size_t retries)
         LOG_PN532_ERR("returned data length (0x%lx) greater than user-provided buffer length (0x%x)\n", data_length,
                       buffer_len);
         response_finish(&response);
-        return false;
+        return I2C_ERR_OTHER;
     }
+
     for (int i = 0; i < data_length; i++) {
         buffer[i] = response_read(&response);
     }
+
     // Read checksum of data
     response_read(&response);
+
     // Read postamble
     response_read(&response);
 
     response_finish(&response);
 
-
-    return true;
+    return I2C_ERR_OK;
 }

--- a/i2c/devices/pn532/pn532.mk
+++ b/i2c/devices/pn532/pn532.mk
@@ -1,0 +1,9 @@
+#
+# Copyright 2023, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+PN532_DRIVER := $(SDDF)/i2c/devices/pn532
+
+pn532.o: ${PN532_DRIVER}/pn532.c
+	${CC} ${CFLAGS} -c -o $@ $<

--- a/include/sddf/i2c/devices/ds3231/ds3231.h
+++ b/include/sddf/i2c/devices/ds3231/ds3231.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define DS3231_I2C_BUS_ADDRESS (0x68)
+
+enum ds3231_registers {                         // RANGE:
+    DS3231_REGISTER_SECONDS,                    // 00–59
+    DS3231_REGISTER_MINUTES,                    // 00–59
+    DS3231_REGISTER_HOURS,                      // 1–12 + AM/PM 10 Hour 00–23
+    DS3231_REGISTER_DAY_OF_WEEK,                // 1–7
+    DS3231_REGISTER_DATE,                       // 00–31
+    DS3231_REGISTER_MONTH,                      // 01–12 + Century
+    DS3231_REGISTER_YEAR,                       // 00–99
+    DS3231_REGISTER_ALARM1_SECONDS,
+    DS3231_REGISTER_ALARM1_MINUTES,
+    DS3231_REGISTER_ALARM1_HOURS,
+    DS3231_REGISTER_ALARM1_DAY_OF_WEEK_OR_DATE,
+    DS3231_REGISTER_ALARM2_MINUTES,
+    DS3231_REGISTER_ALARM2_HOURS,
+    DS3231_REGISTER_ALARM2_DAY_OF_WEEK_OR_DATE,
+    DS3231_REGISTER_CONTROL,
+    DS3231_REGISTER_CONTROL_STATUS,
+    DS3231_REGISTER_AGING_OFFSET,
+    DS3231_REGISTER_ALARM2_TEMP_MSB,
+    DS3231_REGISTER_ALARM2_TEMP_LSB
+};
+// Below are the bit numbers of the respective field
+#define DS3231_BIT_12_24                      0X06
+#define DS3231_BIT_CENTURY                    0X07
+#define DS3231_BIT_A1M1                       0X07
+#define DS3231_BIT_A1M2                       0X07
+#define DS3231_BIT_A1M3                       0X07
+#define DS3231_BIT_A1M4                       0X07
+#define DS3231_BIT_A2M2                       0X07
+#define DS3231_BIT_A3M3                       0X07
+#define DS3231_BIT_A4M4                       0X07
+#define DS3231_BIT_12_24_ALARM1               0X06
+#define DS3231_BIT_12_24_ALARM2               0X06
+#define DS3231_BIT_DY_DT_ALARM1               0X06
+#define DS3231_BIT_DY_DT_ALARM2               0X06
+#define DS3231_BIT_A1IE                       0X00
+#define DS3231_BIT_A2IE                       0X01
+#define DS3231_BIT_INTCN                      0X02
+#define DS3231_BIT_RS1                        0X03
+#define DS3231_BIT_RS2                        0X04
+#define DS3231_BIT_CONV                       0X05
+#define DS3231_BIT_BBSQW                      0X06
+#define DS3231_BIT_EOSC                       0X07
+#define DS3231_BIT_A1F                        0X00
+#define DS3231_BIT_A2F                        0X01
+#define DS3231_BIT_BSY                        0X02
+#define DS3231_BIT_EN32KHZ                    0X03
+#define DS3231_BIT_OSF                        0X07
+
+#define DEFAULT_READ_RESPONSE_RETRIES (256)
+#define DEFAULT_READ_ACK_FRAME_RETRIES (20)
+
+bool ds3231_write(uint8_t *buffer, uint8_t buffer_len, size_t retries);
+bool ds3231_read(uint8_t *buffer, uint8_t buffer_len, size_t retries);
+
+// User Provided Functions
+bool ds3231_get_time(uint8_t *seconds, uint8_t *minutes, uint8_t *hours, uint8_t *day_of_week, uint8_t *day,
+                     uint8_t *month, uint8_t *year);
+bool ds3231_set_time(uint8_t seconds, uint8_t minutes, uint8_t hours, uint8_t day_of_week, uint8_t day, uint8_t month,
+                     uint8_t year);
+
+uint8_t dec_to_bcd(uint8_t val);
+uint8_t bcd_to_dec(uint8_t val);

--- a/include/sddf/i2c/devices/pn532/pn532.h
+++ b/include/sddf/i2c/devices/pn532/pn532.h
@@ -26,5 +26,5 @@
 
 #define PN532_MIFARE_ISO14443A          (0x00)
 
-int8_t pn532_write_command(uint8_t *header, uint8_t hlen, const uint8_t *body, uint8_t blen, size_t retries);
-bool pn532_read_response(uint8_t *buffer, uint8_t buffer_len, size_t retries);
+uint8_t pn532_write_command(uint8_t *header, uint8_t hlen, const uint8_t *body, uint8_t blen, size_t retries);
+uint8_t pn532_read_response(uint8_t *buffer, uint8_t buffer_len, size_t retries);

--- a/include/sddf/i2c/queue.h
+++ b/include/sddf/i2c/queue.h
@@ -25,13 +25,14 @@
 
 #define RESPONSE_ERR 0
 #define RESPONSE_ERR_TOKEN 1
-/* Start of payload bytes in response data */
+/* Start of payload bytes in response data (index of first non error byte that driver adds) */
 #define RESPONSE_DATA_OFFSET 2
 
 #define I2C_ERR_OK 0
 #define I2C_ERR_TIMEOUT 1
 #define I2C_ERR_NACK 2
 #define I2C_ERR_NOREAD 3
+#define I2C_ERR_OTHER 3 // can be used for driver specific implementations
 
 typedef uint8_t i2c_token_t;
 
@@ -45,8 +46,9 @@ enum i2c_token {
     I2C_TOKEN_ADDR_WRITE = 0x2,
     /* ADDRESS READ: Same as ADDRW but sets up DATA tokens as reads. */
     I2C_TOKEN_ADDR_READ = 0x3,
-    /* DATA_LAST: Used for read transactions to write a NACK to alert
-     * the slave device that the read is now over. */
+    /* DATA_END: Used for read transactions to write a NACK to alert
+     * the slave device that the read is now over.
+     * this also acts the same way as I2C_TOKEN_DATA (ie it actually requests a token to read so should be treated the same in that regard) */
     I2C_TOKEN_DATA_END = 0x4,
     /* STOP: Used to send the STOP condition on the bus to end a transaction.
      * Causes master to release the bus. */


### PR DESCRIPTION
- added ds3231 device driver
- updated and refactored pn532 driver
- reorganised them to be outside of example directory and into driver directory
- fixed bugs and refactored i2c driver
- updated readme for i2c driver to be correct for the current implementation
- removed previous pn532 client example
- created new ds3231+pn532 example where they both the clients use the bus simultaneously 
- updated the board for 2 clients
- updated queue.h for an extra field
- updated the virtualiser so it can facilitate 2 clients instead of 1
- added makefiles and readmes to each directory I created.
- added an mp4 video showing the card reader working