### PR TITLE
blk: use capacity where it makes sense

### DIFF
--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -116,7 +116,7 @@ static void partitions_init()
     for (int i = 0; i < BLK_NUM_CLIENTS; i++) {
         blk_storage_info_t *curr_blk_config = blk_virt_cli_config_info(blk_config, i);
         curr_blk_config->sector_size = blk_config_driver->sector_size;
-        curr_blk_config->size = clients[i].sectors / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE);
+        curr_blk_config->capacity = clients[i].sectors / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE);
         curr_blk_config->read_only = false;
         __atomic_store_n(&curr_blk_config->ready, true, __ATOMIC_RELEASE);
     }

--- a/include/sddf/blk/queue.h
+++ b/include/sddf/blk/queue.h
@@ -18,13 +18,19 @@
 
 typedef struct blk_storage_info {
     char serial_number[BLK_MAX_SERIAL_NUMBER + 1];
+    /* device does not accept write requests */
     bool read_only;
-    bool ready; /* true if component closer to driver is ready */
-    uint16_t sector_size; /* size of a sector, in bytes */
-    uint16_t block_size; /* optimal block size, as a multiple of BLK_TRANSFER_SIZE */
+    /* whether this configuration is populated yet */
+    bool ready;
+    /* size of a sector, in bytes */
+    uint16_t sector_size;
+    /* optimal block size, specified in BLK_TRANSFER_SIZE sized units */
+    uint16_t block_size;
     uint16_t queue_depth;
-    uint16_t cylinders, heads, blocks; /* geometry to guide FS layout */
-    uint64_t capacity; /* size of device as a multiple of BLK_TRANSFER_SIZE */
+    /* geometry to guide FS layout */
+    uint16_t cylinders, heads, blocks;
+    /* total capacity of the device, specified in BLK_TRANSFER_SIZE sized units. */
+    uint64_t capacity;
 } blk_storage_info_t;
 
 /* Request code for block */


### PR DESCRIPTION
This patch renames the storage info struct to use 'capacity' instead of 'size' to make it clearer what the field means.

Also renames 'queue_size' to 'capacity' since size could refer to how many entries are in a queue or the max number of entries.