### PR TITLE
Add carriage return printf

### DIFF
--- a/examples/echo_server/lwip.c
+++ b/examples/echo_server/lwip.c
@@ -278,7 +278,7 @@ static err_t ethernet_init(struct netif *netif)
 static void netif_status_callback(struct netif *netif)
 {
     if (dhcp_supplied_address(netif)) {
-        sddf_printf("LWIP|NOTICE: DHCP request for %s returned IP address: %s\r\n", microkit_name,
+        sddf_printf("LWIP|NOTICE: DHCP request for %s returned IP address: %s\n", microkit_name,
                     ip4addr_ntoa(netif_ip4_addr(netif)));
     }
 }

--- a/examples/serial/serial_server.c
+++ b/examples/serial/serial_server.c
@@ -21,7 +21,7 @@ void init(void)
 {
     serial_cli_queue_init_sys(microkit_name, &rx_queue_handle, rx_queue, rx_data, &tx_queue_handle, tx_queue, tx_data);
     serial_putchar_init(TX_CH, &tx_queue_handle);
-    sddf_printf("Hello world! I am %s.\r\nPlease give me character!\r\n", microkit_name);
+    sddf_printf("Hello world! I am %s.\nPlease give me character!\n", microkit_name);
 }
 
 uint16_t char_count;
@@ -39,7 +39,7 @@ void notified(microkit_channel ch)
             }
             char_count ++;
             if (char_count % 10 == 0) {
-                sddf_printf("\r\n%s has received %u characters so far!\r\n", microkit_name, char_count);
+                sddf_printf("\n%s has received %u characters so far!\n", microkit_name, char_count);
             }
         }
 

--- a/util/putchar_serial.c
+++ b/util/putchar_serial.c
@@ -12,10 +12,14 @@ static uint32_t local_tail;
 /* Ensure to call serial_putchar_init during initialisation. Multiplexes output based on \n or when buffer is full. */
 void _sddf_putchar(char character)
 {
-    if (serial_queue_full(tx_queue_handle, local_tail)) {
+    if (serial_queue_full(tx_queue_handle, local_tail) ||
+       (character == '\n' && serial_queue_full(tx_queue_handle, local_tail + 1))) {
         return;
     }
 
+    if (character == '\n') {
+        serial_enqueue(tx_queue_handle, &local_tail, '\r');
+    }
     serial_enqueue(tx_queue_handle, &local_tail, character);
 
     /* Make changes visible to virtualiser if character is flush or if queue is now filled */

--- a/util/putchar_serial.c
+++ b/util/putchar_serial.c
@@ -13,7 +13,7 @@ static uint32_t local_tail;
 void _sddf_putchar(char character)
 {
     if (serial_queue_full(tx_queue_handle, local_tail) ||
-       (character == '\n' && serial_queue_full(tx_queue_handle, local_tail + 1))) {
+        (character == '\n' && serial_queue_full(tx_queue_handle, local_tail + 1))) {
         return;
     }
 


### PR DESCRIPTION
This PR changes `_sddf_putchar` to automatically enqueue a '\r' character when it is called with a '\n' character. This emulates the behaviour of `microkit_dbg_putc` so that the output of a client is the same, whether `sddf_printf` is linked with `putchar_serial` or `putchar_debug`. 