### PR TITLE
Update network and serial style

### DIFF
--- a/drivers/network/imx/ethernet.c
+++ b/drivers/network/imx/ethernet.c
@@ -18,14 +18,13 @@
 #define TX_CH  1
 #define RX_CH  2
 
-uintptr_t eth_regs;
 uintptr_t hw_ring_buffer_vaddr;
 uintptr_t hw_ring_buffer_paddr;
 
-uintptr_t rx_free;
-uintptr_t rx_active;
-uintptr_t tx_free;
-uintptr_t tx_active;
+net_queue_t *rx_free;
+net_queue_t *rx_active;
+net_queue_t *tx_free;
+net_queue_t *tx_active;
 
 #define RX_COUNT 256
 #define TX_COUNT 256
@@ -221,7 +220,6 @@ static void handle_irq(void)
 
 static void eth_setup(void)
 {
-    eth = (struct enet_regs *)eth_regs;
     uint32_t l = eth->palr;
     uint32_t h = eth->paur;
 
@@ -304,8 +302,8 @@ void init(void)
 {
     eth_setup();
 
-    net_queue_init(&rx_queue, (net_queue_t *)rx_free, (net_queue_t *)rx_active, NET_RX_QUEUE_SIZE_DRIV);
-    net_queue_init(&tx_queue, (net_queue_t *)tx_free, (net_queue_t *)tx_active, NET_TX_QUEUE_SIZE_DRIV);
+    net_queue_init(&rx_queue, rx_free, rx_active, NET_RX_QUEUE_SIZE_DRIV);
+    net_queue_init(&tx_queue, tx_free, tx_active, NET_TX_QUEUE_SIZE_DRIV);
 
     rx_provide();
     tx_provide();

--- a/drivers/network/meson/ethernet.c
+++ b/drivers/network/meson/ethernet.c
@@ -18,14 +18,13 @@
 #define TX_CH  1
 #define RX_CH  2
 
-uintptr_t eth_regs;
 uintptr_t hw_ring_buffer_vaddr;
 uintptr_t hw_ring_buffer_paddr;
 
-uintptr_t rx_free;
-uintptr_t rx_active;
-uintptr_t tx_free;
-uintptr_t tx_active;
+net_queue_t *rx_free;
+net_queue_t *rx_active;
+net_queue_t *tx_free;
+net_queue_t *tx_active;
 
 #define RX_COUNT 256
 #define TX_COUNT 256
@@ -227,8 +226,7 @@ static void handle_irq()
 
 static void eth_setup(void)
 {
-    eth_mac = (void *)eth_regs;
-    eth_dma = (void *)(eth_regs + DMA_REG_OFFSET);
+    eth_dma = (void *)((uintptr_t)eth_mac + DMA_REG_OFFSET);
     uint32_t l = eth_mac->macaddr0lo;
     uint32_t h = eth_mac->macaddr0hi;
 

--- a/drivers/network/virtio/ethernet.c
+++ b/drivers/network/virtio/ethernet.c
@@ -48,10 +48,10 @@ uintptr_t eth_regs;
 uintptr_t hw_ring_buffer_vaddr;
 uintptr_t hw_ring_buffer_paddr;
 
-uintptr_t rx_free;
-uintptr_t rx_active;
-uintptr_t tx_free;
-uintptr_t tx_active;
+net_queue_t *rx_free;
+net_queue_t *rx_active;
+net_queue_t *tx_free;
+net_queue_t *tx_active;
 
 #define RX_COUNT 512
 #define TX_COUNT 512
@@ -438,8 +438,8 @@ void init(void)
     ialloc_init(&rx_ialloc_desc, rx_descriptors, RX_COUNT);
     ialloc_init(&tx_ialloc_desc, tx_descriptors, TX_COUNT);
 
-    net_queue_init(&rx_queue, (net_queue_t *)rx_free, (net_queue_t *)rx_active, NET_RX_QUEUE_SIZE_DRIV);
-    net_queue_init(&tx_queue, (net_queue_t *)tx_free, (net_queue_t *)tx_active, NET_TX_QUEUE_SIZE_DRIV);
+    net_queue_init(&rx_queue, rx_free, rx_active, NET_RX_QUEUE_SIZE_DRIV);
+    net_queue_init(&tx_queue, tx_free, tx_active, NET_TX_QUEUE_SIZE_DRIV);
 
     eth_setup();
 

--- a/drivers/serial/arm/uart.c
+++ b/drivers/serial/arm/uart.c
@@ -169,7 +169,9 @@ void init(void)
 {
     uart_setup();
 
+#if !SERIAL_TX_ONLY
     serial_queue_init(&rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_DRIV, rx_data);
+#endif
     serial_queue_init(&tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_DRIV, tx_data);
 }
 

--- a/drivers/serial/imx/uart.c
+++ b/drivers/serial/imx/uart.c
@@ -175,7 +175,9 @@ void init(void)
 {
     uart_setup();
 
+#if !SERIAL_TX_ONLY
     serial_queue_init(&rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_DRIV, rx_data);
+#endif
     serial_queue_init(&tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_DRIV, tx_data);
 }
 

--- a/drivers/serial/meson/uart.c
+++ b/drivers/serial/meson/uart.c
@@ -200,7 +200,9 @@ void init(void)
 {
     uart_setup();
 
+#if !SERIAL_TX_ONLY
     serial_queue_init(&rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_DRIV, rx_data);
+#endif
     serial_queue_init(&tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_DRIV, tx_data);
 }
 

--- a/examples/echo_server/board/imx8mm_evk/echo_server.system
+++ b/examples/echo_server/board/imx8mm_evk/echo_server.system
@@ -104,7 +104,7 @@
             <map mr="serial_tx_data_client2" vaddr="0x4_00a_000" perms="r" cached="true"/>
         </protection_domain>
 
-        <protection_domain name="net_virt_rx" priority="99" pp="true" id="2">
+        <protection_domain name="net_virt_rx" priority="99" id="2">
             <program_image path="network_virt_rx.elf" />
             <map mr="net_rx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_drv" />
             <map mr="net_rx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_drv" />

--- a/examples/echo_server/board/imx8mm_evk/echo_server.system
+++ b/examples/echo_server/board/imx8mm_evk/echo_server.system
@@ -66,7 +66,7 @@
 
         <protection_domain name="eth" priority="101" id="1" budget="100" period="400">
             <program_image path="eth_driver.elf" />
-            <map mr="eth0" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="eth_regs"/>
+            <map mr="eth0" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="eth"/>
 
             <map mr="hw_ring_buffer" vaddr="0x2_200_000" perms="rw" cached="false" setvar_vaddr="hw_ring_buffer_vaddr" />
 
@@ -111,8 +111,8 @@
 
             <map mr="net_rx_free_copy0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
             <map mr="net_rx_active_copy0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
-            <map mr="net_rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli1" />
-            <map mr="net_rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli1" />
+            <map mr="net_rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" />
+            <map mr="net_rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" />
 
             <map mr="net_rx_buffer_data_region" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
             <setvar symbol="buffer_data_paddr" region_paddr="net_rx_buffer_data_region" />
@@ -149,11 +149,11 @@
 
             <map mr="net_tx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli0" />
             <map mr="net_tx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli0" />
-            <map mr="net_tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli1" />
-            <map mr="net_tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli1" />
+            <map mr="net_tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" />
+            <map mr="net_tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" />
 
             <map mr="net_tx_buffer_data_region_cli0" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli0_vaddr" />
-            <map mr="net_tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli1_vaddr" />
+            <map mr="net_tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" />
             <setvar symbol="buffer_data_region_cli0_paddr" region_paddr="net_tx_buffer_data_region_cli0" />
             <setvar symbol="buffer_data_region_cli1_paddr" region_paddr="net_tx_buffer_data_region_cli1" />
         </protection_domain>

--- a/examples/echo_server/board/maaxboard/echo_server.system
+++ b/examples/echo_server/board/maaxboard/echo_server.system
@@ -104,7 +104,7 @@
             <map mr="serial_tx_data_client2" vaddr="0x4_00a_000" perms="r" cached="true"/>
         </protection_domain>
 
-        <protection_domain name="net_virt_rx" priority="99" pp="true" id="2">
+        <protection_domain name="net_virt_rx" priority="99" id="2">
             <program_image path="network_virt_rx.elf" />
             <map mr="net_rx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_drv" />
             <map mr="net_rx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_drv" />

--- a/examples/echo_server/board/maaxboard/echo_server.system
+++ b/examples/echo_server/board/maaxboard/echo_server.system
@@ -66,7 +66,7 @@
 
         <protection_domain name="eth" priority="101" id="1" budget="100" period="400">
             <program_image path="eth_driver.elf" />
-            <map mr="eth0" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="eth_regs"/>
+            <map mr="eth0" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="eth"/>
 
             <map mr="hw_ring_buffer" vaddr="0x2_200_000" perms="rw" cached="false" setvar_vaddr="hw_ring_buffer_vaddr" />
 
@@ -111,8 +111,8 @@
 
             <map mr="net_rx_free_copy0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
             <map mr="net_rx_active_copy0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
-            <map mr="net_rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli1" />
-            <map mr="net_rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli1" />
+            <map mr="net_rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" />
+            <map mr="net_rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" />
 
             <map mr="net_rx_buffer_data_region" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
             <setvar symbol="buffer_data_paddr" region_paddr="net_rx_buffer_data_region" />
@@ -149,11 +149,11 @@
 
             <map mr="net_tx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli0" />
             <map mr="net_tx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli0" />
-            <map mr="net_tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli1" />
-            <map mr="net_tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli1" />
+            <map mr="net_tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" />
+            <map mr="net_tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" />
 
             <map mr="net_tx_buffer_data_region_cli0" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli0_vaddr" />
-            <map mr="net_tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli1_vaddr" />
+            <map mr="net_tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" />
             <setvar symbol="buffer_data_region_cli0_paddr" region_paddr="net_tx_buffer_data_region_cli0" />
             <setvar symbol="buffer_data_region_cli1_paddr" region_paddr="net_tx_buffer_data_region_cli1" />
         </protection_domain>

--- a/examples/echo_server/board/odroidc4/echo_server.system
+++ b/examples/echo_server/board/odroidc4/echo_server.system
@@ -104,7 +104,7 @@
             <map mr="serial_tx_data_client2" vaddr="0x4_00a_000" perms="r" cached="true"/>
         </protection_domain>
 
-        <protection_domain name="net_virt_rx" priority="99" pp="true" id="2">
+        <protection_domain name="net_virt_rx" priority="99" id="2">
             <program_image path="network_virt_rx.elf" />
             <map mr="net_rx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_drv" />
             <map mr="net_rx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_drv" />

--- a/examples/echo_server/board/odroidc4/echo_server.system
+++ b/examples/echo_server/board/odroidc4/echo_server.system
@@ -66,7 +66,7 @@
 
         <protection_domain name="eth" priority="101" id="1" budget="100" period="400">
             <program_image path="eth_driver.elf" />
-            <map mr="eth0" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="eth_regs"/>
+            <map mr="eth0" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="eth_mac"/>
 
             <map mr="hw_ring_buffer" vaddr="0x2_200_000" perms="rw" cached="false" setvar_vaddr="hw_ring_buffer_vaddr" />
 
@@ -111,8 +111,8 @@
 
             <map mr="net_rx_free_copy0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
             <map mr="net_rx_active_copy0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
-            <map mr="net_rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli1" />
-            <map mr="net_rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli1" />
+            <map mr="net_rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" />
+            <map mr="net_rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" />
 
             <map mr="net_rx_buffer_data_region" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
             <setvar symbol="buffer_data_paddr" region_paddr="net_rx_buffer_data_region" />
@@ -149,11 +149,11 @@
 
             <map mr="net_tx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli0" />
             <map mr="net_tx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli0" />
-            <map mr="net_tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli1" />
-            <map mr="net_tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli1" />
+            <map mr="net_tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" />
+            <map mr="net_tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" />
 
             <map mr="net_tx_buffer_data_region_cli0" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli0_vaddr" />
-            <map mr="net_tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli1_vaddr" />
+            <map mr="net_tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" />
             <setvar symbol="buffer_data_region_cli0_paddr" region_paddr="net_tx_buffer_data_region_cli0" />
             <setvar symbol="buffer_data_region_cli1_paddr" region_paddr="net_tx_buffer_data_region_cli1" />
         </protection_domain>

--- a/examples/echo_server/board/qemu_arm_virt/echo_server.system
+++ b/examples/echo_server/board/qemu_arm_virt/echo_server.system
@@ -110,8 +110,8 @@
 
             <map mr="net_rx_free_copy0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
             <map mr="net_rx_active_copy0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
-            <map mr="net_rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli1" />
-            <map mr="net_rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli1" />
+            <map mr="net_rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" />
+            <map mr="net_rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" />
 
             <map mr="net_rx_buffer_data_region" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
             <setvar symbol="buffer_data_paddr" region_paddr="net_rx_buffer_data_region" />
@@ -148,11 +148,11 @@
 
             <map mr="net_tx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli0" />
             <map mr="net_tx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli0" />
-            <map mr="net_tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli1" />
-            <map mr="net_tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli1" />
+            <map mr="net_tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" />
+            <map mr="net_tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" />
 
             <map mr="net_tx_buffer_data_region_cli0" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli0_vaddr" />
-            <map mr="net_tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli1_vaddr" />
+            <map mr="net_tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" />
             <setvar symbol="buffer_data_region_cli0_paddr" region_paddr="net_tx_buffer_data_region_cli0" />
             <setvar symbol="buffer_data_region_cli1_paddr" region_paddr="net_tx_buffer_data_region_cli1" />
         </protection_domain>

--- a/examples/echo_server/board/qemu_arm_virt/echo_server.system
+++ b/examples/echo_server/board/qemu_arm_virt/echo_server.system
@@ -103,7 +103,7 @@
             <map mr="serial_tx_data_client2" vaddr="0x4_00a_000" perms="r" cached="true"/>
         </protection_domain>
 
-        <protection_domain name="net_virt_rx" priority="99" pp="true" id="2">
+        <protection_domain name="net_virt_rx" priority="99" id="2">
             <program_image path="network_virt_rx.elf" />
             <map mr="net_rx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_drv" />
             <map mr="net_rx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_drv" />

--- a/examples/echo_server/include/ethernet_config/ethernet_config.h
+++ b/examples/echo_server/include/ethernet_config/ethernet_config.h
@@ -102,43 +102,43 @@ static inline void net_virt_mac_addr_init_sys(char *pd_name, uint8_t *macs)
     }
 }
 
-static inline void net_cli_queue_init_sys(char *pd_name, net_queue_handle_t *rx_queue, uintptr_t rx_free,
-                                          uintptr_t rx_active, net_queue_handle_t *tx_queue, uintptr_t tx_free,
-                                          uintptr_t tx_active)
+static inline void net_cli_queue_init_sys(char *pd_name, net_queue_handle_t *rx_queue, net_queue_t *rx_free,
+                                          net_queue_t *rx_active, net_queue_handle_t *tx_queue, net_queue_t *tx_free,
+                                          net_queue_t *tx_active)
 {
     if (!sddf_strcmp(pd_name, NET_CLI0_NAME)) {
-        net_queue_init(rx_queue, (net_queue_t *) rx_free, (net_queue_t *) rx_active, NET_RX_QUEUE_SIZE_CLI0);
-        net_queue_init(tx_queue, (net_queue_t *) tx_free, (net_queue_t *) tx_active, NET_TX_QUEUE_SIZE_CLI0);
+        net_queue_init(rx_queue, rx_free, rx_active, NET_RX_QUEUE_SIZE_CLI0);
+        net_queue_init(tx_queue, tx_free, tx_active, NET_TX_QUEUE_SIZE_CLI0);
     } else if (!sddf_strcmp(pd_name, NET_CLI1_NAME)) {
-        net_queue_init(rx_queue, (net_queue_t *) rx_free, (net_queue_t *) rx_active, NET_RX_QUEUE_SIZE_CLI1);
-        net_queue_init(tx_queue, (net_queue_t *) tx_free, (net_queue_t *) tx_active, NET_TX_QUEUE_SIZE_CLI1);
+        net_queue_init(rx_queue, rx_free, rx_active, NET_RX_QUEUE_SIZE_CLI1);
+        net_queue_init(tx_queue, tx_free, tx_active, NET_TX_QUEUE_SIZE_CLI1);
     }
 }
 
-static inline void net_copy_queue_init_sys(char *pd_name, net_queue_handle_t *cli_queue, uintptr_t cli_free,
-                                           uintptr_t cli_active, net_queue_handle_t *virt_queue, uintptr_t virt_free,
-                                           uintptr_t virt_active)
+static inline void net_copy_queue_init_sys(char *pd_name, net_queue_handle_t *cli_queue, net_queue_t *cli_free,
+                                           net_queue_t *cli_active, net_queue_handle_t *virt_queue, net_queue_t *virt_free,
+                                           net_queue_t *virt_active)
 {
     if (!sddf_strcmp(pd_name, NET_COPY0_NAME)) {
-        net_queue_init(cli_queue, (net_queue_t *) cli_free, (net_queue_t *) cli_active, NET_RX_QUEUE_SIZE_CLI0);
-        net_queue_init(virt_queue, (net_queue_t *) virt_free, (net_queue_t *) virt_active, NET_RX_QUEUE_SIZE_COPY0);
+        net_queue_init(cli_queue, cli_free, cli_active, NET_RX_QUEUE_SIZE_CLI0);
+        net_queue_init(virt_queue, virt_free, virt_active, NET_RX_QUEUE_SIZE_COPY0);
     } else if (!sddf_strcmp(pd_name, NET_COPY1_NAME)) {
-        net_queue_init(cli_queue, (net_queue_t *) cli_free, (net_queue_t *) cli_active, NET_RX_QUEUE_SIZE_CLI1);
-        net_queue_init(virt_queue, (net_queue_t *) virt_free, (net_queue_t *) virt_active, NET_RX_QUEUE_SIZE_COPY1);
+        net_queue_init(cli_queue, cli_free, cli_active, NET_RX_QUEUE_SIZE_CLI1);
+        net_queue_init(virt_queue, virt_free, virt_active, NET_RX_QUEUE_SIZE_COPY1);
     }
 }
 
-static inline void net_virt_queue_init_sys(char *pd_name, net_queue_handle_t *cli_queue, uintptr_t cli_free,
-                                           uintptr_t cli_active)
+static inline void net_virt_queue_init_sys(char *pd_name, net_queue_handle_t *cli_queue, net_queue_t *cli_free,
+                                           net_queue_t *cli_active)
 {
     if (!sddf_strcmp(pd_name, NET_VIRT_RX_NAME)) {
-        net_queue_init(cli_queue, (net_queue_t *) cli_free, (net_queue_t *) cli_active, NET_RX_QUEUE_SIZE_COPY0);
-        net_queue_init(&cli_queue[1], (net_queue_t *)(cli_free + 2 * NET_DATA_REGION_SIZE),
-                       (net_queue_t *)(cli_active + 2 * NET_DATA_REGION_SIZE), NET_RX_QUEUE_SIZE_COPY1);
+        net_queue_init(cli_queue, cli_free, cli_active, NET_RX_QUEUE_SIZE_COPY0);
+        net_queue_init(&cli_queue[1], (net_queue_t *)((uintptr_t)cli_free + 2 * NET_DATA_REGION_SIZE),
+                       (net_queue_t *)((uintptr_t)cli_active + 2 * NET_DATA_REGION_SIZE), NET_RX_QUEUE_SIZE_COPY1);
     } else if (!sddf_strcmp(pd_name, NET_VIRT_TX_NAME)) {
-        net_queue_init(cli_queue, (net_queue_t *) cli_free, (net_queue_t *) cli_active, NET_TX_QUEUE_SIZE_CLI0);
-        net_queue_init(&cli_queue[1], (net_queue_t *)(cli_free + 2 * NET_DATA_REGION_SIZE),
-                       (net_queue_t *)(cli_active + 2 * NET_DATA_REGION_SIZE), NET_TX_QUEUE_SIZE_CLI1);
+        net_queue_init(cli_queue, cli_free, cli_active, NET_TX_QUEUE_SIZE_CLI0);
+        net_queue_init(&cli_queue[1], (net_queue_t *)((uintptr_t)cli_free + 2 * NET_DATA_REGION_SIZE),
+                       (net_queue_t *)((uintptr_t)cli_active + 2 * NET_DATA_REGION_SIZE), NET_TX_QUEUE_SIZE_CLI1);
     }
 }
 

--- a/examples/echo_server/include/ethernet_config/ethernet_config.h
+++ b/examples/echo_server/include/ethernet_config/ethernet_config.h
@@ -50,6 +50,7 @@ _Static_assert(NET_TX_DATA_REGION_SIZE_CLI1 >= NET_TX_QUEUE_SIZE_CLI1 *NET_BUFFE
 #define NET_RX_QUEUE_SIZE_DRIV                   512
 #define NET_RX_QUEUE_SIZE_CLI0                   512
 #define NET_RX_QUEUE_SIZE_CLI1                   512
+#define NET_MAX_CLIENT_QUEUE_SIZE                MAX(NET_RX_QUEUE_SIZE_CLI0, NET_RX_QUEUE_SIZE_CLI1)
 #define NET_RX_QUEUE_SIZE_COPY0                  NET_RX_QUEUE_SIZE_DRIV
 #define NET_RX_QUEUE_SIZE_COPY1                  NET_RX_QUEUE_SIZE_DRIV
 

--- a/examples/echo_server/include/serial_config/serial_config.h
+++ b/examples/echo_server/include/serial_config/serial_config.h
@@ -62,7 +62,7 @@ static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle
                           SERIAL_TX_DATA_REGION_SIZE_CLI1, cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0);
         serial_queue_init(&cli_queue_handle[2], (serial_queue_t *)((uintptr_t)cli_queue + 2 * SERIAL_QUEUE_SIZE),
                           SERIAL_TX_DATA_REGION_SIZE_CLI2, cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0 +
-                                                                    SERIAL_TX_DATA_REGION_SIZE_CLI1);
+                          SERIAL_TX_DATA_REGION_SIZE_CLI1);
     }
 }
 

--- a/examples/echo_server/include/serial_config/serial_config.h
+++ b/examples/echo_server/include/serial_config/serial_config.h
@@ -26,9 +26,7 @@
 #define SERIAL_CLI0_NAME "client0"
 #define SERIAL_CLI1_NAME "client1"
 #define SERIAL_CLI2_NAME "bench"
-#define SERIAL_VIRT_RX_NAME "serial_virt_rx"
 #define SERIAL_VIRT_TX_NAME "serial_virt_tx"
-#define SERIAL_DRIVER_NAME "uart"
 
 #define SERIAL_QUEUE_SIZE                          0x1000
 #define SERIAL_DATA_REGION_SIZE                    0x2000
@@ -38,13 +36,7 @@
 #define SERIAL_TX_DATA_REGION_SIZE_CLI1            SERIAL_DATA_REGION_SIZE
 #define SERIAL_TX_DATA_REGION_SIZE_CLI2            SERIAL_DATA_REGION_SIZE
 
-#define SERIAL_RX_DATA_REGION_SIZE_DRIV            SERIAL_DATA_REGION_SIZE
-#define SERIAL_RX_DATA_REGION_SIZE_CLI0            SERIAL_DATA_REGION_SIZE
-#define SERIAL_RX_DATA_REGION_SIZE_CLI1            SERIAL_DATA_REGION_SIZE
-
-#define SERIAL_MAX_TX_DATA_SIZE MAX(SERIAL_TX_DATA_REGION_SIZE_DRIV, MAX(SERIAL_TX_DATA_REGION_SIZE_CLI0, MAX(SERIAL_TX_DATA_REGION_SIZE_CLI1, SERIAL_TX_DATA_REGION_SIZE_CLI2)))
-#define SERIAL_MAX_RX_DATA_SIZE MAX(SERIAL_RX_DATA_REGION_SIZE_DRIV, MAX(SERIAL_RX_DATA_REGION_SIZE_CLI0, SERIAL_RX_DATA_REGION_SIZE_CLI1))
-#define SERIAL_MAX_DATA_SIZE MAX(SERIAL_MAX_TX_DATA_SIZE, SERIAL_MAX_RX_DATA_SIZE)
+#define SERIAL_MAX_DATA_SIZE MAX(SERIAL_TX_DATA_REGION_SIZE_DRIV, MAX(SERIAL_TX_DATA_REGION_SIZE_CLI0, MAX(SERIAL_TX_DATA_REGION_SIZE_CLI1, SERIAL_TX_DATA_REGION_SIZE_CLI2)))
 _Static_assert(SERIAL_MAX_DATA_SIZE < UINT32_MAX,
                "Data regions must be smaller than UINT32 max to correctly use queue data structure.");
 
@@ -64,11 +56,7 @@ static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_
 static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle_t *cli_queue_handle,
                                               uintptr_t cli_queue, uintptr_t cli_data)
 {
-    if (!sddf_strcmp(pd_name, SERIAL_VIRT_RX_NAME)) {
-        serial_queue_init(cli_queue_handle, (serial_queue_t *) cli_queue, SERIAL_RX_DATA_REGION_SIZE_CLI0, (char *)cli_data);
-        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)(cli_queue + SERIAL_QUEUE_SIZE),
-                          SERIAL_RX_DATA_REGION_SIZE_CLI1, (char *)(cli_data + SERIAL_RX_DATA_REGION_SIZE_CLI0));
-    } else if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
+    if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
         serial_queue_init(cli_queue_handle, (serial_queue_t *) cli_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, (char *)cli_data);
         serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)(cli_queue + SERIAL_QUEUE_SIZE),
                           SERIAL_TX_DATA_REGION_SIZE_CLI1, (char *)(cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0));

--- a/examples/echo_server/include/serial_config/serial_config.h
+++ b/examples/echo_server/include/serial_config/serial_config.h
@@ -54,15 +54,15 @@ static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_
 }
 
 static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle_t *cli_queue_handle,
-                                              uintptr_t cli_queue, uintptr_t cli_data)
+                                              serial_queue_t *cli_queue, char *cli_data)
 {
     if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
-        serial_queue_init(cli_queue_handle, (serial_queue_t *) cli_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, (char *)cli_data);
-        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)(cli_queue + SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_SIZE_CLI1, (char *)(cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0));
-        serial_queue_init(&cli_queue_handle[2], (serial_queue_t *)(cli_queue + 2 * SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_SIZE_CLI2, (char *)(cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0 +
-                                                                    SERIAL_TX_DATA_REGION_SIZE_CLI1));
+        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, cli_data);
+        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)((uintptr_t)cli_queue + SERIAL_QUEUE_SIZE),
+                          SERIAL_TX_DATA_REGION_SIZE_CLI1, cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0);
+        serial_queue_init(&cli_queue_handle[2], (serial_queue_t *)((uintptr_t)cli_queue + 2 * SERIAL_QUEUE_SIZE),
+                          SERIAL_TX_DATA_REGION_SIZE_CLI2, cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0 +
+                                                                    SERIAL_TX_DATA_REGION_SIZE_CLI1);
     }
 }
 

--- a/examples/echo_server/lwip.c
+++ b/examples/echo_server/lwip.c
@@ -37,7 +37,7 @@ serial_queue_t *serial_tx_queue;
 serial_queue_handle_t serial_tx_queue_handle;
 
 #define LWIP_TICK_MS 100
-#define NUM_PBUFFS 512
+#define NUM_PBUFFS NET_MAX_CLIENT_QUEUE_SIZE
 
 uintptr_t rx_free;
 uintptr_t rx_active;
@@ -231,6 +231,7 @@ void receive(void)
             assert(!err);
 
             struct pbuf *p = create_interface_buffer(buffer.io_or_offset, buffer.len);
+            assert(p != NULL);
             if (state.netif.input(p, &state.netif) != ERR_OK) {
                 sddf_dprintf("LWIP|ERROR: unkown error inputting pbuf into network stack\n");
                 pbuf_free(p);

--- a/examples/serial/include/serial_config/serial_config.h
+++ b/examples/serial/include/serial_config/serial_config.h
@@ -30,7 +30,6 @@
 #define SERIAL_CLI1_NAME "client1"
 #define SERIAL_VIRT_RX_NAME "serial_virt_rx"
 #define SERIAL_VIRT_TX_NAME "serial_virt_tx"
-#define SERIAL_DRIVER_NAME "uart"
 
 #define SERIAL_QUEUE_SIZE                          0x1000
 #define SERIAL_DATA_REGION_SIZE                    0x2000
@@ -63,16 +62,16 @@ static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_
 }
 
 static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle_t *cli_queue_handle,
-                                              uintptr_t cli_queue, uintptr_t cli_data)
+                                              serial_queue_t *cli_queue, char *cli_data)
 {
     if (!sddf_strcmp(pd_name, SERIAL_VIRT_RX_NAME)) {
-        serial_queue_init(cli_queue_handle, (serial_queue_t *) cli_queue, SERIAL_RX_DATA_REGION_SIZE_CLI0, (char *)cli_data);
-        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)(cli_queue + SERIAL_QUEUE_SIZE),
-                          SERIAL_RX_DATA_REGION_SIZE_CLI1, (char *)(cli_data + SERIAL_RX_DATA_REGION_SIZE_CLI0));
+        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_RX_DATA_REGION_SIZE_CLI0, cli_data);
+        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)((uintptr_t)cli_queue + SERIAL_QUEUE_SIZE),
+                          SERIAL_RX_DATA_REGION_SIZE_CLI1, cli_data + SERIAL_RX_DATA_REGION_SIZE_CLI0);
     } else if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
-        serial_queue_init(cli_queue_handle, (serial_queue_t *) cli_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, (char *)cli_data);
-        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)(cli_queue + SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_SIZE_CLI1, (char *)(cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0));
+        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, cli_data);
+        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)((uintptr_t)cli_queue + SERIAL_QUEUE_SIZE),
+                          SERIAL_TX_DATA_REGION_SIZE_CLI1, cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0);
     }
 }
 

--- a/network/components/arp.c
+++ b/network/components/arp.c
@@ -18,15 +18,13 @@
 net_queue_handle_t rx_queue;
 net_queue_handle_t tx_queue;
 
-uintptr_t rx_free;
-uintptr_t rx_active;
-uintptr_t tx_free;
-uintptr_t tx_active;
+net_queue_t *rx_free;
+net_queue_t *rx_active;
+net_queue_t *tx_free;
+net_queue_t *tx_active;
 
 uintptr_t rx_buffer_data_region;
 uintptr_t tx_buffer_data_region;
-
-uintptr_t uart_base;
 
 uint8_t mac_addrs[NUM_ARP_CLIENTS][ETH_HWADDR_LEN];
 uint32_t ipv4_addrs[NUM_ARP_CLIENTS];
@@ -104,9 +102,7 @@ static int arp_reply(const uint8_t ethsrc_addr[ETH_HWADDR_LEN],
     int err = net_dequeue_free(&tx_queue, &buffer);
     assert(!err);
 
-    uintptr_t addr = tx_buffer_data_region + buffer.io_or_offset;
-
-    struct arp_packet *reply = (struct arp_packet *)addr;
+    struct arp_packet *reply = (struct arp_packet *)(tx_buffer_data_region + buffer.io_or_offset);
     memcpy(&reply->ethdst_addr, ethdst_addr, ETH_HWADDR_LEN);
     memcpy(&reply->ethsrc_addr, ethsrc_addr, ETH_HWADDR_LEN);
 
@@ -139,10 +135,9 @@ void receive(void)
             net_buff_desc_t buffer;
             int err = net_dequeue_active(&rx_queue, &buffer);
             assert(!err);
-            uintptr_t addr = rx_buffer_data_region + buffer.io_or_offset;
 
             /* Check if packet is an ARP request */
-            struct ethernet_header *ethhdr = (struct ethernet_header *)addr;
+            struct ethernet_header *ethhdr = (struct ethernet_header *)(rx_buffer_data_region + buffer.io_or_offset);
             if (ethhdr->type == HTONS(ETH_TYPE_ARP)) {
                 struct arp_packet *pkt = (struct arp_packet *)addr;
                 /* Check if it's a probe, ignore announcements */
@@ -216,8 +211,8 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
 
 void init(void)
 {
-    net_queue_init(&rx_queue, (net_queue_t *)rx_free, (net_queue_t *)rx_active, ETHERNET_RX_QUEUE_SIZE_ARP);
-    net_queue_init(&tx_queue, (net_queue_t *)tx_free, (net_queue_t *)tx_active, ETHERNET_TX_QUEUE_SIZE_ARP);
+    net_queue_init(&rx_queue, rx_free, rx_active, ETHERNET_RX_QUEUE_SIZE_ARP);
+    net_queue_init(&tx_queue, tx_free, tx_active, ETHERNET_TX_QUEUE_SIZE_ARP);
     net_buffers_init(&tx_queue, 0);
 
     ethernet_arp_mac_addr_init_sys(microkit_name, (uint8_t *) mac_addrs);

--- a/network/components/copy.c
+++ b/network/components/copy.c
@@ -2,7 +2,6 @@
 #include <stdbool.h>
 #include <microkit.h>
 #include <sddf/network/queue.h>
-#include <sddf/util/fence.h>
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
 #include <ethernet_config.h>
@@ -13,10 +12,10 @@
 net_queue_handle_t rx_queue_virt;
 net_queue_handle_t rx_queue_cli;
 
-uintptr_t rx_free_virt;
-uintptr_t rx_active_virt;
-uintptr_t rx_free_cli;
-uintptr_t rx_active_cli;
+net_queue_t *rx_free_virt;
+net_queue_t *rx_active_virt;
+net_queue_t *rx_free_cli;
+net_queue_t *rx_active_cli;
 
 uintptr_t virt_buffer_data_region;
 uintptr_t cli_buffer_data_region;

--- a/network/components/virt_rx.c
+++ b/network/components/virt_rx.c
@@ -3,7 +3,6 @@
 #include <microkit.h>
 #include <sddf/network/queue.h>
 #include <sddf/network/constants.h>
-#include <sddf/util/fence.h>
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
 #include <sddf/util/cache.h>
@@ -18,12 +17,10 @@
 #define BROADCAST_ID (NUM_NETWORK_CLIENTS + 1)
 
 /* Queue regions */
-uintptr_t rx_free_drv;
-uintptr_t rx_active_drv;
-uintptr_t rx_free_cli0;
-uintptr_t rx_active_cli0;
-uintptr_t rx_free_cli1;
-uintptr_t rx_active_cli1;
+net_queue_t *rx_free_drv;
+net_queue_t *rx_active_drv;
+net_queue_t *rx_free_cli0;
+net_queue_t *rx_active_cli0;
 
 /* Buffer data regions */
 uintptr_t buffer_data_vaddr;
@@ -202,7 +199,7 @@ void init(void)
 {
     net_virt_mac_addr_init_sys(microkit_name, (uint8_t *) state.mac_addrs);
 
-    net_queue_init(&state.rx_queue_drv, (net_queue_t *)rx_free_drv, (net_queue_t *)rx_active_drv, NET_RX_QUEUE_SIZE_DRIV);
+    net_queue_init(&state.rx_queue_drv, rx_free_drv, rx_active_drv, NET_RX_QUEUE_SIZE_DRIV);
     net_virt_queue_init_sys(microkit_name, state.rx_queue_clients, rx_free_cli0, rx_active_cli0);
     net_buffers_init(&state.rx_queue_drv, buffer_data_paddr);
 

--- a/network/components/virt_tx.c
+++ b/network/components/virt_tx.c
@@ -1,7 +1,6 @@
 #include <microkit.h>
 #include <sddf/network/queue.h>
 #include <sddf/util/cache.h>
-#include <sddf/util/fence.h>
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
 #include <ethernet_config.h>
@@ -9,16 +8,12 @@
 #define DRIVER 0
 #define CLIENT_CH 1
 
-uintptr_t tx_free_drv;
-uintptr_t tx_active_drv;
-uintptr_t tx_free_cli0;
-uintptr_t tx_active_cli0;
-uintptr_t tx_free_cli1;
-uintptr_t tx_active_cli1;
+net_queue_t *tx_free_drv;
+net_queue_t *tx_active_drv;
+net_queue_t *tx_free_cli0;
+net_queue_t *tx_active_cli0;
 
 uintptr_t buffer_data_region_cli0_vaddr;
-uintptr_t buffer_data_region_cli1_vaddr;
-
 uintptr_t buffer_data_region_cli0_paddr;
 uintptr_t buffer_data_region_cli1_paddr;
 
@@ -131,7 +126,7 @@ void notified(microkit_channel ch)
 
 void init(void)
 {
-    net_queue_init(&state.tx_queue_drv, (net_queue_t *)tx_free_drv, (net_queue_t *)tx_active_drv, NET_TX_QUEUE_SIZE_DRIV);
+    net_queue_init(&state.tx_queue_drv, tx_free_drv, tx_active_drv, NET_TX_QUEUE_SIZE_DRIV);
     net_virt_queue_init_sys(microkit_name, state.tx_queue_clients, tx_free_cli0, tx_active_cli0);
 
     net_mem_region_init_sys(microkit_name, state.buffer_region_vaddrs, buffer_data_region_cli0_vaddr);

--- a/serial/components/virt_rx.c
+++ b/serial/components/virt_rx.c
@@ -10,10 +10,10 @@
 #define CLIENT_OFFSET 1
 
 serial_queue_t *rx_queue_drv;
-uintptr_t rx_queue_cli0;
+serial_queue_t *rx_queue_cli0;
 
 char *rx_data_drv;
-uintptr_t rx_data_cli0;
+char *rx_data_cli0;
 
 serial_queue_handle_t rx_queue_handle_drv;
 serial_queue_handle_t rx_queue_handle_cli[SERIAL_NUM_CLIENTS];

--- a/serial/components/virt_tx.c
+++ b/serial/components/virt_tx.c
@@ -9,10 +9,10 @@
 #define CLIENT_OFFSET 1
 
 serial_queue_t *tx_queue_drv;
-uintptr_t tx_queue_cli0;
+serial_queue_t *tx_queue_cli0;
 
 char *tx_data_drv;
-uintptr_t tx_data_cli0;
+char *tx_data_cli0;
 
 #if SERIAL_WITH_COLOUR
 


### PR DESCRIPTION
This PR updates the networking components so that all queue variable declarations have the correct type, as opposed to many using `uintptr_t`. Declaring all microkit patching variables as `uintptr_t` seems to be a relic of the past.

As such, the network initialisation functions in 'ethernet_config.h' and 'serial_config.h' required a signature update.

This PR also removes a handful of unused variables from prior implementations.