### PR TITLE
Stop serial virt_tx transmitting NULL character

### DIFF
--- a/examples/serial/include/serial_config/serial_config.h
+++ b/examples/serial/include/serial_config/serial_config.h
@@ -24,7 +24,7 @@
 
 /* String to be printed to start console input */
 #define SERIAL_CONSOLE_BEGIN_STRING "Begin input\n"
-#define SERIAL_CONSOLE_BEGIN_STRING_LEN 13
+#define SERIAL_CONSOLE_BEGIN_STRING_LEN 12
 
 #define SERIAL_CLI0_NAME "client0"
 #define SERIAL_CLI1_NAME "client1"


### PR DESCRIPTION
This stops the serial tx virtualiser from transmitting the null character at the end of the init string, which causes garbled output in some cases.