### PR TITLE
Remove string.h dependence from the networking copy component

### DIFF
--- a/network/components/copy.c
+++ b/network/components/copy.c
@@ -1,7 +1,7 @@
-#include <string.h>
 #include <stdbool.h>
 #include <microkit.h>
 #include <sddf/network/queue.h>
+#include <sddf/util/string.h>
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
 #include <ethernet_config.h>
@@ -43,7 +43,7 @@ void rx_return(void)
             uintptr_t cli_addr = cli_buffer_data_region + cli_buffer.io_or_offset;
             uintptr_t virt_addr = virt_buffer_data_region + virt_buffer.io_or_offset;
 
-            memcpy((void *)cli_addr, (void *)virt_addr, virt_buffer.len);
+            sddf_memcpy((void *)cli_addr, (void *)virt_addr, virt_buffer.len);
             cli_buffer.len = virt_buffer.len;
             virt_buffer.len = 0;
 


### PR DESCRIPTION
This PR updates the network copy component to not depend on `string.h` and instead use `sddf/util/string.h`. This allows the network components to be compiled without built in string functions. 

Surprisingly, utilising the byte by byte `sddf_memcpy` does not seem to negatively impact performance. I took two samples on the IMX8mm and odroidc4:

Requested_Throughput,Receive_Throughput,Send_Throughput,Packet_Size,Minimum_RTT,Average_RTT,Maximum_RTT,Stdev_RTT,Median_RTT,Idle_Cycles,Total_Cycles

IMX8MM -`sddf_memcpy`: 1000000000,957035645,999995450,1472,1329,1516,1944,97.95,1471,6230124072,23058230899 (0.7298)
IMX8MM -built in `memcpy`: 1000000000,957447712,999994417,1472,1340,1519,1959,94.60,1475,0,6262811899,23007070662 (0.7277)
odroidc4 -`sddf_memcpy`: 600000000,594346605,600002066,1472,562,910,1938,137.83,886,0,7298553638,23758305220 (0.6927)
odroidc4 -built in `memcpy`: 600000000,595561379,600000631,1472,575,911,1467,136.09,888,0,7213734934,24867576841 (0.7099)

Regardless, it is future work to update sDDF string definitions to be more efficient. 