### PR TITLE
i2c: do not use 'size'

### DIFF
--- a/examples/i2c/pn532.c
+++ b/examples/i2c/pn532.c
@@ -158,8 +158,8 @@ int8_t read_ack_frame(size_t retries)
         co_switch(t_event);
 
         const uint8_t PN532_ACK[] = {0, 0, 0xFF, 0, 0xFF, 0};
-        if (i2c_queue_size(queue.response) != 1) {
-            LOG_PN532_ERR("response queue size is not 1, actual size is %d\n", i2c_queue_size(queue.response));
+        if (i2c_queue_length(queue.response) != 1) {
+            LOG_PN532_ERR("response queue size is not 1, actual size is %d\n", i2c_queue_length(queue.response));
             return -1;
         }
         struct response response = {};
@@ -290,8 +290,8 @@ int8_t read_response_length(size_t retries)
         request_send(&req);
         co_switch(t_event);
 
-        if (i2c_queue_size(queue.response) > 1) {
-            LOG_PN532_ERR("response queue size is more than 1, actual size is %d\n", i2c_queue_size(queue.response));
+        if (i2c_queue_length(queue.response) > 1) {
+            LOG_PN532_ERR("response queue size is more than 1, actual size is %d\n", i2c_queue_length(queue.response));
             return -1;
         }
         struct response response = {};

--- a/include/sddf/i2c/queue.h
+++ b/include/sddf/i2c/queue.h
@@ -119,7 +119,14 @@ static inline int i2c_queue_full(i2c_queue_t *queue)
     return queue->tail - queue->head + 1 == NUM_QUEUE_ENTRIES;
 }
 
-static inline uint32_t i2c_queue_size(i2c_queue_t *queue)
+/**
+ * Get the number of entries in a queue
+ *
+ * @param queue queue to check.
+ *
+ * @return number of entries in a queue
+ */
+static inline uint32_t i2c_queue_length(i2c_queue_t *queue)
 {
     return (queue->tail - queue->head);
 }


### PR DESCRIPTION
It is ambiguous and so we use 'length' to mean how many entries are in a given queue and 'capacity' to mean the maximum length/size of a queue.