### PR TITLE
serial: avoid certain colours in TX virt

### DIFF
--- a/include/sddf/serial/queue.h
+++ b/include/sddf/serial/queue.h
@@ -261,7 +261,7 @@ static inline void serial_transfer_all(serial_queue_handle_t *active_queue_handl
  */
 static inline void serial_transfer_all_with_colour(serial_queue_handle_t *active_queue_handle,
                                                    serial_queue_handle_t *free_queue_handle,
-                                                   const char *colour_start, 
+                                                   const char *colour_start,
                                                    uint16_t colour_start_len,
                                                    const char *colour_end,
                                                    uint16_t colour_end_len)

--- a/include/sddf/serial/queue.h
+++ b/include/sddf/serial/queue.h
@@ -254,21 +254,24 @@ static inline void serial_transfer_all(serial_queue_handle_t *active_queue_handl
  *
  * @param active_queue_handle queue to remove from.
  * @param free_queue_handle queue to insert into.
- * @param colour_start colour string to be printed at the start
- * @param colour_end colour string to be printed at the end
+ * @param colour_start colour string to be printed at the start.
+ * @param colour_start_len length of colour start string.
+ * @param colour_end colour string to be printed at the end.
+ * @param colour_end_len length of colour end string.
  */
 static inline void serial_transfer_all_with_colour(serial_queue_handle_t *active_queue_handle,
                                                    serial_queue_handle_t *free_queue_handle,
-                                                   char *colour_start, char *colour_end)
+                                                   const char *colour_start, 
+                                                   uint16_t colour_start_len,
+                                                   const char *colour_end,
+                                                   uint16_t colour_end_len)
 {
-    uint16_t colour_start_length = sddf_strlen(colour_start);
-    uint16_t colour_end_length = sddf_strlen(colour_end);
-    assert(serial_queue_length(active_queue_handle) + colour_start_length + colour_end_length
+    assert(serial_queue_length(active_queue_handle) + colour_start_len + colour_end_len
            <= serial_queue_free(free_queue_handle));
 
     uint16_t colour_transferred = 0;
-    while (colour_transferred < colour_start_length) {
-        uint32_t remaining = colour_start_length - colour_transferred;
+    while (colour_transferred < colour_start_len) {
+        uint32_t remaining = colour_start_len - colour_transferred;
         uint32_t free = serial_queue_contiguous_free(free_queue_handle);
         uint32_t to_transfer = (remaining < free) ? remaining : free;
 
@@ -295,8 +298,8 @@ static inline void serial_transfer_all_with_colour(serial_queue_handle_t *active
     }
 
     colour_transferred = 0;
-    while (colour_transferred < colour_end_length) {
-        uint32_t remaining = colour_end_length - colour_transferred;
+    while (colour_transferred < colour_end_len) {
+        uint32_t remaining = colour_end_len - colour_transferred;
         uint32_t free = serial_queue_contiguous_free(free_queue_handle);
         uint32_t to_transfer = (remaining < free) ? remaining : free;
 

--- a/serial/components/virt_tx.c
+++ b/serial/components/virt_tx.c
@@ -32,8 +32,9 @@ const char *colours[] = {
     "\x1b[36m"
 };
 
-#define COLOUR_LENGTH 5
+#define COLOUR_BEGIN_LEN 5
 #define COLOUR_END "\x1b[0m"
+#define COLOUR_END_LEN 4
 
 char *client_names[SERIAL_NUM_CLIENTS];
 
@@ -93,8 +94,8 @@ bool process_tx_queue(uint32_t client)
     uint32_t length = serial_queue_length(handle);
 #if SERIAL_WITH_COLOUR
     const char *client_colour = colours[client % ARRAY_SIZE(colours)];
-    assert(COLOUR_LENGTH == sddf_strlen(client_colour));
-    length += COLOUR_LENGTH;
+    assert(COLOUR_BEGIN_LEN == sddf_strlen(client_colour));
+    length += COLOUR_BEGIN_LEN + COLOUR_END_LEN;
 #endif
 
     /* Not enough space to transmit string to virtualiser. Continue later */
@@ -110,9 +111,8 @@ bool process_tx_queue(uint32_t client)
     }
 
 #if SERIAL_WITH_COLOUR
-    char colour_start_buff[COLOUR_LENGTH];
-    sddf_sprintf(colour_start_buff, "%s", client_colour);
-    serial_transfer_all_with_colour(handle, &tx_queue_handle_drv, colour_start_buff, COLOUR_END);
+    serial_transfer_all_with_colour(handle, &tx_queue_handle_drv, client_colour, COLOUR_BEGIN_LEN,
+                                    COLOUR_END, COLOUR_END_LEN);
 #else
     serial_transfer_all(handle, &tx_queue_handle_drv);
 #endif


### PR DESCRIPTION
This patch adds 6 possible colours for clients, reusing the colours when we have more than 6 clients. If this becomes limiting then we can revisit this strategy but for now this is simple and will work for all of our use-cases.

Closes https://github.com/au-ts/sddf/issues/141.

The output of the serial example now looks like:

![Screenshot from 2024-07-22 13 14 58](https://github.com/user-attachments/assets/b6a4293a-0a52-45ef-98f1-8d9c2e1d9905)
