### PR TITLE
Pass physical addresses to the block driver PD instead of offsets

### DIFF
--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -29,6 +29,10 @@
 
 #define REQBK_SIZE BLK_QUEUE_SIZE_DRIV
 
+/*
+ * Convert a virtual address within the block data region into a physical
+ * address for the driver to give to the device for DMA.
+ */
 #define BLK_DRIV_TO_PADDR(addr) ((addr) - blk_data_driver + blk_data_driver_paddr)
 
 blk_storage_info_t *blk_config_driver;

--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -29,10 +29,13 @@
 
 #define REQBK_SIZE BLK_QUEUE_SIZE_DRIV
 
+#define BLK_DRIV_TO_PADDR(addr) ((addr) - blk_data_driver + blk_data_driver_paddr)
+
 blk_storage_info_t *blk_config_driver;
 blk_req_queue_t *blk_req_queue_driver;
 blk_resp_queue_t *blk_resp_queue_driver;
 uintptr_t blk_data_driver;
+uintptr_t blk_data_driver_paddr;
 
 blk_storage_info_t *blk_config;
 blk_req_queue_t *blk_req_queue;
@@ -134,7 +137,7 @@ static void request_mbr()
     assert(!err);
     reqbk[mbr_req_id] = mbr_req_data;
 
-    err = blk_enqueue_req(&drv_h, READ_BLOCKS, mbr_addr - blk_data_driver, 0, 1, mbr_req_id);
+    err = blk_enqueue_req(&drv_h, READ_BLOCKS, BLK_DRIV_TO_PADDR(mbr_addr), 0, 1, mbr_req_id);
     assert(!err);
 
     microkit_notify_delayed(DRIVER_CH);
@@ -337,7 +340,7 @@ static void handle_client(int cli_id)
         assert(!err);
         reqbk[drv_req_id] = cli_data;
 
-        err = blk_enqueue_req(&drv_h, cli_code, drv_addr - blk_data_driver, drv_block_number, cli_count, drv_req_id);
+        err = blk_enqueue_req(&drv_h, cli_code, BLK_DRIV_TO_PADDR(drv_addr), drv_block_number, cli_count, drv_req_id);
         assert(!err);
     }
 }

--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -257,7 +257,7 @@ static void handle_driver()
             }
         } else {
             // When more error conditions are added, this will need to be updated to a switch statement
-            err = blk_enqueue_resp(&h, SEEK_ERROR, drv_success_count, cli_data.cli_req_id);
+            err = blk_enqueue_resp(&h, drv_status, drv_success_count, cli_data.cli_req_id);
             assert(!err);
         }
 


### PR DESCRIPTION
Requires adding the blk_data_driver_paddr to the system file.
Set BLK_VIRT_PASS_OFFSETS to revert to the previous behaviour.

Needed for #157 