### PR TITLE
IMX8MQ (MaaXBoard) uSDHC Driver

### DIFF
--- a/ci/examples.sh
+++ b/ci/examples.sh
@@ -25,6 +25,7 @@ NETWORK=true
 I2C=true
 SERIAL=true
 TIMER=true
+BLK=true
 
 build_network_echo_server_make() {
     BOARD=$1
@@ -112,6 +113,20 @@ build_serial_zig() {
     zig build -Dsdk=${SDK_PATH} -Dboard=${BOARD} -Dconfig=${CONFIG} -p ${BUILD_DIR}
 }
 
+build_blk_make() {
+    BOARD=$1
+    CONFIG=$2
+    echo "CI|INFO: building blk example with Make, board: ${BOARD}, config: ${CONFIG}"
+    BUILD_DIR="${PWD}/${CI_BUILD_DIR}/examples/blk/mmc/make/${BOARD}/${CONFIG}"
+    rm -rf ${BUILD_DIR}
+    mkdir -p ${BUILD_DIR}
+    make -j${NUM_JOBS} -C ${SDDF}/examples/blk/mmc \
+        BUILD_DIR=${BUILD_DIR} \
+        MICROKIT_CONFIG=${CONFIG} \
+        MICROKIT_SDK=${SDK_PATH} \
+        MICROKIT_BOARD=${BOARD}
+}
+
 network() {
     BOARDS=("odroidc4" "imx8mm_evk" "maaxboard" "qemu_virt_aarch64")
     CONFIGS=("debug" "release" "benchmark")
@@ -163,11 +178,24 @@ serial() {
     done
 }
 
+blk() {
+    BOARDS=("maaxboard")
+    CONFIGS=("debug" "release")
+    for BOARD in "${BOARDS[@]}"
+    do
+      for CONFIG in "${CONFIGS[@]}"
+      do
+         build_blk_make ${BOARD} ${CONFIG}
+      done
+    done
+}
+
 # Only run the examples that have been enabled
 $NETWORK && network
 $I2C && i2c
 $TIMER && timer
 $SERIAL && serial
+$BLK && blk
 
 echo ""
 echo "CI|INFO: Passed all sDDF tests"

--- a/drivers/blk/mmc/imx/README.md
+++ b/drivers/blk/mmc/imx/README.md
@@ -1,0 +1,33 @@
+<!--
+    Copyright 2024, UNSW
+    SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# uSDHC iMX8 Driver
+
+This is a driver for the MaaXBoard SD host controller, based on the following documents:
+
+- i.MX 8M Dual/8M QuadLite/8M Quad Applications Processors Reference Manual
+  Document Number: IMX8MDQLQRM, Rev 3.1, 06/2021.
+  https://www.nxp.com/webapp/Download?colCode=IMX8MDQLQRM
+- SD Specifications Part 1 Physical Layer Simplified Specification.
+  Version 9.10, Dec. 2023.
+  https://www.sdcard.org/downloads/pls/
+- SD Specifications Part A2 SD Host Controller Simplified Specification.
+  Version 4.20, July 2018.
+  https://www.sdcard.org/downloads/pls/
+
+## Implemented
+- IRQ & DMA based driver
+- Supports 3.3V operation of Version 2 SDHC cards (4GiB–32GiB) at $f_{OD}$ (400kHz).
+
+## Not Implemented
+- Voltage Negotiation (anything but 3.3V)
+- Version 1 SD cards (the initialisation flow)
+- Version 2 SDSC / SDXC cards (only because I haven't implemented support for calculating card capacity)
+- Higher speed operation (even Default Speed / 25 MHz ($f_{PP}$)) and DDR
+- Setting as RO when write protect is set on the SD card
+- Clock setup (currently inherits 150MHz clock from U-Boot)
+- Pinmux setup (again, inherits from U-Boot)
+- Timeouts as required by various commands & a lot of error cases
+- Card detect on the MaaXboard doesn't seem to work (even in U-Boot/Linux)

--- a/drivers/blk/mmc/imx/include/usdhc.h
+++ b/drivers/blk/mmc/imx/include/usdhc.h
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <sddf/util/util.h>
+
+/* The driver is based on:
+
+    [IMX8MDQLQRM]: i.MX8 Quad i.MX 8M Dual/8M QuadLite/8M Quad Applications Processors Reference Manual
+                   Document Number: IMX8MDQLQRM, Rev 3.1, 06/2021.
+                   https://www.nxp.com/webapp/Download?colCode=IMX8MDQLQRM
+    [SD-PHY]:      SD Specifications Part 1 Physical Layer Simplified Specification.
+                   Version 9.10, Dec. 2023.
+                   https://www.sdcard.org/downloads/pls/
+    [SD-HOST]:     SD Specifications Part A2 SD Host Controller Simplified Specification.
+                   Version 4.20, July 2018.
+                   https://www.sdcard.org/downloads/pls/
+*/
+
+/* [IMX8MDQLQRM] Section 10.3.7.1 uSDHC register descriptions.
+   - uSDHC1 base address: 30B4_0000h
+   - uSDHC2 base address: 30B5_0000h
+   - uSDHC3 base address: 30B6_0000h
+
+   Also, Section 7.1 Interrupts and DMA Events
+   - uSDHC1 Enhanced SDHC Interrupt Request: 22 (use IRQ# 54)
+   - uSDHC2 Enhanced SDHC Interrupt Request: 23 (use IRQ# 55)
+*/
+typedef struct imx_usdhc_regs {
+    uint32_t ds_addr;              /* DMA System Address            (RW)   */
+    uint32_t blk_att;              /* Block Attributes              (RW)   */
+    uint32_t cmd_arg;              /* Command Argument              (RW)   */
+    uint32_t cmd_xfr_typ;          /* Command Transfer Type         (RW)   */
+    uint32_t cmd_rsp0;             /* Command Response0             (RO)   */
+    uint32_t cmd_rsp1;             /* Command Response1             (RO)   */
+    uint32_t cmd_rsp2;             /* Command Response2             (RO)   */
+    uint32_t cmd_rsp3;             /* Command Response3             (RO)   */
+    uint32_t data_buff_acc_port;   /* Data Buffer Access Port       (RW)   */
+    uint32_t pres_state;           /* Present State                 (ROT)  */
+    uint32_t prot_ctrl;            /* Protocol Control              (RW)   */
+    uint32_t sys_ctrl;             /* System Control                (RW)   */
+    uint32_t int_status;           /* Interrupt Status              (W1C)  */
+    uint32_t int_status_en;        /* Interrupt Status Enable       (RW)   */
+    uint32_t int_signal_en;        /* Interrupt Signal Enable       (RW)   */
+    uint32_t autocmd12_err_status; /* Auto CMD12 Error Status       (RW)   */
+    uint32_t host_ctrl_cap;        /* Host Controller Capabilities  (RW)   */
+    uint32_t wtmk_lvl;             /* Watermark Level               (RW)   */
+    uint32_t mix_ctrl;             /* Mixer Control                 (RW)   */
+    uint32_t force_event;          /* Force Event                   (WORZ) */
+    uint32_t adma_err_status;      /* ADMA Error Status             (RO)   */
+    uint32_t adma_sys_addr;        /* ADMA System Address           (RW)   */
+    uint32_t dll_ctrl;             /* DLL (Delay Line) Control      (RW)   */
+    uint32_t dll_status;           /* DLL Status                    (RO)   */
+    uint32_t clk_tune_ctrl_status; /* CLK Tuning Control and Status (RW)   */
+    uint32_t strobe_dll_ctrl;      /* Strobe DLL control            (RW)   */
+    uint32_t strobe_dll_status;    /* Strobe DLL status             (RO)   */
+    uint32_t vend_spec;            /* Vendor Specific Register      (RW)   */
+    uint32_t mmc_boot;             /* MMC Boot                      (RW)   */
+    uint32_t vend_spec2;           /* Vendor Specific 2 Register    (RW)   */
+    uint32_t tuning_ctrl;          /* Tuning Control                (RW)   */
+    uint32_t cqe;                  /* Command Queue                 (ROZ)  */
+} imx_usdhc_regs_t;
+
+#define _LEN(start, end) ((end - start) + 1)
+#define _MASK(start, end)  ((BIT(_LEN(start, end)) - 1) << (start))
+
+/* [IMX8MDQLQRM] Section 10.3.7.1.3 Block Attributes */
+#define USDHC_BLK_ATT_BLKSIZE_SHIFT 0             /* Transfer block size  */
+#define USDHC_BLK_ATT_BLKSIZE_MASK  _MASK(0, 12)  /* BLK_ATT[12-0]        */
+#define USDHC_BLK_ATT_BLKCNT_SHIFT  16            /* Blocks count         */
+#define USDHC_BLK_ATT_BLKCNT_MASK   _MASK(16, 31) /* BLK_ATT[16-31]        */
+
+/* [IMX8MDQLQRM] Section 10.3.7.1.5 Command Transfer Type */
+#define USDHC_CMD_XFR_TYP_CCCEN        BIT(19)       /* Command CRC check enable   */
+#define USHDC_CMD_XFR_TYP_CICEN        BIT(20)       /* Command index check enable */
+#define USDHC_CMD_XFR_TYP_DPSEL        BIT(21)       /* Data present select        */
+#define USDHC_CMD_XFR_TYP_RSPTYP_SHIFT 16            /* Response type select       */
+#define USDHC_CMD_XFR_TYP_RSPTYP_MASK  _MASK(16, 17) /* RSPTYP[17-16]              */
+#define USDHC_CMD_XFR_TYP_CMDINX_SHIFT 24            /* Command index              */
+#define USDHC_CMD_XFR_TYP_CMDINX_MASK  _MASK(24, 29) /* CMDINX[29-24]              */
+
+#define USDHC_CMD_XFR_TYP_RSPTYP_NONE  0b00          /* No response                    */
+#define USDHC_CMD_XFR_TYP_RSPTYP_L136  0b01          /* Response length 136            */
+#define USDHC_CMD_XFR_TYP_RSPTYP_L48   0b10          /* Response length 48             */
+#define USDHC_CMD_XFR_TYP_RSPTYP_L48B  0b11          /* Response length 48, check busy */
+
+/* [IMX8MDQLQRM] Section 10.3.7.1.11 Present State */
+#define USDHC_PRES_STATE_CIHB  BIT(0)  /* Command inhibit (CMD) */
+#define USDHC_PRES_STATE_CDIHB BIT(1)  /* Command inhibit (DATA) */
+#define USDHC_PRES_STATE_DLA   BIT(2)  /* Data line active */
+#define USDHC_PRES_STATE_SDSTB BIT(3)  /* SD clock stable */
+#define USDHC_PRES_STATE_CINST BIT(16) /* Card inserted. */
+#define USDHC_PRES_STATE_DLSL0 BIT(24) /* DATA[0] line signal level */
+
+/* [IMX8MDQLQRM] Section 10.3.7.1.12 Protocol Control */
+#define USDHC_PROT_CTRL_DTW_SHIFT    1             /* Data transfer width.   */
+#define USDHC_PROT_CTRL_DTW_MASK     _MASK(1, 2)   /* 2 Bits: PROT_CTRL[2-1] */
+#define USDHC_PROT_CTRL_EMODE_SHIFT  4             /* Endian mode.           */
+#define USDHC_PROT_CTRL_EMODE_MASK   _MASK(4, 5)   /* 2 Bits: PROT_CTRL[5-4] */
+#define USDHC_PROT_CTRL_DMASEL_SHIFT 8             /* DMA select.            */
+#define USDHC_PROT_CTRL_DMASEL_MASK  _MASK(8, 9)   /* 2 Bits: PROT_CTRL[9-8] */
+
+#define USDHC_PROT_CTRL_DTW_1_BIT      0b00
+#define USDHC_PROT_CTRL_DTW_4_BIT      0b01
+#define USDHC_PROT_CTRL_DTW_8_BIT      0b10
+
+#define USDHC_PROT_CTRL_EMODE_BIG      0b00
+#define USDHC_PROT_CTRL_EMODE_HWBIG    0b01
+#define USDHC_PROT_CTRL_EMODE_LITTLE   0b10
+
+#define USDHC_PROT_CTRL_DMASEL_SIMPLE  0b00
+#define USDHC_PROT_CTRL_DMASEL_ADMA1   0b01
+#define USDHC_PROT_CTRL_DMASEL_ADMA2   0b10
+
+/* [IMX8MDQLQRM] Section 10.3.7.1.13 System Control*/
+#define USDHC_SYS_CTRL_RSTA  BIT(24)  /* Software reset for all */
+#define USDHC_SYS_CTRL_RSTC  BIT(25)  /* Software reset for CMD line */
+#define USDHC_SYS_CTRL_RSTD  BIT(26)  /* Software reset for data line */
+#define USDHC_SYS_CTRL_INITA BIT(27)  /* Initialization active */
+#define USDHC_SYS_CTRL_RSTT  BIT(28)  /* Reset tuning */
+
+#define USDHC_SYS_CTRL_DTOCV_SHIFT   16            /* Data timeout counter value */
+#define USDHC_SYS_CTRL_DTOCV_MASK    _MASK(16, 19) /* 4 bits; SYS_CTRL[19-16]    */
+#define USDHC_SYS_CTRL_SDCLKFS_SHIFT 8             /* SDCLK frequency select     */
+#define USDHC_SYS_CTRL_SDCLKFS_MASK  _MASK(8, 15)  /* 8 bits; SYS_CTRL[8-15]     */
+#define USDHC_SYS_CTRL_DVS_SHIFT     4             /* Divisor                    */
+#define USDHC_SYS_CTRL_DVS_MASK      _MASK(4, 7)   /* 4 bits; SYS_CTRL[4-7]      */
+
+/* [IMX8MDQLQRM] Section 10.3.7.1.14 Interrupt Status */
+#define USDHC_INT_STATUS_CC    BIT(0)  /* Command complete. */
+#define USDHC_INT_STATUS_TC    BIT(1)  /* Transfer complete. */
+#define USDHC_INT_STATUS_CTOE  BIT(16) /* Command timeout error. */
+#define USDHC_INT_STATUS_CCE   BIT(17) /* Command CRC error. */
+#define USDHC_INT_STATUS_CEBE  BIT(18) /* Command end bit error */
+#define USDHC_INT_STATUS_CIE   BIT(19) /* Command index error. */
+#define USDHC_INT_STATUS_DTOE  BIT(20) /* Data timeout error. */
+#define USDHC_INT_STATUS_AC12E BIT(24) /* Auto CMD12 error. */
+
+/* [IMX8MDQLQRM] Section 10.3.7.1.15 Interrupt Status Enable (used ones only) */
+#define USDHC_INT_STATUS_EN_CCSEN    BIT(0)   /* Command complete status enable */
+#define USDHC_INT_STATUS_EN_TCSEN    BIT(1)   /* Transfer complete status enable */
+#define USDHC_INT_STATUS_EN_CINSSEN  BIT(6)   /* Card insertion status enable */
+#define USDHC_INT_STATUS_EN_CRMSEN   BIT(7)   /* Card removal status enable */
+#define USDHC_INT_STATUS_EN_CTOESEN  BIT(16)  /* Command timeout error status enable */
+#define USDHC_INT_STATUS_EN_CCESEN   BIT(17)  /* Command CRC error status enable */
+#define USDHC_INT_STATUS_EN_CEBESEN  BIT(18)  /* Command end bit error status enable */
+#define USDHC_INT_STATUS_EN_CIESEN   BIT(19)  /* Command index error status enable */
+#define USDHC_INT_STATUS_EN_DTOESEN  BIT(20)  /* Data timeout error status enable*/
+#define USDHC_INT_STATUS_EN_DCSESEN  BIT(21)  /* Data CRC error status enable */
+#define USDHC_INT_STATUS_EN_DEBESEN  BIT(22)  /* Data end bit error status enable */
+#define USDHC_INT_STATUS_EN_AC12ESEN BIT(24)  /* Auto CMD12 error status enable */
+#define USDHC_INT_STATUS_EN_DMAESEN  BIT(28)  /* DMA error status enable */
+
+/* [IMX8MDQLQRM] Section 10.3.7.1.16 Interrupt Signal Enable (used ones only) */
+#define USDHC_INT_SIGNAL_EN_CCIEN    BIT(0)   /* Command complete interrupt enable */
+#define USDHC_INT_SIGNAL_EN_TCIEN    BIT(1)   /* Transfer complete interrupt enable */
+#define USDHC_INT_SIGNAL_EN_CINSIEN  BIT(6)   /* Card insertion interrupt enable */
+#define USDHC_INT_SIGNAL_EN_CRMIEN   BIT(7)   /* Card removal interrupt enable */
+#define USDHC_INT_SIGNAL_EN_CTOEIEN  BIT(16)  /* Command timeout error interrupt enable */
+#define USDHC_INT_SIGNAL_EN_CCEIEN   BIT(17)  /* Command CRC error interrupt enable */
+#define USDHC_INT_SIGNAL_EN_CEBEIEN  BIT(18)  /* Command end bit error interrupt enable */
+#define USDHC_INT_SIGNAL_EN_CIEIEN   BIT(19)  /* Command index error interrupt enable */
+#define USDHC_INT_SIGNAL_EN_DTOEIEN  BIT(20)  /* Data timeout error interrupt enable*/
+#define USDHC_INT_SIGNAL_EN_DCSEIEN  BIT(21)  /* Data CRC error interrupt enable */
+#define USDHC_INT_SIGNAL_EN_DEBEIEN  BIT(22)  /* Data end bit error interrupt enable */
+#define USDHC_INT_SIGNAL_EN_AC12EIEN BIT(24)  /* Auto CMD12 error interrupt enable */
+#define USDHC_INT_SIGNAL_EN_DMAEIEN  BIT(28)  /* DMA error interrupt enable */
+
+/* [IMX8MDQLQRM] Section 10.3.7.1.18 Host Controller Capabilities */
+#define USDHC_HOST_CTRL_CAP_DMAS  BIT(22)  /* DMA Support */
+#define USDHC_HOST_CTRL_CAP_VS33  BIT(24)  /* Voltage support 3.3 V */
+
+/* [IMX8MDQLQRM] Section 10.3.7.1.20 Mixer Control */
+#define USDHC_MIX_CTRL_DMAEN  BIT(0)  /* DMA enable */
+#define USDHC_MIX_CTRL_BCEN   BIT(1)  /* Block count enable */
+#define USDHC_MIX_CTRL_AC12EN BIT(2)  /* Auto CMD12 enable */
+#define USDHC_MIX_CTRL_DTDSEL BIT(4)  /* Data transfer direction select (1 = read) */
+#define USDHC_MIX_CTRL_MSBSEL BIT(5)  /* Mult / Single block select */
+
+/* [IMX8MDQLQRM] Section 10.3.7.1.29 Vendor Specific Register */
+#define USDHC_VEND_SPEC_FRC_SDCLK_ON BIT(8) /* Force CLK output active. */
+
+
+/*
+    Below this point is generic non-imx specific SD items from [SD-PHY].
+*/
+
+/* [SD-PHY] Section 4.9 Responses */
+typedef enum __attribute__((__packed__))
+{
+    RespType_None = 0,
+    RespType_R1,
+    RespType_R1b,
+    RespType_R2,
+    RespType_R3,
+    RespType_R4,
+    RespType_R5,
+    RespType_R6,
+    RespType_R7,
+}
+response_type_t;
+
+/* An arbitrary sd_cmd_t type for passing commands */
+typedef struct {
+    uint8_t cmd_index;
+    response_type_t cmd_response_type;
+    bool is_app_cmd;
+    bool data_present;
+} sd_cmd_t;
+#define _SD_CMD_DEF(number, rtype, ...)  (sd_cmd_t){.cmd_index = (number), .cmd_response_type = (rtype), .is_app_cmd = false, ##__VA_ARGS__}
+#define _SD_ACMD_DEF(number, rtype) (sd_cmd_t){.cmd_index = (number), .cmd_response_type = (rtype), .is_app_cmd = true, .data_present = false}
+
+/* [SD-PHY] Section 4.7.4 Detailed Command Description */
+#define SD_CMD0_GO_IDLE_STATE        _SD_CMD_DEF(0, RespType_None)  /* [31:0] stuff bits */
+#define SD_CMD2_ALL_SEND_CID         _SD_CMD_DEF(2, RespType_R2)    /* [31:0] stuff bits */
+#define SD_CMD3_SEND_RELATIVE_ADDR   _SD_CMD_DEF(3, RespType_R6)    /* [31:0] stuff bits */
+#define SD_CMD7_CARD_SELECT          _SD_CMD_DEF(7, RespType_R1b)   /* [31:16] RCA, [15:0] stuff bits */
+#define SD_CMD8_SEND_IF_COND         _SD_CMD_DEF(8, RespType_R7)    /* [31:12] zeroed, [11:8] VHS, [7:0] check pattern */
+#define SD_CMD9_SEND_CSD             _SD_CMD_DEF(9, RespType_R2)    /* [31:16] RCA, [15:0] stuff bits */
+#define SD_CMD13_SEND_STATUS         _SD_CMD_DEF(13, RespType_R1)   /* [31:16] RCA, [15:0] stuff bits */
+#define SD_CMD16_SET_BLOCKLEN        _SD_CMD_DEF(16, RespType_R1)   /* [31:0] block length */
+#define SD_CMD18_READ_MULTIPLE_BLOCK _SD_CMD_DEF(18, RespType_R1, .data_present = true)  /* [31:0] data address */
+#define SD_CMD25_WRITE_MULTIPLE_BLOCK  _SD_CMD_DEF(25, RespType_R1, .data_present = true)  /* [31:0] data address */
+#define SD_CMD55_APP_CMD             _SD_CMD_DEF(55, RespType_R1)   /* [31:16] RCA, [15:0] stuff bits */
+
+#define SD_ACMD41_SD_SEND_OP_COND    _SD_ACMD_DEF(41, RespType_R3)  /* [31] zero, [30] host capacity status (CCS), [29] eSD reserved , [28] XPC, [27:25] zeroed, [24] S18R, [23:0] Vdd Voltage Window (host) */
+#define SD_ACMD51_SEND_SCR           _SD_ACMD_DEF(51, RespType_R1)  /* [31:0] stuff bits */
+
+/* [SD-PHY] Section 4.9.5 R6 Published RCA Response */
+#define SD_RCA_SHIFT 16               /* New published RCA of the card */
+#define SD_RCA_MASK  _MASK(16, 31)    /* RCA: [31:16]                  */
+
+/* [SD-PHY] Section 4.9.6 R7 Card Interface Condition / Section 4.3.13 CMD8  */
+#define SD_IF_COND_CHECK_SHIFT 0            /* Check pattern, to be echoed   */
+#define SD_IF_COND_CHECK_MASK  _MASK(0, 7)  /* Bits [7:0]                    */
+#define SD_IF_COND_VHS_SHIFT   8            /* Voltage supplied; Table 4-18. */
+#define SD_IF_COND_VHS_MASK    _MASK(8, 11) /* 0001b = 2.7-3.6V; or reserved */
+#define SD_IF_COND_VHS27_36    0b0001       /* VHS = 2.7-3.6V               */
+
+/* [SD-PHY] Section 4.10.1 Card Status */
+#define SD_CARD_STATUS_APP_CMD  BIT(5)   /* The card will expect ACMD */
+
+/* [SD-PHY] Section 5.1 OCR Register */
+#define SD_OCR_VDD27_28         BIT(15)  /* Vdd supports 2.7–2.8V */
+#define SD_OCR_VDD28_29         BIT(16)  /* Vdd supports 2.8–2.9V */
+#define SD_OCR_VDD29_30         BIT(17)  /* Vdd supports 2.9–3.0V */
+#define SD_OCR_VDD30_31         BIT(18)  /* Vdd supports 3.0–3.1V */
+#define SD_OCR_VDD31_32         BIT(19)  /* Vdd supports 3.1–3.2V */
+#define SD_OCR_VDD32_33         BIT(20)  /* Vdd supports 3.2–3.3V */
+#define SD_OCR_VDD33_34         BIT(21)  /* Vdd supports 3.3–3.4V */
+#define SD_OCR_VDD34_35         BIT(22)  /* Vdd supports 3.4–3.5V */
+#define SD_OCR_VDD35_36         BIT(23)  /* Vdd supports 3.5–3.6V */
+#define SD_OCR_CCS              BIT(30)  /* Card Capacity Status (CCS) */
+#define SD_OCR_HCS              BIT(30)  /* Host Capacity Status (HCS) */
+#define SD_OCR_POWER_UP_STATUS  BIT(31)  /* Card power up status bit (busy) */
+
+/* [SD-PHY] Section 5.3.4 CSD Register (CSD Version 3.0) */
+#define SD_CSD_CSD_STRUCTURE_SHIFT 126              /* CSD Structure (version)      */
+#define SD_CSD_CSD_STRUCTURE_MASK  _MASK(126, 127)  /* CSD-slice: [127:126]         */
+#define SD_CSD_C_SIZE_SHIFT        48               /* device size (user area size) */
+#define SD_CSD_C_SIZE_MASK         _MASK(48, 75)    /* CSD-slice: [75:48]           */
+
+/* [SD-HOST] Section 3.2.3 Clock Frequency Change - timeout is 150ms */
+#define SD_CLOCK_STABLE_TIMEOUT (150 * NS_IN_MS)
+/* [SD-PHY] 4.2.3.1 Initialization Command - timeout is 1s */
+#define SD_INITIALISATION_TIMEOUT (1 * NS_IN_S)
+
+/* [SD-PHY] Section 4.10.1 Card Status Field 'CURRENT_STATE',
+       and Section 4.1 - Table 4-1. */
+typedef enum sd_card_state {
+    CardStateIdle = 0,  /* Idle State           (Card Identification) */
+    CardStateReady = 1, /* Ready State          (Card Identification) */
+    CardStateIdent = 2, /* Identification State (Card Identification) */
+    CardStateStdby = 3, /* Stand-by State       (Data Transfer)       */
+    CardStateTran = 4,  /* Transfer State       (Data Transfer)       */
+    CardStateData = 5,  /* Sending-data State   (Data Transfer)       */
+    CardStateRcv = 6,   /* Receive-data State   (Data Transfer)       */
+    CardStatePrg = 7,   /* Programming State    (Data Transfer)       */
+    CardStateDis = 8,   /* Disconnect State     (Data Transfer)       */
+
+    /* 9-15 reserved */
+} sd_card_state_t;
+
+#define KHZ (1000)
+#define MHZ (1000 * KHZ)
+
+typedef enum sd_clock_freq {
+    /* [SD-PHY] 4.2.1 Card Reset "The cards are initialized... 400KHz clock frequency" */
+    ClockSpeedIdentify_400KHz = 400 * KHZ,
+
+    // TODO: Higher speeds are currently never used.
+    // ClockSpeedDefaultSpeed_25MHz = 25 * MHZ,
+} sd_clock_freq_t;

--- a/drivers/blk/mmc/imx/mmc_driver.mk
+++ b/drivers/blk/mmc/imx/mmc_driver.mk
@@ -1,0 +1,28 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Include this snippet in your project Makefile to build the IMX8 uSDHC driver.
+# Assumes libsddf_util_debug.a is in ${LIBS}.
+# Requires usdhc_regs to be set to the mapped base of the uSDHC registers
+# in the system description file.
+
+USDHC_DRIVER_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
+
+mmc_driver.elf: blk/mmc/imx/mmc_driver.o
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+blk/mmc/imx/mmc_driver.o: ${USDHC_DRIVER_DIR}/usdhc.c |blk/mmc/imx
+	$(CC) -c $(CFLAGS) -I${USDHC_DRIVER_DIR}/include -o $@ $<
+
+-include mmc_driver.d
+
+blk/mmc/imx:
+	mkdir -p $@
+
+clean::
+	rm -f blk/mmc/imx/mmc_driver.[do]
+
+clobber::
+	rm -rf blk/mmc

--- a/drivers/blk/mmc/imx/usdhc.c
+++ b/drivers/blk/mmc/imx/usdhc.c
@@ -1,0 +1,1018 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "usdhc.h"
+
+#include <microkit.h>
+#include <sddf/blk/queue.h>
+#include <sddf/util/printf.h>
+#include <sddf/timer/client.h>
+
+#include "blk_config.h"
+
+// #define DEBUG_DRIVER
+
+#ifdef DEBUG_DRIVER
+#define LOG_DRIVER(...) do{ sddf_dprintf("uSDHC DRIVER|INFO: "); sddf_dprintf(__VA_ARGS__); }while(0)
+#else
+#define LOG_DRIVER(...) do{}while(0)
+#endif
+
+#define LOG_DRIVER_ERR(...) do{ sddf_printf("uSDHC DRIVER|ERROR: "); sddf_printf(__VA_ARGS__); }while(0)
+
+#define USDHC_VIRT_CHANNEL   0
+#define USDHC_IRQ_CHANNEL    1
+#define USDHC_TIMER_CHANNEL  2
+
+#define INT_STATUSES_ENABLED ( \
+    USDHC_INT_STATUS_EN_CCSEN   | USDHC_INT_STATUS_EN_TCSEN                                  \
+  | USDHC_INT_STATUS_EN_CINSSEN | USDHC_INT_STATUS_EN_CRMSEN                                 \
+  | USDHC_INT_STATUS_EN_CTOESEN | USDHC_INT_STATUS_EN_CCESEN   | USDHC_INT_STATUS_EN_CEBESEN \
+  | USDHC_INT_STATUS_EN_CIESEN  | USDHC_INT_STATUS_EN_DTOESEN  | USDHC_INT_STATUS_EN_DCSESEN \
+  | USDHC_INT_STATUS_EN_DEBESEN | USDHC_INT_STATUS_EN_AC12ESEN | USDHC_INT_STATUS_EN_DMAESEN )
+#define INT_SIGNALS_ENABLED ( \
+    USDHC_INT_SIGNAL_EN_CCIEN   | USDHC_INT_SIGNAL_EN_TCIEN                                  \
+  | USDHC_INT_SIGNAL_EN_CINSIEN | USDHC_INT_SIGNAL_EN_CRMIEN                                 \
+  | USDHC_INT_SIGNAL_EN_CTOEIEN | USDHC_INT_SIGNAL_EN_CCEIEN   | USDHC_INT_SIGNAL_EN_CEBEIEN \
+  | USDHC_INT_SIGNAL_EN_CIEIEN  | USDHC_INT_SIGNAL_EN_DTOEIEN  | USDHC_INT_SIGNAL_EN_DCSEIEN \
+  | USDHC_INT_SIGNAL_EN_DEBEIEN | USDHC_INT_SIGNAL_EN_AC12EIEN | USDHC_INT_SIGNAL_EN_DMAEIEN )
+
+/* See [SD-PHY] 4.3.13 Send Interface Condition; any value is good. */
+#define IF_COND_CHECK_PATTERN 0xAA
+
+#define SD_BLOCK_SIZE 512
+
+#define fallthrough __attribute__((__fallthrough__))
+
+blk_queue_handle_t blk_queue;
+volatile imx_usdhc_regs_t *usdhc_regs;
+blk_storage_info_t *blk_config;
+blk_req_queue_t *blk_req_queue;
+blk_resp_queue_t *blk_resp_queue;
+uintptr_t blk_data;
+
+typedef enum {
+    PollDone,
+    PollPending,
+} poll_t;
+
+static struct card_info {
+    /* Relative Card Address ([SD-PHY] 4.9.5) */
+    uint16_t rca;
+    /* card capacity status; false = SDSC, true = SDHC/SDXC. TODO(#187): more card types */
+    bool ccs;
+    /* Current card state */
+    sd_card_state_t card_state;
+    /* [SD-PHY] 5.3 CSD Register */
+    uint32_t csd[4];
+} card_info;
+
+#define DRIVER_STATE_INIT 0
+
+typedef enum {
+    SendStateInit = DRIVER_STATE_INIT,
+    SendStateSend,
+    SendStateRecv,
+    SendStateDone,
+} command_state_t;
+
+static struct driver_state {
+    struct command_state {
+        command_state_t normal;
+        command_state_t app_prefix;
+    } command;
+
+    enum {
+        ExecutorStateInit = DRIVER_STATE_INIT,
+        ExecutorStateActive,
+    } executor;
+
+    enum {
+        ClientStateIdle = DRIVER_STATE_INIT,
+        ClientStateInflight,
+    } clients;
+
+    enum {
+        CardIdentStateInit = DRIVER_STATE_INIT,
+        CardIdentStateIfCond,
+        CardIdentStateOpCondInquiry,
+        CardIdentStateOpCond,
+        CardIdentStateSendCid,
+        CardIdentStateSendRca,
+        CardIdentStateSendCsd,
+        CardIdentStateCardSelect,
+        CardIdentStateDone,
+    } card_ident;
+
+    enum {
+        DataStateInit = DRIVER_STATE_INIT,
+        DataStateSend,
+        DataStateTransfer,
+    } data_transfer;
+} driver_state;
+
+static inline void reset_driver_and_card_state(void)
+{
+    driver_state = (struct driver_state) {
+        .command = {
+            .normal = DRIVER_STATE_INIT,
+            .app_prefix = DRIVER_STATE_INIT,
+        },
+        .executor = DRIVER_STATE_INIT,
+        .clients = DRIVER_STATE_INIT,
+        .card_ident = DRIVER_STATE_INIT,
+        .data_transfer = DRIVER_STATE_INIT,
+    };
+
+    card_info = (struct card_info) {
+        .rca = 0,
+        .ccs = false, /* really: unknown */
+
+        /* [SD-PHY] Section 4.2.1 Card Reset:
+        > After power-on by the host, all cards are in Idle State */
+        .card_state = CardStateIdle,
+        .csd = {0x0, 0x0, 0x0, 0x0},
+    };
+}
+
+static inline void usdhc_debug(void)
+{
+    LOG_DRIVER("PRES_STATE: %u, PROT_CTRL: %u, SYS_CTRL: %u, MIX_CTRL: %u\n", usdhc_regs->pres_state, usdhc_regs->prot_ctrl,
+               usdhc_regs->sys_ctrl, usdhc_regs->mix_ctrl);
+    LOG_DRIVER("CMD_RSP0: %u, CMD_RSP1: %u, CMD_RSP2: %u, CMD_RSP3: %u\n", usdhc_regs->cmd_rsp0, usdhc_regs->cmd_rsp1,
+               usdhc_regs->cmd_rsp2, usdhc_regs->cmd_rsp3);
+    LOG_DRIVER("INT_STATUS: %u, INT_STATUS_EN: %u, INT_SIGNAL_EN: %u\n", usdhc_regs->int_status, usdhc_regs->int_status_en,
+               usdhc_regs->int_signal_en);
+    LOG_DRIVER("VEND_SPEC: %u, VEND_SPEC2: %u, BLK_ATT: %u\n", usdhc_regs->vend_spec, usdhc_regs->vend_spec2,
+               usdhc_regs->blk_att);
+}
+
+static uint32_t get_command_xfr_typ(sd_cmd_t cmd)
+{
+    // Set bits 29-24 (CMDINDX).
+    uint32_t cmd_xfr_typ = ((uint32_t)cmd.cmd_index << USDHC_CMD_XFR_TYP_CMDINX_SHIFT) & USDHC_CMD_XFR_TYP_CMDINX_MASK;
+
+    if (cmd.data_present) {
+        cmd_xfr_typ |= USDHC_CMD_XFR_TYP_DPSEL;
+    }
+
+    /* [IMX8MDQLQRM] Table 10-42. Relationship between parameters and the name of the response type
+     * Note that R7 doesn't exist in the table but is essentially just R1.
+     */
+    switch (cmd.cmd_response_type) {
+    case RespType_None:
+        cmd_xfr_typ |= (USDHC_CMD_XFR_TYP_RSPTYP_NONE << USDHC_CMD_XFR_TYP_RSPTYP_SHIFT);
+        break;
+
+    case RespType_R2:
+        cmd_xfr_typ |= USDHC_CMD_XFR_TYP_CCCEN \
+                       | (USDHC_CMD_XFR_TYP_RSPTYP_L136 << USDHC_CMD_XFR_TYP_RSPTYP_SHIFT);
+        break;
+
+    case RespType_R3:
+    case RespType_R4:
+        cmd_xfr_typ |= (USDHC_CMD_XFR_TYP_RSPTYP_L48 << USDHC_CMD_XFR_TYP_RSPTYP_SHIFT);
+        break;
+
+    case RespType_R1:
+    case RespType_R5:
+    case RespType_R6:
+    case RespType_R7:
+        cmd_xfr_typ |= USHDC_CMD_XFR_TYP_CICEN | USDHC_CMD_XFR_TYP_CCCEN \
+                       | (USDHC_CMD_XFR_TYP_RSPTYP_L48 << USDHC_CMD_XFR_TYP_RSPTYP_SHIFT);
+        break;
+
+    case RespType_R1b:
+        cmd_xfr_typ |= USHDC_CMD_XFR_TYP_CICEN | USDHC_CMD_XFR_TYP_CCCEN \
+                       | (USDHC_CMD_XFR_TYP_RSPTYP_L48B << USDHC_CMD_XFR_TYP_RSPTYP_SHIFT);
+        break;
+
+    default:
+        assert(!"unknown rtype!");
+    }
+
+    return cmd_xfr_typ;
+}
+
+/**
+ * Send a command `cmd` with argument `cmd_arg`.
+ *
+ * Ref: [IMX8MDQLQRM] 10.3.4.1 Command send & response receive basic operation.
+ */
+poll_t send_command_inner(command_state_t *state, sd_cmd_t cmd, uint32_t cmd_arg)
+{
+    uint32_t cmd_xfr_typ;
+
+    switch (*state) {
+    case SendStateInit:
+        /* [IMX8MDQLQRM] 10.3.7.1.5 Command Transfer Type
+           The host driver checks the Command Inhibit DAT field (PRES_STATE[CDIHB]) and
+           the \Command Inhibit CMD field (PRES_STATE[CIHB]) in the Present State register
+           before writing to this register.
+
+           TODO: We should probably not be busy waiting here, but we shouldn't
+                 be experiencing this in normal operation.
+        */
+        if (usdhc_regs->pres_state & (USDHC_PRES_STATE_CIHB | USDHC_PRES_STATE_CDIHB)) {
+            LOG_DRIVER("waiting for command inhibit fields to clear... pres: %u, int_status: %u\n", usdhc_regs->pres_state,
+                       usdhc_regs->int_status);
+            while (usdhc_regs->pres_state & (USDHC_PRES_STATE_CIHB | USDHC_PRES_STATE_CDIHB));
+        }
+
+        if (usdhc_regs->pres_state & USDHC_PRES_STATE_DLA) {
+            LOG_DRIVER("waiting for data line active to clear...\n");
+            while (usdhc_regs->pres_state & USDHC_PRES_STATE_DLA);
+        }
+
+        *state = SendStateSend;
+        fallthrough;
+
+    case SendStateSend:
+
+        cmd_xfr_typ = get_command_xfr_typ(cmd);
+
+        LOG_DRIVER("Running %s%2u; argument=0x%08x; cmd_xfr_typ=0x%08x; data_present=%s\n",
+                   cmd.is_app_cmd ? "ACMD" : " CMD",
+                   cmd.cmd_index, cmd_arg, cmd_xfr_typ,
+                   cmd.data_present ? "yes" : "no");
+
+        usdhc_regs->cmd_arg = cmd_arg;
+        usdhc_regs->cmd_xfr_typ = cmd_xfr_typ;
+        *state = SendStateRecv;
+        return PollPending;
+
+    case SendStateRecv:
+        if (usdhc_regs->int_status != USDHC_INT_STATUS_CC) {
+            LOG_DRIVER_ERR("-> received error response\n");
+
+            // TODO(errors): At the moment we assume any errors are unrecoverable
+            //   => There is a defined error recovery flow in [SD-PHY].
+            //   => Also, for Ver 1.XX SD Cards, CMD8 has no response.
+            assert(!"todo");
+            *state = SendStateDone;
+            return PollDone;
+        }
+
+        usdhc_regs->int_status = USDHC_INT_STATUS_CC;
+        LOG_DRIVER("-> received response\n");
+
+        if (cmd.cmd_response_type == RespType_R1b) {
+            LOG_DRIVER("-> waiting on DAT[0]...\n");
+            // [SD-PHY] 4.9.2 R1b  "The Host shall check for busy at the response"
+            //          "... an optional busy signal transmitted on the data line"
+            while (!(usdhc_regs->pres_state & USDHC_PRES_STATE_DLSL0));
+        }
+
+        *state = SendStateDone;
+        fallthrough;
+
+    case SendStateDone:
+        return PollDone;
+
+    default:
+        return PollPending;
+    }
+}
+
+poll_t send_command(sd_cmd_t cmd, uint32_t cmd_arg)
+{
+    if (cmd.is_app_cmd && driver_state.command.app_prefix != SendStateDone) {
+        /* See description of App-Specific commands in [SD-PHY] 4.3.9 */
+        poll_t poll = send_command_inner(&driver_state.command.app_prefix, SD_CMD55_APP_CMD,
+                                         (uint32_t)card_info.rca << SD_RCA_SHIFT);
+        if (poll == PollPending) {
+            return PollPending;
+        }
+
+        // Check APP_CMD in the card status to ensure was recognised as such
+        uint32_t card_status = usdhc_regs->cmd_rsp0;
+        if (!(card_status & SD_CARD_STATUS_APP_CMD)) {
+            usdhc_debug();
+            assert(!"card should be expecting an ACMD, but is not");
+        }
+
+        // Sanity check for me.
+        assert(driver_state.command.app_prefix == SendStateDone);
+    }
+
+    return send_command_inner(&driver_state.command.normal, cmd, cmd_arg);
+}
+
+/**
+ * Set the clock frequency registers.
+ * This ASSUMES that the SD clock has been stopped beforehand, for applicability
+ * in the [SD-HOST] 3.2.1 Internal Clock Setup & 3.2.3 Clock Frequency Change
+ * sequences.
+ *
+ * TODO(#187): At the moment, always assumes SDR not dual data rate (DDR), which
+ *       affects calculations.
+ */
+static void set_clock_frequency_registers(sd_clock_freq_t frequency)
+{
+    /* TODO(#187): We currently don't have a clock driver....
+        we inherit a 150MHz clock from U-Boot, so let's use that...
+    */
+    uint32_t clock_source = 150 * MHZ;
+    /* Described by [IMX8MDQLQRM] SYS_CTRL, page 2755.
+       Values here are 1-offset compared to datasheet ones */
+    uint16_t sdclkfs = 1;
+    uint8_t dvs = 1;
+
+    /* This logic is based on code in U-Boot.
+        https://github.com/u-boot/u-boot/blob/8937bb265a/drivers/mmc/fsl_esdhc_imx.c#L606-L610
+    */
+    while ((clock_source / (16 * sdclkfs)) > frequency && sdclkfs < 256) {
+        sdclkfs *= 2;
+    }
+
+    while (clock_source / (dvs * sdclkfs) > frequency && dvs < 16) {
+        dvs++;
+    }
+
+    LOG_DRIVER("Found freq %uHz for target %uHz\n", clock_source / (dvs * sdclkfs), frequency);
+
+    /* Remove the offset by 1 */
+    sdclkfs >>= 1;
+    dvs -= 1;
+
+    uint32_t sys_ctrl = usdhc_regs->sys_ctrl;
+    sys_ctrl &= ~(USDHC_SYS_CTRL_DTOCV_MASK | USDHC_SYS_CTRL_SDCLKFS_MASK | USDHC_SYS_CTRL_DVS_MASK);
+    sys_ctrl |= (sdclkfs << USDHC_SYS_CTRL_SDCLKFS_SHIFT);
+    sys_ctrl |= (dvs << USDHC_SYS_CTRL_DVS_SHIFT);
+    sys_ctrl |= ((0b1111) << USDHC_SYS_CTRL_DTOCV_SHIFT); // Set the DTOCV to max
+
+    LOG_DRIVER("Changing clocks(SYS_CTRL) from 0x%x to 0x%x\n", usdhc_regs->sys_ctrl, sys_ctrl);
+    usdhc_regs->sys_ctrl = sys_ctrl;
+}
+
+
+/**
+ * Waits for the SD clock to stabilise.
+ *
+ * [IMX8MDQLQRM] Section 10.3.7.1.11 Present State: Field 'SDSTB'
+ * > SD clock stable
+ * > This status field indicates that the internal card clock is stable.
+ * >   0b - Clock is changing frequency and not stable.
+ * >   1b - Clock is stable.
+ */
+void wait_clock_stable()
+{
+    uint64_t start = sddf_timer_time_now(USDHC_TIMER_CHANNEL);
+    while (!(usdhc_regs->pres_state & USDHC_PRES_STATE_SDSTB)) {
+        if (sddf_timer_time_now(USDHC_TIMER_CHANNEL) - start > SD_CLOCK_STABLE_TIMEOUT) {
+            LOG_DRIVER_ERR("internal clock never stabilised...\n");
+            break;
+        }
+    }
+}
+
+/**
+ * [SD-HOST] Section 3.2.3 SD Clock Frequency Change Sequence
+ * 1. SD Clock Stop
+ * 2. [irrelevant]
+ * 3. Change clock parameters
+ * 4. [irrelevant]
+ * 5. Check internal clock stable; timeout is 150ms.
+ */
+void usdhc_change_clock_frequency(sd_clock_freq_t frequency)
+{
+    /* [IMX8MDQLQRM] Section 10.3.6.7 Changing clock frequency
+        > To prevent possible glitch on the card clock, clear the FRC_SDCLK_ON
+        > bit when changing the clock divisor value (SDCLKFS or DVS in
+        > System Control Register) or [...].
+        >
+        > Also, before changing the clock divisor value, the host driver should
+        > make sure that the SDSTB bit is high.
+    */
+    usdhc_regs->vend_spec &= ~USDHC_VEND_SPEC_FRC_SDCLK_ON;
+
+    wait_clock_stable();
+    set_clock_frequency_registers(frequency);
+    wait_clock_stable();
+}
+
+void usdhc_setup_clock()
+{
+    // TODO(#187): Set up clocks instead of relying on U-Boot.
+
+    usdhc_change_clock_frequency(ClockSpeedIdentify_400KHz);
+}
+
+/*
+    Reset the uSDHC (SD Host Controller), bringing all cards back to the idle State.
+
+    Ref: [IMX8MDQLQRM] Section 10.3.4.2.2 Reset
+*/
+void usdhc_reset(void)
+{
+    /* [IMX8MDQLQRM] Section 10.3.6.7 Changing clock frequency
+        > To prevent possible glitch on the card clock, clear the FRC_SDCLK_ON
+        > bit when changing [...] or setting the RSTA bit.
+    */
+    usdhc_regs->vend_spec &= ~USDHC_VEND_SPEC_FRC_SDCLK_ON;
+
+    /* Software reset for all; wait until it self-clears */
+    usdhc_regs->sys_ctrl |= USDHC_SYS_CTRL_RSTA;
+    while (usdhc_regs->sys_ctrl & USDHC_SYS_CTRL_RSTA);
+
+    usdhc_setup_clock();
+
+    /* Wait 74 (~80) clock ticks for power up as required by the spec.
+
+       [IMX8MDQLQRM] 10.3.7.1.13 System Control:
+        > INITA / Field 27 can only be set when CIHB & CDIHB fields are unset.
+
+       At this stage, there should be no commands happening...
+    */
+    assert(!(usdhc_regs->pres_state & (USDHC_PRES_STATE_CIHB | USDHC_PRES_STATE_CDIHB)));
+    usdhc_regs->sys_ctrl |= USDHC_SYS_CTRL_INITA;
+    while (!(usdhc_regs->sys_ctrl & USDHC_SYS_CTRL_INITA));
+
+    /* Set-up registers to desired values */
+    usdhc_regs->int_status_en = INT_STATUSES_ENABLED;
+    usdhc_regs->int_signal_en = INT_SIGNALS_ENABLED;
+
+    /* Following [1] and [2], we set several registers that are not cleared
+       after software reset.
+
+       [1]: https://github.com/BarrelfishOS/barrelfish/blob/master/usr/drivers/imx8x/sdhc/sdhc.c#L166-L175
+       [2]: https://github.com/u-boot/u-boot/blob/v2024.07/drivers/mmc/fsl_esdhc_imx.c#L999-L1015
+    */
+    usdhc_regs->mmc_boot = 0;
+    usdhc_regs->clk_tune_ctrl_status = 0;
+    usdhc_regs->dll_ctrl = 0;
+
+    /* Make sure we have DMA support. */
+    assert(usdhc_regs->host_ctrl_cap & USDHC_HOST_CTRL_CAP_DMAS);
+
+    /* Enable DMA, Auto-CMD12 */
+    usdhc_regs->mix_ctrl = USDHC_MIX_CTRL_DMAEN | USDHC_MIX_CTRL_AC12EN \
+                           /* Do multi-block transfers (impl detail: we always do) */
+                           | USDHC_MIX_CTRL_MSBSEL | USDHC_MIX_CTRL_BCEN;
+
+    /* Again following [1] and [2] we configure various registers to good values */
+    // TODO(#187): UBoot sets these to blocksize/4 on each data command
+    // => this is just arbitrarily set to 1 here. What are good values?
+    usdhc_regs->wtmk_lvl = (0x01 << 16) | (0x01);
+    usdhc_regs->prot_ctrl = (USDHC_PROT_CTRL_DTW_1_BIT << USDHC_PROT_CTRL_DTW_SHIFT)
+                            | (USDHC_PROT_CTRL_EMODE_LITTLE << USDHC_PROT_CTRL_EMODE_SHIFT)
+                            | (USDHC_PROT_CTRL_DMASEL_SIMPLE << USDHC_PROT_CTRL_DMASEL_SHIFT);
+
+    // TODO(#187): Probably should set up VEND_SPEC as desired...?
+}
+
+static void read_r2_response(uint32_t response[4])
+{
+    /* [IMX8MDQLQRM] Table 10-43 Response bit definition for each response type
+        R[127:8] maps to {RSP3[23:0], CMDRSP2, CMDRSP1, CMDRSP0}
+    */
+    response[0] = (usdhc_regs->cmd_rsp3 << 8) | (usdhc_regs->cmd_rsp2 >> 24);
+    response[1] = (usdhc_regs->cmd_rsp2 << 8) | (usdhc_regs->cmd_rsp1 >> 24);
+    response[2] = (usdhc_regs->cmd_rsp1 << 8) | (usdhc_regs->cmd_rsp0 >> 24);
+    response[3] = (usdhc_regs->cmd_rsp0 << 8);
+}
+
+/* [SD-PHY] Section 4.2 Card Identification Mode. Following the flowcharts of
+    - Figure 4-1: SD Memory Card State Diagram (card identification mode)
+    - Figure 4-2: Card Initialization and Identification Flow (SD Mode)
+*/
+poll_t perform_card_identification_and_select()
+{
+    static uint64_t initialisation_start_time = 0; /* not set */
+
+    poll_t poll;
+    switch (driver_state.card_ident) {
+    case CardIdentStateInit:
+        /* [SD-PHY] Section 4.21.5 Pre-init mode
+            => we now exit this mode and move to idle */
+        poll = send_command(SD_CMD0_GO_IDLE_STATE, 0x0);
+        if (poll == PollPending) {
+            return PollPending;
+        }
+
+        driver_state.command = (struct command_state) {};
+        driver_state.card_ident = CardIdentStateIfCond;
+        fallthrough;
+
+    case CardIdentStateIfCond:
+        /* [SD-PHY] Section 4.3.13 Send Interface Condition Command
+            > [19:16] Voltage supplied (VHS) from Table 4-18
+            > [15:8 ] Check pattern to any 8-bit pattern.
+        */
+        poll = send_command(SD_CMD8_SEND_IF_COND,
+                            (SD_IF_COND_VHS27_36 << SD_IF_COND_VHS_SHIFT) | (IF_COND_CHECK_PATTERN << SD_IF_COND_CHECK_SHIFT));
+        if (poll == PollPending) {
+            return PollPending;
+        }
+
+#if 0
+        // TODO(errors): This is not handled as we fail inside send_command. See note inside.
+        if (usdhc_regs->int_status != USDHC_INT_STATUS_CC) {
+            LOG_DRIVER("CMD8 had no response / some other error\n");
+            // TODO: Document elsewhere
+            LOG_DRIVER_ERR("Ver 1.X SD Card, or Ver2.00 with voltage mismatch not supported\n");
+            assert(false);
+        }
+#endif
+
+        uint32_t r7_resp = usdhc_regs->cmd_rsp0;
+        /* [SD-PHY] 4.2.2 Operating Condition Validation
+            > If the card can operate on the supplied voltage, the response echoes
+            > back the supply voltage and the check pattern that were set in the command argument.
+        */
+        if (((r7_resp & SD_IF_COND_VHS_MASK) >> SD_IF_COND_VHS_SHIFT) != SD_IF_COND_VHS27_36) {
+            LOG_DRIVER_ERR("CMD8: Non-compatible voltage range\n");
+            assert(false);
+        } else if (((r7_resp & SD_IF_COND_CHECK_MASK) >> SD_IF_COND_CHECK_SHIFT) != IF_COND_CHECK_PATTERN) {
+            LOG_DRIVER_ERR("CMD8: Check pattern is incorrect... got 0x%02lX\n",
+                           (r7_resp & SD_IF_COND_CHECK_MASK) >> SD_IF_COND_CHECK_SHIFT);
+            assert(false);
+        }
+
+        driver_state.card_ident = CardIdentStateOpCondInquiry;
+        driver_state.command = (struct command_state) {};
+        fallthrough;
+
+    case CardIdentStateOpCondInquiry:
+        /* [SD-PHY] 4.2.3.1 Initialization Command
+            > If the voltage window field (bit 23-0) in the argument is set
+            > to zero, it is called "inquiry CMD41" that does not start
+            > initialization and is use for getting OCR. The inquiry ACMD41
+            > shall ignore the other field (bit 31-24) in the argument.
+        */
+        poll = send_command(SD_ACMD41_SD_SEND_OP_COND, 0x0);
+        if (poll == PollPending) {
+            return PollPending;
+        }
+
+        uint32_t ocr_register = usdhc_regs->cmd_rsp0;
+        // TODO(#187): At the moment, we support and assume 3.3V operation.
+        //       => Ideally we should find a compatible set of voltages.
+        assert(usdhc_regs->host_ctrl_cap & USDHC_HOST_CTRL_CAP_VS33);
+        assert(ocr_register & (SD_OCR_VDD31_32 | SD_OCR_VDD32_33));
+
+        driver_state.card_ident = CardIdentStateOpCond;
+        driver_state.command = (struct command_state) {};
+        fallthrough;
+
+    case CardIdentStateOpCond:
+        /* [SD-PHY] 4.2.3.1 Initialization Command
+           > If the voltage window field (bit 23-0) in the argument is set to
+           > non-zero at the first time, it is called "first ACMD41" that starts
+           > initialization. The other field (bit 31-24) in the argument is effective.
+           >
+           > The argument of following ACMD41 shall be the same as that of the first ACMD41.
+           >
+           > The HCS (Host Capacity Support) bit set to 1 indicates that the
+           > host supports SDHC or SDXC Card. The HCS (Host Capacity Support)
+           > bit set to 0 indicates that the host supports neither SDHC nor SDXC Card.
+           > If HCS is set to 0, SDHC and SDXC Cards never return ready status.
+           >
+           > The host shall set ACMD41 timeout more than 1 second to abort repeat of
+           > issuing ACMD41 when the card does not indicate ready. The timeout count
+           > starts from the first ACMD41 which is set voltage window in the argument.
+        */
+        if (initialisation_start_time == 0) {
+            initialisation_start_time = sddf_timer_time_now(USDHC_TIMER_CHANNEL);
+        }
+
+        do {
+            poll = send_command(SD_ACMD41_SD_SEND_OP_COND,
+                                SD_OCR_HCS | SD_OCR_VDD31_32 | SD_OCR_VDD32_33);
+            if (poll == PollPending) {
+                return PollPending;
+            }
+            driver_state.command = (struct command_state) {};
+
+            ocr_register = usdhc_regs->cmd_rsp0;
+            if (!(ocr_register & SD_OCR_POWER_UP_STATUS)) {
+                LOG_DRIVER("Card not initialised (OCR: 0x%08x), retrying...\n", ocr_register);
+            }
+        } while (!(ocr_register & SD_OCR_POWER_UP_STATUS)
+                 && (sddf_timer_time_now(USDHC_TIMER_CHANNEL) - initialisation_start_time) < SD_INITIALISATION_TIMEOUT);
+
+        if (!((sddf_timer_time_now(USDHC_TIMER_CHANNEL) - initialisation_start_time) < SD_INITIALISATION_TIMEOUT)) {
+            LOG_DRIVER_ERR("Initialisation timeout...\n");
+            assert(false);
+        }
+
+        initialisation_start_time = 0; /* reset so we can try initialisation again later */
+
+        /* CCS=1, Ver2.00 or later high/extended capciaty            */
+        /* CCS=0, Ver2.00 or later Standard Capacity SD Memory Card  */
+        card_info.ccs = !!(ocr_register & SD_OCR_CCS);
+
+        card_info.card_state = CardStateReady;
+        driver_state.card_ident = CardIdentStateSendCid;
+        fallthrough;
+
+    case CardIdentStateSendCid:
+        poll = send_command(SD_CMD2_ALL_SEND_CID, 0x0);
+        if (poll == PollPending) {
+            return PollPending;
+        }
+
+        /* [SD-PHY] The response type R2 describes in 4.9.3.
+            We don't do anything with the CID. */
+
+        card_info.card_state = CardStateIdent;
+        driver_state.card_ident = CardIdentStateSendRca;
+        driver_state.command = (struct command_state) {};
+        fallthrough;
+
+    case CardIdentStateSendRca:
+        poll = send_command(SD_CMD3_SEND_RELATIVE_ADDR, 0x0);
+        if (poll == PollPending) {
+            return PollPending;
+        }
+
+        /* [SD-PHY] 4.9.5 R6 (Published RCA response) */
+        card_info.rca = (usdhc_regs->cmd_rsp0 & SD_RCA_MASK) >> SD_RCA_SHIFT;
+
+        /* The card is now in the STANDBY state of the 'Data transfer mode' */
+        card_info.card_state = CardStateStdby;
+        /* [SD-PHY] 4.3 Data Transfer Mode
+            > In Data Transfer Mode the host may operate the card in f_PP frequency range.
+
+            TODO(#187): Actually do `usdhc_change_clock_frequency(ClockSpeedDefault_25MHz)`
+         */
+        driver_state.card_ident = CardIdentStateSendCsd;
+        driver_state.command = (struct command_state) {};
+        fallthrough;
+
+    case CardIdentStateSendCsd:
+        poll = send_command(SD_CMD9_SEND_CSD, ((uint32_t)card_info.rca << SD_RCA_SHIFT));
+        if (poll == PollPending) {
+            return PollPending;
+        }
+
+        read_r2_response(card_info.csd);
+
+        driver_state.card_ident = CardIdentStateCardSelect;
+        driver_state.command = (struct command_state) {};
+        fallthrough;
+
+    case CardIdentStateCardSelect:
+        poll = send_command(SD_CMD7_CARD_SELECT, ((uint32_t)card_info.rca << SD_RCA_SHIFT));
+        if (poll == PollPending) {
+            return PollPending;
+        }
+
+        LOG_DRIVER("Card (RCA: 0x%04x) is now waiting in the transfer state\n", card_info.rca);
+        card_info.card_state = CardStateTran;
+
+        driver_state.card_ident = CardIdentStateDone;
+        driver_state.command = (struct command_state) {};
+        fallthrough;
+
+    case CardIdentStateDone:
+        return PollDone;
+
+    default:
+        return PollPending;
+    }
+}
+
+/* [IMX8MDQLQRM] 10.3.4.3.2.1 Normal read
+
+    1. Wait until the card is ready for data
+    2. Set the block length with SET_BLOCKLEN
+    3. Set the uSDHC block length register
+    4. Set the uSDHC number block register
+    5. a. Disable the buffer read ready interrupt, configure the DMA settings
+       b. enable the uSDHC DMA when sending the command with data transfer
+       c. The AC12EN bit should also be set.
+    6. Wait for the Transfer Complete interrupt.
+
+    Also reference [SD-PHY] 4.3.3 Data Read.
+*/
+poll_t usdhc_read_blocks(uintptr_t dma_address, uint32_t sector_number, uint16_t sector_count)
+{
+    poll_t poll;
+    uint32_t data_address;
+    switch (driver_state.data_transfer) {
+    case DataStateInit:
+        // TODO(#187): We shouldn't need to do this for every command I think.
+        poll = send_command(SD_CMD16_SET_BLOCKLEN, SD_BLOCK_SIZE);
+        if (poll == PollPending) {
+            return PollPending;
+        }
+
+        usdhc_regs->blk_att = (usdhc_regs->blk_att & ~USDHC_BLK_ATT_BLKSIZE_MASK) | (SD_BLOCK_SIZE <<
+                                                                                     USDHC_BLK_ATT_BLKSIZE_SHIFT);
+
+        usdhc_regs->ds_addr = dma_address;
+
+        /* Select read data transfer direction */
+        usdhc_regs->mix_ctrl |= USDHC_MIX_CTRL_DTDSEL;
+        usdhc_regs->blk_att &= ~USDHC_BLK_ATT_BLKCNT_MASK;
+        usdhc_regs->blk_att |= ((uint32_t)sector_count << USDHC_BLK_ATT_BLKCNT_SHIFT);
+
+        driver_state.data_transfer = DataStateSend;
+        driver_state.command = (struct command_state) {};
+        fallthrough;
+
+    case DataStateSend:
+        /* [SD-PHY] Table 4-24 Block-Oriented Read Commands
+            CMD17:
+            > Argument: [31:0] data address
+            > SDSC Card (CCS=0) uses byte unit address and SDHC and SDXC Cards (CCS=1)
+            > use block unit address (512 Bytes unit).
+        */
+        if (card_info.ccs) {
+            data_address = sector_number;
+        } else {
+            data_address = sector_number * SD_BLOCK_SIZE;
+        }
+        poll = send_command(SD_CMD18_READ_MULTIPLE_BLOCK, data_address);
+        if (poll == PollPending) {
+            return PollPending;
+        }
+
+        card_info.card_state = CardStateData;
+        driver_state.data_transfer = DataStateTransfer;
+        driver_state.command = (struct command_state) {};
+        return PollPending; // wait for IRQ.
+
+    case DataStateTransfer:
+        // todo: handle this earlier to prevent race conditions inside send_cmd
+
+        if (usdhc_regs->int_status & USDHC_INT_STATUS_DTOE) {
+            LOG_DRIVER_ERR("data timeout error\n");
+            assert(false);
+        }
+
+        LOG_DRIVER("-> read complete\n");
+        usdhc_regs->int_status = USDHC_INT_STATUS_TC;
+        assert(!usdhc_regs->int_status);
+
+        card_info.card_state = CardStateTran;
+
+        return PollDone;
+
+    default:
+        return PollPending;
+    }
+}
+
+/* [IMX8MDQLQRM] 10.3.4.3.1.1 Normal write
+
+    1. Wait until the card is ready for data
+    2. Set the block length with SET_BLOCKLEN
+    3. Set the uSDHC block length register
+    4. Set the uSDHC number block register
+    5. a. Disable the buffer write ready interrupt, configure the DMA settings
+       b. enable the uSDHC DMA when sending the command with data transfer
+       c. The AC12EN bit should also be set.
+    6. Wait for the Transfer Complete interrupt.
+
+    Also reference [SD-PHY] 4.3.4 Data Write
+*/
+poll_t usdhc_write_blocks(uintptr_t dma_address, uint32_t sector_number, uint16_t sector_count)
+{
+    poll_t poll;
+    uint32_t data_address;
+    switch (driver_state.data_transfer) {
+    case DataStateInit:
+        // TODO(#187): We shouldn't need to do this for every command I think.
+        poll = send_command(SD_CMD16_SET_BLOCKLEN, SD_BLOCK_SIZE);
+        if (poll == PollPending) {
+            return PollPending;
+        }
+
+        usdhc_regs->blk_att = (usdhc_regs->blk_att & ~USDHC_BLK_ATT_BLKSIZE_MASK) | (SD_BLOCK_SIZE <<
+                                                                                     USDHC_BLK_ATT_BLKSIZE_SHIFT);
+
+        usdhc_regs->ds_addr = dma_address;
+
+        /* Select write data transfer direction */
+        usdhc_regs->mix_ctrl &= ~USDHC_MIX_CTRL_DTDSEL;
+        usdhc_regs->blk_att &= ~USDHC_BLK_ATT_BLKCNT_MASK;
+        usdhc_regs->blk_att |= ((uint32_t)sector_count << USDHC_BLK_ATT_BLKCNT_SHIFT);
+
+        driver_state.data_transfer = DataStateSend;
+        driver_state.command = (struct command_state) {};
+        fallthrough;
+
+    case DataStateSend:
+        /* [SD-PHY] Table 4-25 Block-Oriented Write Commands
+            CMD17:
+            > Argument: [31:0] data address
+            > SDSC Card (CCS=0) uses byte unit address and SDHC and SDXC Cards (CCS=1)
+            > use block unit address (512 Bytes unit).
+        */
+        if (card_info.ccs) {
+            data_address = sector_number;
+        } else {
+            data_address = sector_number * SD_BLOCK_SIZE;
+        }
+        poll = send_command(SD_CMD25_WRITE_MULTIPLE_BLOCK, data_address);
+        if (poll == PollPending) {
+            return PollPending;
+        }
+
+        card_info.card_state = CardStateRcv;
+        driver_state.data_transfer = DataStateTransfer;
+        driver_state.command = (struct command_state) {};
+        return PollPending; // wait for IRQ.
+
+    case DataStateTransfer:
+        // todo: handle this earlier to prevent race conditions inside send_cmd
+
+        if (usdhc_regs->int_status & USDHC_INT_STATUS_DTOE) {
+            LOG_DRIVER_ERR("data timeout error\n");
+            assert(false);
+        }
+
+        LOG_DRIVER("-> write complete\n");
+        usdhc_regs->int_status = USDHC_INT_STATUS_TC;
+        assert(!usdhc_regs->int_status);
+
+        card_info.card_state = CardStateTran;
+
+        return PollDone;
+
+    default:
+        return PollPending;
+    }
+}
+
+void setup_blk_queues()
+{
+    assert(!blk_config->ready);
+
+    blk_queue_init(&blk_queue, blk_req_queue, blk_resp_queue, BLK_QUEUE_SIZE_DRIV);
+    blk_config->sector_size = SD_BLOCK_SIZE;
+    // blk_config->read_only = /* TODO(#187): look at write protect flag */
+    blk_config->block_size = 1;
+
+    __uint128_t csd = ((__uint128_t)card_info.csd[0] << 96)
+                      | ((__uint128_t)card_info.csd[1] << 64)
+                      | ((__uint128_t)card_info.csd[2] << 32)
+                      | ((__uint128_t)card_info.csd[3] <<  0);
+    /* [SD-PHY] 5.3.3 CSD Register (Ver2); CSD[127:126] CSD_STRUCTURE == 0b01
+        =>  the below calculation is different for different versions (TODO(#187)) */
+    assert(((csd /* & SD_CSD_CSD_STRUCTURE_MASK */) >> SD_CSD_CSD_STRUCTURE_SHIFT) == 0b01);
+
+    /* [SD-PHY] 5.3.4 C_SIZE (pg. 234)
+       > The user data area capacity is calculated from C_SIZE as follows:
+       >
+       >             memory capacity = (C_SIZE+1) * 512KByte
+    */
+    uint64_t c_size = (csd & SD_CSD_C_SIZE_MASK) >> SD_CSD_C_SIZE_SHIFT;
+    blk_config->capacity = (c_size + 1) * (512 * 1024) / BLK_TRANSFER_SIZE;
+
+    LOG_DRIVER("size: %lu\n", blk_config->capacity);
+
+    __atomic_store_n(&blk_config->ready, true, __ATOMIC_RELEASE);
+    LOG_DRIVER("Driver initialisation complete\n");
+}
+
+void handle_clients(void)
+{
+    static blk_req_code_t req_code;
+    static uintptr_t req_offset;
+    static uint32_t req_block_number;
+    static uint16_t req_count;
+    static uint32_t req_id;
+    int err;
+
+    // TODO(#187): Handle overflow with this multiplication...?
+    uint32_t block_to_sectors = BLK_TRANSFER_SIZE / SD_BLOCK_SIZE;
+
+    switch (driver_state.clients) {
+    case ClientStateIdle:
+        err = blk_dequeue_req(&blk_queue, &req_code, &req_offset, &req_block_number, &req_count, &req_id);
+        if (err == -1) {
+            // no requests to handle
+            return;
+        }
+
+        LOG_DRIVER("Received command: code=%d, offset=0x%lx, block_number=%d, count=%d, id=%d\n",
+                   req_code, req_offset, req_block_number, req_count, req_id);
+
+        driver_state.clients = ClientStateInflight;
+        fallthrough;
+
+    case ClientStateInflight: {
+        blk_resp_status_t status;
+        uint16_t success_count = 0;
+        poll_t poll;
+
+        switch (req_code) {
+        case BLK_REQ_READ:
+            poll = usdhc_read_blocks(req_offset, req_block_number * block_to_sectors,
+                                     req_count * block_to_sectors);
+            if (poll == PollPending) {
+                return;
+            }
+            driver_state.data_transfer = DataStateInit;
+
+            status = BLK_RESP_OK;
+            success_count = 1;
+            break;
+
+        case BLK_REQ_WRITE:
+            poll = usdhc_write_blocks(req_offset, req_block_number * block_to_sectors,
+                                      req_count * block_to_sectors);
+            if (poll == PollPending) {
+                return;
+            }
+            driver_state.data_transfer = DataStateInit;
+
+            status = BLK_RESP_OK;
+            success_count = 1;
+            break;
+
+        case BLK_REQ_FLUSH:
+        case BLK_REQ_BARRIER:
+            /* No-ops. */
+            status = BLK_RESP_OK;
+            success_count = req_count;
+            break;
+
+        default:
+            LOG_DRIVER_ERR("Unknown command code: %d\n", req_code);
+            return;
+        }
+
+        int err = blk_enqueue_resp(&blk_queue, status, success_count, req_id);
+        assert(!err);
+        LOG_DRIVER("Enqueued response: status=%d, success_count=%d, id=%d\n", status, success_count, req_id);
+        microkit_notify(USDHC_VIRT_CHANNEL);
+
+        driver_state.clients = ClientStateIdle;
+        return handle_clients();
+    }
+
+    default:
+        assert(!"unreachable");
+    }
+}
+
+void usdhc_executor(bool is_irq)
+{
+    if (driver_state.executor == ExecutorStateInit && !is_irq) {
+        /* Ignore client requests until we're ready (at which point we will process them) */
+        return;
+    }
+
+    poll_t poll;
+    switch (driver_state.executor) {
+    case ExecutorStateInit:
+        poll = perform_card_identification_and_select();
+        if (poll == PollPending) {
+            return;
+        }
+        setup_blk_queues();
+
+        driver_state.executor = ExecutorStateActive;
+        fallthrough;
+
+    case ExecutorStateActive:
+        handle_clients();
+        // We always stay in the Active state now.
+        break;
+
+    default:
+        assert(!"unreachable");
+    }
+}
+
+void notified(microkit_channel ch)
+{
+    switch (ch) {
+    case USDHC_IRQ_CHANNEL:
+        usdhc_executor(true);
+        break;
+
+    case USDHC_VIRT_CHANNEL:
+        usdhc_executor(false);
+        break;
+
+    case USDHC_TIMER_CHANNEL:
+        LOG_DRIVER("got timer interrupt -- UNHANDLED\n");
+        assert(false);
+        break;
+
+    default:
+        LOG_DRIVER_ERR("notification on unknown channel: %d\n", ch);
+        break;
+    }
+
+    if (ch == USDHC_IRQ_CHANNEL) {
+        microkit_irq_ack(ch);
+    }
+}
+
+void init()
+{
+    reset_driver_and_card_state();
+
+    LOG_DRIVER("Beginning driver initialisation...\n");
+
+    usdhc_reset();
+    usdhc_executor(true);
+}

--- a/examples/blk/mmc/Makefile
+++ b/examples/blk/mmc/Makefile
@@ -1,0 +1,32 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+ifeq ($(strip $(MICROKIT_SDK)),)
+$(error MICROKIT_SDK must be specified)
+endif
+
+ifeq ($(strip $(MICROKIT_BOARD)),)
+$(error MICROKIT_BOARD must be specified)
+endif
+export MICROKIT_BOARD
+BUILD_DIR ?= build
+export SDDF=$(abspath ../../..)
+export BUILD_DIR:=$(abspath ${BUILD_DIR})
+export override MICROKIT_SDK:=$(abspath ${MICROKIT_SDK})
+
+IMAGE_FILE:= ${BUILD_DIR}/loader.img
+REPORT_FILE:= ${BUILD_DIR}/report.txt
+
+all: ${IMAGE_FILE}
+
+qemu ${IMAGE_FILE} ${REPORT_FILE} clean clobber: ${BUILD_DIR}/Makefile FORCE
+	${MAKE} -C ${BUILD_DIR}  MICROKIT_SDK=${MICROKIT_SDK} $(notdir $@)
+
+${BUILD_DIR}/Makefile: mmc.mk
+	mkdir -p ${BUILD_DIR}
+	cp mmc.mk $@
+
+FORCE:

--- a/examples/blk/mmc/README.md
+++ b/examples/blk/mmc/README.md
@@ -1,0 +1,79 @@
+<!--
+    Copyright 2024, UNSW
+    SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Block (mmc) client example
+
+This is an example to show a single client reading & writing from an SD card.
+
+This example is intended to be used with an Avnet MaaXBoard.
+It has been tested and developed on that platform.
+
+The client reads & writes to the 3rd partition on the SD card (0-index = 2).
+It _will_ overwrite data in this partition.
+
+The example has been tested using a Class 4 SanDisk 8GiB microSD card formatted with the [Debian Linux Out of Box Image](https://downloads.element14.com/downloads/zedboard/MaaxBoard/maaxboard/02LinuxShipmentImage_Debian.zip), with an additional partition created in the free space following the Linux rootfs.
+
+## Building
+### Make
+
+```sh
+make MICROKIT_SDK=<path/to/sdk> MICROKIT_BOARD=<board> MICROKIT_CONFIG=<debug/release>
+```
+
+Currently the only option for `MICROKIT_BOARD` is "maaxboard".
+
+## Running
+
+The produced `build/loader.img` can then be loaded from U-Boot.
+
+It should produce the following output:
+
+```
+Hello from client
+client notified!
+client notified!
+client notified!
+client notified!
+client notified!
+[   0] = 0x3
+[   1] = 0x4
+[   2] = 0x5
+[   3] = 0x6
+[ 508] = 0xff
+[ 509] = 0x0
+[ 510] = 0x1
+[ 511] = 0x2
+[ 512] = 0x3
+[ 513] = 0x4
+[ 514] = 0x5
+[ 515] = 0x6
+[ 516] = 0x7
+[4092] = 0xff
+[4093] = 0x0
+[4094] = 0x1
+[4095] = 0x2
+[4096] = 0x3
+[4097] = 0x4
+[NW-3] = 0x0
+[NW-2] = 0x1
+[NWB-] = 0x2
+
+[NWB=] = 0x0
+[NWB+] = 0x0
+[NW++] = 0x0
+[NR-2] = 0x0
+[NR-1] = 0x0
+
+[NRB=] = 0x3
+[NR+1] = 0x4
+[NR+2] = 0x5
+[NR+3] = 0x6
+Client read/write data is correct!
+```
+
+The client first zeroes the SD card, then writes some data and reads it back.
+From `0` to `NWB-`, the bytes should be an increasing sequence starting at 0x3 and wrapping around repeatedly. These are read from the SD card.
+From `NWB=` to `NR-1`, these bytes should all be zero, also read from the SD card.
+From `NRB=` onwards, these bytes are set up for writing _from_ host to the _sd card_, and should not have been overwritten during reads.

--- a/examples/blk/mmc/board/maaxboard/mmc.system
+++ b/examples/blk/mmc/board/maaxboard/mmc.system
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2024, UNSW
+    SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="timer"  size="0x10_000" phys_addr="0x302d_0000" />
+    <memory_region name="usdhc1" size="0x10_000" phys_addr="0x30b4_0000" />
+
+    <!-- sDDF Block -->
+    <memory_region name="blk_driver_config" size="0x1000"   page_size="0x1000"   />
+    <memory_region name="blk_driver_req"    size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_driver_resp"   size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_driver_data"   size="0x200000" page_size="0x200000" />
+
+    <memory_region name="blk_client_config" size="0x1000"   page_size="0x1000"   />
+    <memory_region name="blk_client_req"    size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client_resp"   size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client_data"   size="0x200000" page_size="0x200000" />
+
+    <protection_domain name="mmc_driver" priority="100" >
+        <program_image path="mmc_driver.elf" />
+        <map mr="usdhc1" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="usdhc_regs" />
+        <irq irq="54" id="1"  />
+
+        <!-- sDDF block -->
+        <map mr="blk_driver_config" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
+        <map mr="blk_driver_req"    vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
+        <map mr="blk_driver_resp"   vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
+    </protection_domain>
+
+    <protection_domain name="timer" priority="101" pp="true" passive="true">
+        <program_image path="timer_driver.elf" />
+        <map mr="timer" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
+        <irq irq="87" id="0" />
+    </protection_domain>
+
+    <channel>
+        <end pd="timer"      id="1" />
+        <end pd="mmc_driver" id="2" />
+    </channel>
+
+    <protection_domain name="client" priority="1" >
+        <program_image path="client.elf" />
+
+        <!-- sDDF Block -->
+        <map mr="blk_client_config" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
+        <map mr="blk_client_req"    vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
+        <map mr="blk_client_resp"   vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
+        <map mr="blk_client_data"   vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_data"       />
+    </protection_domain>
+
+    <channel>
+        <end pd="client"     id="0" />
+        <end pd="blk_virt"   id="1" />
+    </channel>
+
+    <!-- sDDF Block -->
+    <protection_domain name="blk_virt" priority="99">
+        <program_image path="blk_virt.elf" />
+
+        <map mr="blk_driver_config" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_config_driver"     />
+        <map mr="blk_driver_req"    vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue_driver"  />
+        <map mr="blk_driver_resp"   vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue_driver" />
+        <map mr="blk_driver_data"   vaddr="0x40600000" perms="rw" cached="false" setvar_vaddr="blk_data_driver" />
+        <setvar symbol="blk_data_driver_paddr" region_paddr="blk_driver_data" />
+
+        <map mr="blk_client_config" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
+        <map mr="blk_client_req"    vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
+        <map mr="blk_client_resp"   vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
+        <map mr="blk_client_data"   vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_client_data_start" />
+    </protection_domain>
+
+    <channel>
+        <end pd="mmc_driver" id="0" />
+        <end pd="blk_virt"   id="0" />
+    </channel>
+
+</system>

--- a/examples/blk/mmc/client.c
+++ b/examples/blk/mmc/client.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <microkit.h>
+#include <sddf/blk/queue.h>
+#include <sddf/util/printf.h>
+#include <sddf/util/util.h>
+
+#include "blk_config.h"
+
+#define BLK_VIRT_CHANNEL 0
+
+blk_queue_handle_t blk_queue;
+/* set by microkit */
+blk_storage_info_t *blk_config;
+blk_req_queue_t *blk_req_queue;
+blk_resp_queue_t *blk_resp_queue;
+uintptr_t blk_data;
+
+#define NUM_READ_BLOCKS   6
+#define NUM_WRITE_BLOCKS  5
+_Static_assert(NUM_READ_BLOCKS > NUM_WRITE_BLOCKS, "#read must be greater than #write");
+
+/* we write something different than the index into position i for clarity */
+#define BYTE_ADJUST(i) ((i + 3) & 0xFF)
+
+void print_some_data()
+{
+    /* start from the read (from card) section, which should contain the data we wrote to the card */
+    volatile uint8_t *block_data = (volatile uint8_t *)(blk_data);
+    sddf_printf("[   0] = 0x%x\n", block_data[   0]);
+    sddf_printf("[   1] = 0x%x\n", block_data[   1]);
+    sddf_printf("[   2] = 0x%x\n", block_data[   2]);
+    sddf_printf("[   3] = 0x%x\n", block_data[   3]);
+    sddf_printf("[ 508] = 0x%x\n", block_data[ 508]);
+    sddf_printf("[ 509] = 0x%x\n", block_data[ 509]);
+    sddf_printf("[ 510] = 0x%x\n", block_data[ 510]);
+    sddf_printf("[ 511] = 0x%x\n", block_data[ 511]);
+    sddf_printf("[ 512] = 0x%x\n", block_data[ 512]);
+    // ^ that was one 512 block, but we should see a 4096 block of increasing digits
+    sddf_printf("[ 513] = 0x%x\n", block_data[ 513]);
+    sddf_printf("[ 514] = 0x%x\n", block_data[ 514]);
+    sddf_printf("[ 515] = 0x%x\n", block_data[ 515]);
+    sddf_printf("[ 516] = 0x%x\n", block_data[ 516]);
+    sddf_printf("[4092] = 0x%x\n", block_data[4092]);
+    sddf_printf("[4093] = 0x%x\n", block_data[4093]);
+    sddf_printf("[4094] = 0x%x\n", block_data[4094]);
+    sddf_printf("[4095] = 0x%x\n", block_data[4095]);
+    sddf_printf("[4096] = 0x%x\n", block_data[4096]);
+    sddf_printf("[4097] = 0x%x\n", block_data[4097]);
+    // all the way up to NUM_WRITE_BLOCKS - 1 (as we wrote data there)
+    sddf_printf("[NW-3] = 0x%x\n", block_data[NUM_WRITE_BLOCKS * BLK_TRANSFER_SIZE - 3]);
+    sddf_printf("[NW-2] = 0x%x\n", block_data[NUM_WRITE_BLOCKS * BLK_TRANSFER_SIZE - 2]);
+    sddf_printf("[NWB-] = 0x%x\n\n", block_data[NUM_WRITE_BLOCKS * BLK_TRANSFER_SIZE - 1]);
+    // but not past it! these should all be zeroes, as we didn't write data to the card; and we assume the card is empty
+    sddf_printf("[NWB=] = 0x%x\n", block_data[NUM_WRITE_BLOCKS * BLK_TRANSFER_SIZE + 0]);
+    sddf_printf("[NWB+] = 0x%x\n", block_data[NUM_WRITE_BLOCKS * BLK_TRANSFER_SIZE + 1]);
+    sddf_printf("[NW++] = 0x%x\n", block_data[NUM_WRITE_BLOCKS * BLK_TRANSFER_SIZE + 2]);
+    // all the way up to NUM_READ_BLOCKS, where we stopped reading
+    sddf_printf("[NR-2] = 0x%x\n", block_data[NUM_READ_BLOCKS * BLK_TRANSFER_SIZE - 2]);
+    sddf_printf("[NR-1] = 0x%x\n\n", block_data[NUM_READ_BLOCKS * BLK_TRANSFER_SIZE - 1]);
+
+    // then we should encounter the writing data that we prefilled into our memory, before writing it to the card
+    // which should be some increasing numbers.
+    sddf_printf("[NRB=] = 0x%x\n", block_data[NUM_READ_BLOCKS * BLK_TRANSFER_SIZE + 0]);
+    sddf_printf("[NR+1] = 0x%x\n", block_data[NUM_READ_BLOCKS * BLK_TRANSFER_SIZE + 1]);
+    sddf_printf("[NR+2] = 0x%x\n", block_data[NUM_READ_BLOCKS * BLK_TRANSFER_SIZE + 2]);
+    sddf_printf("[NR+3] = 0x%x\n", block_data[NUM_READ_BLOCKS * BLK_TRANSFER_SIZE + 3]);
+}
+
+void ensure_data_is_correct()
+{
+    volatile uint8_t *block_data = (volatile uint8_t *)blk_data;
+
+    for (int i = 0; i < NUM_WRITE_BLOCKS * BLK_TRANSFER_SIZE; i++) {
+        if (block_data[i] != BYTE_ADJUST(i)) {
+            assert(!"The data we wrote, then read from the device doesn't match!\n");
+        }
+    }
+    for (int i = NUM_WRITE_BLOCKS * BLK_TRANSFER_SIZE; i < NUM_READ_BLOCKS * BLK_TRANSFER_SIZE; i++) {
+        if (block_data[i] != 0x0) {
+            assert(!"The data that was on the card, which we didn't touch, wasn't still zeroed!\n");
+        }
+    }
+    for (int i = 0; i < BLK_TRANSFER_SIZE; i++) {
+        if (block_data[NUM_READ_BLOCKS * BLK_TRANSFER_SIZE + i] != BYTE_ADJUST(i)) {
+            assert(!"The original memory that we wrote to the device was overwritten, when it should have been left alone by the read command\n");
+        }
+    }
+
+    sddf_printf("Client read/write data is correct!\n");
+}
+
+void notified(microkit_channel ch)
+{
+    microkit_dbg_puts("client notified!\n");
+    if (ch != BLK_VIRT_CHANNEL) {
+        assert(!"bad channel?");
+    }
+
+    if (blk_queue_length_resp(&blk_queue) < 6 /* the number of requests we sent */) {
+        /* just wait until all requests are serviced */
+        return;
+    }
+
+    /* dequeue and check the requests succeeded */
+    blk_resp_status_t status = BLK_RESP_OK;
+    uint16_t success_count;
+    uint32_t id = 0;
+    while (blk_queue_length_resp(&blk_queue) > 0) {
+        assert(!blk_dequeue_resp(&blk_queue, &status, &success_count, &id));
+        if (status != BLK_RESP_OK) {
+            sddf_printf("request failed: stat: %u, id: %u\n", status, id);
+            assert(!"failed");
+        }
+
+    }
+
+    print_some_data();
+    ensure_data_is_correct();
+}
+
+void init(void)
+{
+    blk_queue_init(&blk_queue, blk_req_queue, blk_resp_queue, BLK_QUEUE_SIZE_CLI0);
+
+    /* Busy wait until blk device is ready */
+    while (!__atomic_load_n(&blk_config->ready, __ATOMIC_ACQUIRE));
+
+    sddf_printf("Hello from client\n");
+
+    /* The third partition on the SD card (after Uboot & Linux) is made empty
+       so we don't overwrite anything important.
+    */
+    assert(blk_partition_mapping[0] == 2);
+    uint32_t data_address = 0;
+
+    /* Setup a data region with a region to read into from the card, initially zeroed
+        then another region to write to the card with.
+
+        Note: Read region is before the write region, so that we can ensure
+              that reading into it doesn't overwrite our original data we wrote from
+              i.e. a driver bug
+    */
+    volatile uint8_t *block_data = (volatile uint8_t *)blk_data;
+    for (int i = 0; i < NUM_READ_BLOCKS * BLK_TRANSFER_SIZE; i++) {
+        block_data[i] = 0x0;
+    }
+    for (int i = 0; i < NUM_WRITE_BLOCKS * BLK_TRANSFER_SIZE; i++) {
+        // we offset it so it's not 0 at start or end
+        block_data[i + NUM_READ_BLOCKS * BLK_TRANSFER_SIZE] = BYTE_ADJUST(i);
+    }
+
+    /* Request to write data, then read it back */
+
+    // write some zeroed data first; just our zeroed read blocks as a test.
+    int err = blk_enqueue_req(&blk_queue, BLK_REQ_WRITE, 0x0, data_address, NUM_READ_BLOCKS, /* req ID */ 0);
+    assert(!err);
+    err = blk_enqueue_req(&blk_queue, BLK_REQ_WRITE, 0x0 + NUM_READ_BLOCKS * BLK_TRANSFER_SIZE, data_address,
+                          NUM_WRITE_BLOCKS, /* req ID */ 1);
+    assert(!err);
+    err = blk_enqueue_req(&blk_queue, BLK_REQ_BARRIER, 0, 0, 0, /* req ID */ 2);
+    assert(!err);
+    err = blk_enqueue_req(&blk_queue, BLK_REQ_FLUSH, 0, 0, 0, /* req ID */ 3);
+    assert(!err);
+    // read some random stuff
+    err = blk_enqueue_req(&blk_queue, BLK_REQ_READ, 0x0, 0x0, NUM_READ_BLOCKS, /* req ID */ 4);
+    assert(!err);
+    // do a second read test to check this
+    err = blk_enqueue_req(&blk_queue, BLK_REQ_READ, 0x0, data_address, NUM_READ_BLOCKS, /* req ID */ 5);
+    assert(!err);
+
+    microkit_notify(BLK_VIRT_CHANNEL);
+}

--- a/examples/blk/mmc/include/configs/blk_config.h
+++ b/examples/blk/mmc/include/configs/blk_config.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sddf/blk/queue.h>
+#include <sddf/util/string.h>
+
+#define BLK_NUM_CLIENTS 1
+
+#define BLK_NAME_CLI0                      "CLIENT_MMC"
+
+#define BLK_QUEUE_SIZE_CLI0                 1024
+#define BLK_QUEUE_SIZE_DRIV                 (BLK_QUEUE_SIZE_CLI0)
+
+#define BLK_REGION_SIZE                     0x200000
+#define BLK_CONFIG_REGION_SIZE_CLI0         BLK_REGION_SIZE
+
+#define BLK_DATA_REGION_SIZE_CLI0           BLK_REGION_SIZE
+#define BLK_DATA_REGION_SIZE_DRIV           BLK_REGION_SIZE
+
+#define BLK_QUEUE_REGION_SIZE_CLI0          BLK_REGION_SIZE
+#define BLK_QUEUE_REGION_SIZE_DRIV          BLK_REGION_SIZE
+
+_Static_assert(BLK_DATA_REGION_SIZE_CLI0 >= BLK_TRANSFER_SIZE && BLK_DATA_REGION_SIZE_CLI0 % BLK_TRANSFER_SIZE == 0,
+               "Client0 data region size must be a multiple of the transfer size");
+_Static_assert(BLK_DATA_REGION_SIZE_DRIV >= BLK_TRANSFER_SIZE && BLK_DATA_REGION_SIZE_DRIV % BLK_TRANSFER_SIZE == 0,
+               "Driver data region size must be a multiple of the transfer size");
+
+/* Mapping from client index to disk partition that the client will have access to. */
+static const int blk_partition_mapping[BLK_NUM_CLIENTS] = { 2 };
+
+static inline blk_storage_info_t *blk_virt_cli_config_info(blk_storage_info_t *info, unsigned int id)
+{
+    switch (id) {
+    case 0:
+        return info;
+    case 1:
+        return (blk_storage_info_t *)((uintptr_t)info + BLK_CONFIG_REGION_SIZE_CLI0);
+    default:
+        return NULL;
+    }
+}
+
+static inline uintptr_t blk_virt_cli_data_region(uintptr_t data, unsigned int id)
+{
+    switch (id) {
+    case 0:
+        return data;
+    default:
+        return 0;
+    }
+}
+
+static inline uint64_t blk_virt_cli_data_region_size(unsigned int id)
+{
+    switch (id) {
+    case 0:
+        return BLK_DATA_REGION_SIZE_CLI0;
+    default:
+        return 0;
+    }
+}
+
+static inline blk_req_queue_t *blk_virt_cli_req_queue(blk_req_queue_t *req, unsigned int id)
+{
+    switch (id) {
+    case 0:
+        return req;
+    default:
+        return NULL;
+    }
+}
+
+static inline blk_resp_queue_t *blk_virt_cli_resp_queue(blk_resp_queue_t *resp, unsigned int id)
+{
+    switch (id) {
+    case 0:
+        return resp;
+    default:
+        return NULL;
+    }
+}
+
+static inline uint32_t blk_virt_cli_queue_size(unsigned int id)
+{
+    switch (id) {
+    case 0:
+        return BLK_QUEUE_SIZE_CLI0;
+    default:
+        return 0;
+    }
+}
+
+static inline uint32_t blk_cli_queue_size(char *pd_name)
+{
+    if (!sddf_strcmp(pd_name, BLK_NAME_CLI0)) {
+        return BLK_QUEUE_SIZE_CLI0;
+    } else {
+        return 0;
+    }
+}

--- a/examples/blk/mmc/mmc.mk
+++ b/examples/blk/mmc/mmc.mk
@@ -1,0 +1,89 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+ifeq ($(strip $(MICROKIT_SDK)),)
+$(error MICROKIT_SDK must be specified)
+endif
+
+ifeq ($(strip $(SDDF)),)
+$(error SDDF must be specified)
+endif
+
+ifeq ($(strip $(TOOLCHAIN)),)
+	TOOLCHAIN := aarch64-none-elf
+endif
+
+ifeq ($(strip $(TOOLCHAIN)), clang)
+	CC := clang -target aarch64-none-elf
+	LD := ld.lld
+	AR := llvm-ar
+	RANLIB := llvm-ranlib
+else
+	CC := $(TOOLCHAIN)-gcc
+	LD := $(TOOLCHAIN)-ld
+	AS := $(TOOLCHAIN)-as
+	AR := $(TOOLCHAIN)-ar
+	RANLIB := $(TOOLCHAIN)-ranlib
+endif
+
+BUILD_DIR ?= build
+MICROKIT_CONFIG ?= debug
+
+DRIVER_DIR := imx
+CPU := cortex-a53
+
+TOP := ${SDDF}/examples/blk/mmc
+CONFIGS_INCLUDE := ${TOP}/include/configs
+
+MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
+
+BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+
+IMAGES := mmc_driver.elf timer_driver.elf client.elf blk_virt.elf
+CFLAGS := -mcpu=$(CPU) \
+		  -mstrict-align \
+		  -nostdlib \
+		  -ffreestanding \
+		  -g3 \
+		  -O3 \
+		  -Wall -Wno-unused-function -Werror -Wno-unused-command-line-argument \
+		  -I$(BOARD_DIR)/include \
+		  -I$(SDDF)/include \
+		  -I$(CONFIGS_INCLUDE)
+LDFLAGS := -L$(BOARD_DIR)/lib
+LIBS := --start-group -lmicrokit -Tmicrokit.ld libsddf_util_debug.a --end-group
+
+IMAGE_FILE   := loader.img
+REPORT_FILE  := report.txt
+SYSTEM_FILE  := ${TOP}/board/$(MICROKIT_BOARD)/mmc.system
+
+MMC_DRIVER   := $(SDDF)/drivers/blk/mmc/${DRIVER_DIR}
+TIMER_DRIVER := $(SDDF)/drivers/clock/${DRIVER_DIR}
+
+BLK_COMPONENTS := $(SDDF)/blk/components
+
+all: $(IMAGE_FILE)
+
+include ${MMC_DRIVER}/mmc_driver.mk
+include ${TIMER_DRIVER}/timer_driver.mk
+
+include ${SDDF}/util/util.mk
+include ${BLK_COMPONENTS}/blk_components.mk
+
+${IMAGES}: libsddf_util_debug.a
+
+client.o: ${TOP}/client.c
+	$(CC) -c $(CFLAGS) $< -o client.o
+client.elf: client.o
+	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
+
+$(IMAGE_FILE) $(REPORT_FILE): $(IMAGES) $(SYSTEM_FILE)
+	$(MICROKIT_TOOL) $(SYSTEM_FILE) --search-path $(BUILD_DIR) --board $(MICROKIT_BOARD) --config $(MICROKIT_CONFIG) -o $(IMAGE_FILE) -r $(REPORT_FILE)
+
+clean::
+	rm -f client.o
+clobber:: clean
+	rm -f client.elf ${IMAGE_FILE} ${REPORT_FILE}


### PR DESCRIPTION
## Driver
This is a driver for the MaaXBoard SD host controller, based on the following documents:

- i.MX 8M Dual/8M QuadLite/8M Quad Applications Processors Reference Manual
  Document Number: IMX8MDQLQRM, Rev 3.1, 06/2021.
  https://www.nxp.com/webapp/Download?colCode=IMX8MDQLQRM
- SD Specifications Part 1 Physical Layer Simplified Specification.
  Version 9.10, Dec. 2023.
  https://www.sdcard.org/downloads/pls/
- SD Specifications Part A2 SD Host Controller Simplified Specification.
  Version 4.20, July 2018.
  https://www.sdcard.org/downloads/pls/

## Implemented
- IRQ & DMA based driver
- Supports 3.3V operation of Version 2 SDHC cards (4GiB–32GiB) at $f_{OD}$ (400kHz).

### Still in progress
- [x] Sending and receiving multiple blocks with the sDDF block queues (can only do it once)
- [x] Currently assumes client only sends notifications when it should be (it treats them as a IRQ when it should not)
- [x] Timeouts for card initialisation (SD-PHY specifies a 1 second timeout, we retry indefinitely)
- [x] The example client does only some manual tests, should do some automatic ones.
- [x] Clarifying the U-Boot quirks regarding `VEND_SPEC_CKEN` et al
- [x] Example should use virtualiser but does not right now.
- [x] Needs #152 

## Not Implemented
- Voltage Negotiation (anything but 3.3V)
- Version 1 SD cards (the initialisation flow)
- Version 2 SDSC / SDXC cards (only because I haven't implemented support for calculating card capacity)
- Higher speed operation (even Default Speed / 25 MHz ($f_{PP}$)) and DDR
- Setting as RO when write protect is set on the SD card
- Clock setup (currently inherits 150MHz clock from U-Boot)
- Pinmux setup (again, inherits from U-Boot)
- Timeouts as required by various commands, a lot of error handling
- Card detect does not seem to work