### PR TITLE
uSDHC Hotplugging

### DIFF
--- a/blk/components/partitioning.c
+++ b/blk/components/partitioning.c
@@ -99,7 +99,6 @@ static bool gpt_partitions_init()
         client_storage_info->sector_size = driver_storage_info->sector_size;
         client_storage_info->capacity = clients[i].sectors / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE);
         client_storage_info->read_only = driver_storage_info->read_only;
-        __atomic_store_n(&client_storage_info->ready, true, __ATOMIC_RELEASE);
     }
 
     return true;
@@ -274,8 +273,8 @@ static bool mbr_partitions_init(void)
         client_storage_info->sector_size = driver_storage_info->sector_size;
         client_storage_info->capacity = clients[i].sectors / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE);
         client_storage_info->read_only = driver_storage_info->read_only;
-        __atomic_store_n(&client_storage_info->ready, true, __ATOMIC_RELEASE);
     }
+
     return true;
 }
 
@@ -421,4 +420,13 @@ bool virt_partition_init(void)
     }
 
     return success;
+}
+
+void virt_partition_reset(void)
+{
+    sddf_memset(&clients, 0x0, sizeof(clients));
+    sddf_memset(&mbr_state, 0x0, sizeof(mbr_state));
+    sddf_memset(&msdos_mbr, 0x0, sizeof(msdos_mbr));
+    sddf_memset(&gpt_state, 0x0, sizeof(gpt_state));
+    sddf_memset(&gpt_meta, 0x0, sizeof(gpt_meta));
 }

--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -46,14 +46,17 @@ static reqbk_t reqsbk[DRIVER_MAX_NUM_BUFFERS];
 ialloc_t ialloc;
 static uint32_t ialloc_idxlist[DRIVER_MAX_NUM_BUFFERS];
 
-bool initialised = false;
+static enum {
+    VirtInactive,
+    VirtBringup,
+    VirtReady
+} virt_status = VirtInactive;
+
+static void handle_driver_state(void);
 
 void init(void)
 {
     assert(blk_config_check_magic(&config));
-
-    blk_storage_info_t *driver_storage_info = config.driver.conn.storage_info.vaddr;
-    while (!blk_storage_is_ready(driver_storage_info));
 
     /* Initialise client queues */
     for (int i = 0; i < config.num_clients; i++) {
@@ -72,10 +75,48 @@ void init(void)
     /* Initialise index allocator */
     ialloc_init(&ialloc, ialloc_idxlist, DRIVER_MAX_NUM_BUFFERS);
 
-    virt_partition_init();
+    /* continued via driver block state ready notifications */
 }
 
-static void handle_driver()
+static void notify_clients_ready()
+{
+    bool driver_ready = blk_storage_is_ready(config.driver.conn.storage_info.vaddr);
+    for (int i = 0; i < config.num_clients; i++) {
+        blk_virt_config_client_t *client = &config.clients[i];
+        blk_storage_info_t *client_storage_info = client->conn.storage_info.vaddr;
+
+        blk_storage_notify_ready(client_storage_info, client->conn.id_state, driver_ready);
+    }
+}
+
+static void handle_driver_ready()
+{
+    bool driver_ready = blk_storage_is_ready(config.driver.conn.storage_info.vaddr);
+
+    /* As per the documentation, if we receive a BLK_STATE_CH notification
+       we must treat it as if the device went In -> Out -> In even if we only
+       ever see the In state.
+       This actually makes our lives easier, because of instead of 4 states we
+       only have two ( {drv_ready, us_ready}  ->   {drv_ready} ).
+    */
+
+    if (driver_ready) {
+        virt_partition_reset();
+        virt_status = VirtBringup;
+        bool done = virt_partition_init();
+        if (done) {
+            /* keep in sync with notified() */
+            virt_status = VirtReady;
+            notify_clients_ready();
+        }
+    } else {
+        virt_status = VirtInactive;
+        virt_partition_reset();
+        notify_clients_ready();
+    }
+}
+
+static void handle_driver_queue(void)
 {
     bool client_notify[SDDF_BLK_MAX_CLIENTS];
     sddf_memset(client_notify, 0, SDDF_BLK_MAX_CLIENTS);
@@ -251,13 +292,30 @@ static void handle_clients()
 
 void notified(microkit_channel ch)
 {
-    if (!initialised) {
-        /* Continue processing partitions until initialisation has finished. */
-        initialised = virt_partition_init();
+    if (ch == config.driver.conn.id_state) {
+        handle_driver_ready();
+        return;
+    }
+
+    if (virt_status == VirtBringup) {
+        /* ignore client requests */
+        if (ch != config.driver.conn.id) return;
+
+        bool done = virt_partition_init();
+        if (done) {
+            /* keep in sync with handle_driver_ready() */
+            virt_status = VirtReady;
+            notify_clients_ready();
+        }
+
+        return;
+    } else if (virt_status == VirtInactive) {
+        // TODO: Respond with GONE?
+        return;
     }
 
     if (ch == config.driver.conn.id) {
-        handle_driver();
+        handle_driver_queue();
         handle_clients();
     } else {
         handle_clients();

--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -321,3 +321,8 @@ void notified(microkit_channel ch)
         handle_clients();
     }
 }
+
+microkit_msginfo protected(microkit_channel ch, microkit_msginfo msginfo)
+{
+    return microkit_ppcall(config.driver.conn.id_state, msginfo);
+}

--- a/blk/components/virt.h
+++ b/blk/components/virt.h
@@ -54,3 +54,9 @@ blk_resp_status_t get_drv_block_number(uint64_t cli_block_number, uint16_t cli_c
  *    fill the client storage info based on that.
  */
 bool virt_partition_init(void);
+
+/**
+ * Reset the state associated with block device partitions, so that we can
+ * initialise them again due to a device change.
+ */
+void virt_partition_reset(void);

--- a/drivers/blk/mmc/imx/usdhc.c
+++ b/drivers/blk/mmc/imx/usdhc.c
@@ -9,6 +9,7 @@
 #include <sddf/blk/config.h>
 #include <sddf/blk/queue.h>
 #include <sddf/blk/storage_info.h>
+#include <sddf/hotplug/control.h>
 #include <sddf/util/printf.h>
 #include <sddf/timer/config.h>
 #include <sddf/timer/client.h>
@@ -1394,4 +1395,51 @@ void handle_card_detect_irq()
 void *memset(void *s, int c, size_t n)
 {
     return sddf_memset(s, c, n);
+}
+
+seL4_MessageInfo_t protected(microkit_channel ch, seL4_MessageInfo_t msginfo)
+{
+    /* only the state channel should allow ppcalls. (can we enforce this?) */
+    assert(ch == blk_config.virt.id_state);
+
+    switch (microkit_msginfo_get_label(msginfo)) {
+    case SDDF_HOTPLUG_REQ_INSERT:
+        if (!gpio_card_detected()) {
+            return microkit_msginfo_new(SDDF_HOTPLUG_RESP_NO_DEV, 0);
+        }
+
+        if (driver_status == DrvStatusActive) {
+            return microkit_msginfo_new(SDDF_HOTPLUG_RESP_NOOP, 0);
+        } else if (driver_status == DrvStatusInactive) {
+
+            /* protected() invariant: do_bringup() should near-immediately
+               begin waiting for an IRQ, won't block for ages */
+            driver_status = DrvStatusBringup;
+            do_bringup();
+            return microkit_msginfo_new(SDDF_HOTPLUG_RESP_OK, 0);
+        } else if (driver_status == DrvStatusBringup) {
+            return microkit_msginfo_new(SDDF_HOTPLUG_RESP_OK, 0);
+        } else if (driver_status == DrvStatusTeardown) {
+            return microkit_msginfo_new(SDDF_HOTPLUG_RESP_INVALID_OPERATION, 0);
+        }
+
+    case SDDF_HOTPLUG_REQ_EJECT:
+        if (driver_status == DrvStatusActive) {
+            driver_status = DrvStatusTeardown;
+            do_teardown();
+            return microkit_msginfo_new(SDDF_HOTPLUG_RESP_OK, 0);
+        } else if (driver_status == DrvStatusInactive) {
+            /* already there */
+            return microkit_msginfo_new(SDDF_HOTPLUG_RESP_NOOP, 0);
+        } else if (driver_status == DrvStatusBringup) {
+            return microkit_msginfo_new(SDDF_HOTPLUG_RESP_INVALID_OPERATION, 0);
+        } else if (driver_status == DrvStatusTeardown) {
+            /* already in progress */
+            return microkit_msginfo_new(SDDF_HOTPLUG_RESP_OK, 0);
+        }
+
+    default:
+        LOG_DRIVER_ERR("Unhandled protected call message label\n");
+        return microkit_msginfo_new(SDDF_HOTPLUG_RESP_INVALID_OPERATION, 0);
+    }
 }

--- a/examples/mmc_hotplug/Makefile
+++ b/examples/mmc_hotplug/Makefile
@@ -1,0 +1,34 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+ifeq ($(strip $(MICROKIT_SDK)),)
+$(error MICROKIT_SDK must be specified)
+endif
+
+ifeq ($(strip $(MICROKIT_BOARD)),)
+$(error MICROKIT_BOARD must be specified)
+endif
+
+BUILD_DIR ?= build
+
+export MICROKIT_BOARD
+export SDDF=$(abspath ../..)
+export override MICROKIT_SDK:=$(abspath ${MICROKIT_SDK})
+export BUILD_DIR:=$(abspath ${BUILD_DIR})
+
+IMAGE_FILE:= ${BUILD_DIR}/loader.img
+REPORT_FILE:= ${BUILD_DIR}/report.txt
+
+all: ${IMAGE_FILE}
+
+${IMAGE_FILE} ${REPORT_FILE} clean clobber: ${BUILD_DIR}/Makefile FORCE
+	${MAKE} -C ${BUILD_DIR} $(notdir $@)
+
+${BUILD_DIR}/Makefile: mmc_hotplug.mk
+	mkdir -p ${BUILD_DIR}
+	cp mmc_hotplug.mk $@
+
+FORCE:

--- a/examples/mmc_hotplug/README.md
+++ b/examples/mmc_hotplug/README.md
@@ -1,0 +1,83 @@
+<!--
+    Copyright 2024, UNSW
+    SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Block (mmc) Hotplugging Example
+
+This examples demonstrates an implementation of hotplugging.
+
+The setup is:
+- One plug controller, which can send insert/eject requests to the block virtualiser.
+- A client which "plays a game" and will receive "pending eject" notifications from the controller
+    - The "game" involves a client which writes a block with counts full of
+      0s, then 1s, then 2s, etc, and so forth, up to UINT8_MAX.
+    - The game only ever considers a "safe" unplug state to be when UINT8_MAX is written, i.e. all 1s on the device, and will prevent the controller from unplugging until before then.
+
+
+## Building
+### Make
+
+```sh
+make MICROKIT_SDK=<path/to/sdk> MICROKIT_BOARD=<board> MICROKIT_CONFIG=<debug/release>
+```
+
+Currently the options for `MICROKIT_BOARD` are:
+
+* maaxboard
+* imx8mm_evk
+
+## Running
+
+The produced `build/loader.img` can then be loaded from U-Boot.
+
+It should produce something like the following output. Note that the text might appear somewhat scrambled.
+
+```bash
+Hello from plug controller
+GAME: Hello!
+PLUG: Storage is now ready
+GAME: Storage ready!
+GAME: playing...
+GAME: Enqueued a playthrough
+GAME: Finished a playthrough
+GAME: Enqueued a playthrough
+# at this point the card was removed (checkpoint #1)
+GAME: Received 1 or more non-successful queue response...
+GAME: -> 1st: status: 2, count: 1, id: 288
+GAME: Errors encountered, stopping play.
+PLUG: Storage is now not ready
+GAME: Storage is no longer ready
+# the card is then reinserted
+PLUG: Storage is now ready
+GAME: Storage ready!
+GAME: playing...
+GAME: Enqueued a playthrough
+# the '[' key is pressed, triggerring a safe eject
+PLUG: Notifying clients of pending EJECT...
+GAME: Hotplug notify: pending eject...: 1
+GAME: Finished a playthrough
+PLUG: Safe to eject from client: 0
+PLUG: All clients responded... ejecting
+PLUG: -> response: 0
+PLUG: Storage is now not ready
+GAME: Storage is no longer ready
+```
+
+At checkpoint #1 above, during an unsafe ejection, the card should read something like:
+
+```bash
+$ hexdump -C -n 512 /dev/mmcblk0p3
+00000000  bb bb bb bb bb bb bb bb  bb bb bb bb bb bb bb bb  |................|
+*
+00000200
+```
+
+If it is safely ejected (as at checkpoint #2), the output should be:
+
+```bash
+$ hexdump -C -n 512 /dev/mmcblk0p3
+00000000  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
+*
+00000200
+```

--- a/examples/mmc_hotplug/board/imx8mm_evk/mmc_hotplug.system
+++ b/examples/mmc_hotplug/board/imx8mm_evk/mmc_hotplug.system
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2024, UNSW
+    SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <!-- Device Driver Regions -->
+    <memory_region name="timer"  size="0x10_000" phys_addr="0x302d_0000" />
+    <memory_region name="usdhc2" size="0x10_000" phys_addr="0x30b5_0000" />
+    <memory_region name="uart"   size="0x1000"   phys_addr="0x3089_0000" />
+    <memory_region name="gpio1"  size="0x1000"   phys_addr="0x3020_0000" />
+
+    <!-- sDDF Block -->
+    <memory_region name="blk_driver_storage_info" size="0x1000"   page_size="0x1000"   />
+    <memory_region name="blk_driver_req"          size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_driver_resp"         size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_driver_data"         size="0x200000" page_size="0x200000" />
+
+    <memory_region name="blk_client0_storage_info" size="0x1000"   page_size="0x1000"   />
+    <memory_region name="blk_client0_req"          size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client0_resp"         size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client0_data"         size="0x200000" page_size="0x200000" />
+
+    <memory_region name="blk_client1_storage_info" size="0x1000"   page_size="0x1000"   />
+    <memory_region name="blk_client1_req"          size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client1_resp"         size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client1_data"         size="0x200000" page_size="0x200000" />
+
+    <!-- Hotplug -->
+    <memory_region name="hotplug_client0_info" size="0x1000" page_size="0x1000" />
+
+    <protection_domain name="mmc_driver" priority="100" pp="true">
+        <program_image path="mmc_driver.elf" />
+        <map mr="usdhc2" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="usdhc_regs" />
+        <irq irq="55" id="0"  />
+
+        <!-- sDDF block -->
+        <map mr="blk_driver_storage_info" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_storage_info" />
+        <map mr="blk_driver_req"          vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"    />
+        <map mr="blk_driver_resp"         vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue"   />
+
+        <!-- GPIO Messing -->
+        <map mr="gpio1" vaddr="0x4_500_000" perms="r" cached="false" setvar_vaddr="gpio1_regs" />
+    </protection_domain>
+
+    <protection_domain name="timer" priority="101" pp="true" passive="true">
+        <program_image path="timer_driver.elf" />
+        <map mr="timer" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
+        <irq irq="87" id="0" />
+    </protection_domain>
+
+    <channel>
+        <end pd="timer"      id="1" />
+        <end pd="mmc_driver" id="3" />
+    </channel>
+
+    <protection_domain name="game" priority="1" >
+        <program_image path="game.elf" />
+
+        <!-- sDDF Block -->
+        <map mr="blk_client0_storage_info" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_storage_info" />
+        <map mr="blk_client0_req"          vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"    />
+        <map mr="blk_client0_resp"         vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue"   />
+        <map mr="blk_client0_data"         vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_data"         />
+
+        <!-- Hotplug -->
+        <map mr="hotplug_client0_info" vaddr="0x3500_0000" perms="r" cached="true" setvar_vaddr="hotplug_info" />
+    </protection_domain>
+
+    <channel>
+        <!-- block queue -->
+        <end pd="game"     id="0" />
+        <end pd="blk_virt" id="2" />
+    </channel>
+
+    <channel>
+        <!-- storage info -->
+        <end pd="game"     id="1" />
+        <end pd="blk_virt" id="3" />
+    </channel>
+
+    <channel>
+        <!-- safe hotplug -->
+        <end pd="game"            id="2" />
+        <end pd="plug_controller" id="5" />
+    </channel>
+
+    <!-- Plug Controller -->
+    <protection_domain name="plug_controller" priority="2" pp="true" >
+        <program_image path="plug_controller.elf" />
+
+        <!-- Serial -->
+        <map mr="rx_queue_client0" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue" />
+        <map mr="tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue" />
+        <map mr="rx_data_client0"  vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="rx_data"  />
+        <map mr="tx_data_client0"  vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data"  />
+
+        <!-- sDDF Block -->
+        <map mr="blk_client1_storage_info" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_storage_info" />
+        <map mr="blk_client1_req"          vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"    />
+        <map mr="blk_client1_resp"         vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue"   />
+        <map mr="blk_client1_data"         vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_data"         />
+
+        <!-- Hotplug -->
+        <map mr="hotplug_client0_info" vaddr="0x3500_0000" perms="rw" cached="true" setvar_vaddr="hotplug_client0_info" />
+    </protection_domain>
+
+    <channel>
+        <end pd="serial_virt_tx" id="1"/>
+        <end pd="plug_controller" id="1"/>
+    </channel>
+
+    <channel>
+        <end pd="serial_virt_rx" id="1"/>
+        <end pd="plug_controller" id="2"/>
+    </channel>
+
+    <channel>
+        <!-- block queues -->
+        <end pd="plug_controller" id="3" />
+        <end pd="blk_virt"        id="4" />
+    </channel>
+
+    <channel>
+        <!-- storage info -->
+        <end pd="plug_controller" id="4" />
+        <end pd="blk_virt"        id="5" />
+    </channel>
+
+    <!-- sDDF Block -->
+    <protection_domain name="blk_virt" priority="99" pp="true">
+        <program_image path="blk_virt.elf" />
+
+        <map mr="blk_driver_storage_info" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_driver_storage_info"  />
+        <map mr="blk_driver_req"          vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_driver_req_queue"     />
+        <map mr="blk_driver_resp"         vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_driver_resp_queue"    />
+        <map mr="blk_driver_data"         vaddr="0x40600000" perms="rw" cached="false" setvar_vaddr="blk_driver_data"          />
+        <setvar symbol="blk_data_paddr_driver" region_paddr="blk_driver_data" />
+
+        <map mr="blk_client0_storage_info" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_client_storage_info" />
+        <map mr="blk_client1_storage_info" vaddr="0x30001000" perms="rw" cached="false"                                        />
+        <map mr="blk_client0_req"          vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_client_req_queue"    />
+        <map mr="blk_client1_req"          vaddr="0x30400000" perms="rw" cached="false"                                        />
+        <map mr="blk_client0_resp"         vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_client_resp_queue"   />
+        <map mr="blk_client1_resp"         vaddr="0x30800000" perms="rw" cached="false"                                        />
+        <map mr="blk_client0_data"         vaddr="0x30A00000" perms="rw" cached="true"  setvar_vaddr="blk_client_data"         />
+        <setvar symbol="blk_client0_data_paddr" region_paddr="blk_client0_data" />
+        <map mr="blk_client1_data"         vaddr="0x30C00000" perms="rw" cached="true"                                         />
+        <setvar symbol="blk_client1_data_paddr" region_paddr="blk_client0_data" />
+    </protection_domain>
+
+    <channel>
+        <!-- block queues -->
+        <end pd="mmc_driver" id="1" />
+        <end pd="blk_virt"   id="0" />
+    </channel>
+
+    <channel>
+        <!-- state control / storage info -->
+        <end pd="mmc_driver" id="2" />
+        <end pd="blk_virt"   id="1" />
+    </channel>
+
+    <!-- sDDF Serial -->
+    <memory_region name="rx_data_driver" size="0x2_000" />
+    <memory_region name="tx_data_driver" size="0x2_000" />
+    <memory_region name="rx_data_client0" size="0x2_000" />
+    <memory_region name="tx_data_client0" size="0x2_000" />
+
+    <memory_region name="rx_queue_driver" size="0x1_000" />
+    <memory_region name="tx_queue_driver" size="0x1_000" />
+    <memory_region name="rx_queue_client0" size="0x1_000" />
+    <memory_region name="tx_queue_client0" size="0x1_000" />
+
+    <protection_domain name="uart" priority="100">
+        <program_image path="uart_driver.elf" />
+
+        <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
+
+        <map mr="rx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue" />
+        <map mr="tx_queue_driver" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue" />
+
+        <map mr="rx_data_driver" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_driver" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+
+        <irq irq="59" id="0" /> <!-- UART interrupt -->
+    </protection_domain>
+
+    <protection_domain name="serial_virt_tx" priority="99">
+        <program_image path="serial_virt_tx.elf" />
+        <map mr="tx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
+        <map mr="tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
+
+        <map mr="tx_data_driver" vaddr="0x4_003_000" perms="rw" cached="true" setvar_vaddr="tx_data_drv" />
+        <map mr="tx_data_client0" vaddr="0x4_005_000" perms="r" cached="true" setvar_vaddr="tx_data_cli0" />
+    </protection_domain>
+
+    <protection_domain name="serial_virt_rx" priority="98">
+        <program_image path="serial_virt_rx.elf" />
+        <map mr="rx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue_drv" />
+        <map mr="rx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="rx_queue_cli0" />
+
+        <map mr="rx_data_driver" vaddr="0x4_003_000" perms="r" cached="true" setvar_vaddr="rx_data_drv" />
+        <map mr="rx_data_client0" vaddr="0x4_005_000" perms="rw" cached="true" setvar_vaddr="rx_data_cli0" />
+    </protection_domain>
+
+    <channel>
+        <end pd="uart" id="1"/>
+        <end pd="serial_virt_tx" id="0"/>
+    </channel>
+
+    <channel>
+        <end pd="uart" id="2"/>
+        <end pd="serial_virt_rx" id="0"/>
+    </channel>
+
+</system>

--- a/examples/mmc_hotplug/game.c
+++ b/examples/mmc_hotplug/game.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <microkit.h>
+#include <sddf/blk/queue.h>
+#include <sddf/blk/storage_info.h>
+#include <sddf/hotplug/clients.h>
+#include <sddf/util/printf.h>
+#include <sddf/util/util.h>
+
+#include "blk_config.h"
+
+#define CHANNEL_BLK_QUEUE 0
+#define CHANNEL_BLK_STATE 1
+#define CHANNEL_HOTPLUG   2
+
+blk_queue_handle_t blk_queue;
+blk_storage_info_t *blk_storage_info;
+blk_req_queue_t *blk_req_queue;
+blk_resp_queue_t *blk_resp_queue;
+uint8_t *blk_data;
+
+hotplug_info_t *hotplug_info;
+
+static uint32_t request_id = 0;
+static uint32_t done_request_id;
+static bool is_playing = false;
+static bool pending_eject = false;
+
+#define GAME_PRINT(...) do{ sddf_printf("GAME: "); sddf_printf(__VA_ARGS__); }while(0)
+
+void play_our_game_stage(uint8_t stage)
+{
+    for (int i = 0; i < BLK_TRANSFER_SIZE; i++) {
+        blk_data[stage * BLK_TRANSFER_SIZE + i] = stage;
+    }
+}
+
+void play_our_game(void)
+{
+    is_playing = true;
+
+    int err;
+    for (int stage = 150; stage <= UINT8_MAX; stage++) {
+        play_our_game_stage(stage);
+        err = blk_enqueue_req(&blk_queue, BLK_REQ_WRITE, /* data offset */ stage * BLK_TRANSFER_SIZE,
+                              /* block number */ 0x0, /* block count */ 1, request_id++);
+        assert(!err);
+
+        /* not strictly necessary, but let's do this anyway */
+        err = blk_enqueue_req(&blk_queue, BLK_REQ_FLUSH, 0, 0, 0, request_id++);
+        assert(!err);
+    }
+
+    microkit_notify(CHANNEL_BLK_QUEUE);
+
+    done_request_id = request_id - 1;
+    GAME_PRINT("Enqueued a playthrough\n");
+}
+
+void notified_blk_virt(void)
+{
+    if (!is_playing) {
+        return;
+    }
+
+    bool did_finish = false;
+    bool did_fail = false;
+    while (!blk_queue_empty_resp(&blk_queue)) {
+        blk_resp_status_t status;
+        uint16_t success_count;
+        uint32_t id;
+        int err = blk_dequeue_resp(&blk_queue, &status, &success_count, &id);
+        assert(!err);
+
+        if (status != BLK_RESP_OK) {
+            /* only print it out once */
+            if (!did_fail) {
+                GAME_PRINT("Received 1 or more non-successful queue response...\n");
+                GAME_PRINT("-> 1st: status: %u, count: %u, id: %u\n", status, success_count, id);
+                did_fail = true;
+            }
+            continue;
+        }
+
+        /* assumes in-order response IDs, good enough for now. */
+        if (status == BLK_RESP_OK && id == done_request_id) {
+            GAME_PRINT("Finished a playthrough\n");
+            did_finish = true;
+        }
+    }
+
+    if (did_fail) {
+        GAME_PRINT("Errors encountered, stopping play.\n");
+        is_playing = false;
+
+        if (pending_eject) {
+            pending_eject = false;
+            hotplug_ready_for_eject(CHANNEL_HOTPLUG);
+        }
+
+        return;
+    }
+
+    if (did_finish) {
+        if (pending_eject) {
+            is_playing = false;
+            pending_eject = false;
+            hotplug_ready_for_eject(CHANNEL_HOTPLUG);
+        } else if (blk_storage_is_ready(blk_storage_info)) {
+            play_our_game();
+        } else {
+            is_playing = false;
+            GAME_PRINT("Cannot continue the game\n");
+        }
+    }
+}
+
+void notified_blk_state(void)
+{
+    if (blk_storage_is_ready(blk_storage_info)) {
+        GAME_PRINT("Storage ready!\n");
+        if (!is_playing) {
+            GAME_PRINT("playing...\n");
+            play_our_game();
+        }
+    } else {
+        GAME_PRINT("Storage is no longer ready\n");
+        is_playing = false;
+    }
+}
+
+void notified_hotplug(void)
+{
+    pending_eject = hotplug_is_pending_eject(hotplug_info);
+    GAME_PRINT("Hotplug notify: pending eject...: %u\n", pending_eject);
+    if (!is_playing) {
+        GAME_PRINT("... wasn't playing, ACK.\n");
+        hotplug_ready_for_eject(CHANNEL_HOTPLUG);
+    }
+}
+
+void notified(microkit_channel ch)
+{
+    switch (ch) {
+    case CHANNEL_BLK_QUEUE:
+        notified_blk_virt();
+        break;
+
+    case CHANNEL_BLK_STATE:
+        notified_blk_state();
+        break;
+
+    case CHANNEL_HOTPLUG:
+        notified_hotplug();
+        break;
+
+    default:
+        assert(!"unknown channel");
+    }
+}
+
+void init(void)
+{
+    /* The third partition on the SD card (after Uboot & Linux) is made empty
+       so we don't overwrite anything important.
+    */
+    assert(blk_partition_mapping[0] == 2);
+
+    blk_queue_init(&blk_queue, blk_req_queue, blk_resp_queue, BLK_QUEUE_CAPACITY_CLI0);
+    GAME_PRINT("Hello!\n");
+
+    /* continued via state notification */
+}

--- a/examples/mmc_hotplug/mmc_hotplug.mk
+++ b/examples/mmc_hotplug/mmc_hotplug.mk
@@ -1,0 +1,103 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+ifeq ($(strip $(MICROKIT_SDK)),)
+$(error MICROKIT_SDK must be specified)
+endif
+
+ifeq ($(strip $(SDDF)),)
+$(error SDDF must be specified)
+endif
+
+ifeq ($(strip $(TOOLCHAIN)),)
+	TOOLCHAIN := aarch64-none-elf
+endif
+
+ifeq ($(strip $(TOOLCHAIN)), clang)
+	CC := clang -target aarch64-none-elf
+	LD := ld.lld
+	AR := llvm-ar
+	RANLIB := llvm-ranlib
+else
+	CC := $(TOOLCHAIN)-gcc
+	LD := $(TOOLCHAIN)-ld
+	AS := $(TOOLCHAIN)-as
+	AR := $(TOOLCHAIN)-ar
+	RANLIB := $(TOOLCHAIN)-ranlib
+endif
+
+BUILD_DIR ?= build
+MICROKIT_CONFIG ?= debug
+
+DRIVER_DIR := imx
+CPU := cortex-a53
+
+TOP := $(SDDF)/examples/mmc_hotplug
+CONFIGS_INCLUDE := $(TOP)/include/configs
+
+MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
+
+BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+
+IMAGES := game.elf plug_controller.elf \
+		  mmc_driver.elf blk_virt.elf \
+		  uart_driver.elf serial_virt_tx.elf serial_virt_rx.elf \
+		  timer_driver.elf
+
+CFLAGS := -mcpu=$(CPU) \
+		  -mstrict-align \
+		  -nostdlib \
+		  -ffreestanding \
+		  -g3 \
+		  -O3 \
+		  -MD \
+		  -Wall -Wno-unused-function -Werror -Wno-unused-command-line-argument \
+		  -I$(BOARD_DIR)/include \
+		  -I$(SDDF)/include \
+		  -I$(CONFIGS_INCLUDE)
+LDFLAGS := -L$(BOARD_DIR)/lib
+LIBS := --start-group -lmicrokit -Tmicrokit.ld libsddf_util_debug.a --end-group
+
+IMAGE_FILE   := loader.img
+REPORT_FILE  := report.txt
+SYSTEM_FILE  := $(TOP)/board/$(MICROKIT_BOARD)/mmc_hotplug.system
+
+MMC_DRIVER   := $(SDDF)/drivers/blk/mmc/$(DRIVER_DIR)
+TIMER_DRIVER := $(SDDF)/drivers/timer/$(DRIVER_DIR)
+UART_DRIVER  := $(SDDF)/drivers/serial/$(DRIVER_DIR)
+
+BLK_COMPONENTS    := $(SDDF)/blk/components
+SERIAL_COMPONENTS := $(SDDF)/serial/components
+
+all: $(IMAGE_FILE)
+
+include $(MMC_DRIVER)/mmc_driver.mk
+include $(TIMER_DRIVER)/timer_driver.mk
+include $(UART_DRIVER)/uart_driver.mk
+
+include $(SDDF)/util/util.mk
+include $(BLK_COMPONENTS)/blk_components.mk
+include $(SERIAL_COMPONENTS)/serial_components.mk
+
+$(IMAGES): libsddf_util_debug.a
+
+game.o: $(TOP)/game.c
+	$(CC) -c $(CFLAGS) $< -o game.o
+game.elf: game.o
+	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
+
+plug_controller.o: $(TOP)/plug_controller.c
+	$(CC) -c $(CFLAGS) $^ -o plug_controller.o
+plug_controller.elf: plug_controller.o libsddf_util.a
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+$(IMAGE_FILE) $(REPORT_FILE): $(IMAGES) $(SYSTEM_FILE)
+	$(MICROKIT_TOOL) $(SYSTEM_FILE) --search-path $(BUILD_DIR) --board $(MICROKIT_BOARD) --config $(MICROKIT_CONFIG) -o $(IMAGE_FILE) -r $(REPORT_FILE)
+
+clean::
+	rm -f game.[od] plug_controller.[od]
+clobber:: clean
+	rm -f game.elf plug_controller.elf $(IMAGE_FILE) $(REPORT_FILE)

--- a/examples/mmc_hotplug/plug_controller.c
+++ b/examples/mmc_hotplug/plug_controller.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <microkit.h>
+#include <sddf/blk/queue.h>
+#include <sddf/blk/storage_info.h>
+#include <sddf/hotplug/clients.h>
+#include <sddf/hotplug/control.h>
+#include <sddf/util/printf.h>
+#include <sddf/util/util.h>
+
+#include "serial_config.h"
+#include "blk_config.h"
+
+#define SERIAL_TX_CH 1
+#define SERIAL_RX_CH 2
+#define BLK_QUEUE_CH 3
+#define BLK_STATE_CH 4
+#define CLIS_BASE_CH 5
+
+#define PLUG_PRINT(...) do{ sddf_printf("PLUG: "); sddf_printf(__VA_ARGS__); }while(0)
+
+serial_queue_t *rx_queue;
+serial_queue_t *tx_queue;
+char *rx_data;
+char *tx_data;
+serial_queue_handle_t rx_queue_handle;
+serial_queue_handle_t tx_queue_handle;
+
+blk_storage_info_t *blk_storage_info;
+
+// TODO: All of these are unnecessary.
+blk_queue_handle_t blk_queue;
+blk_req_queue_t *blk_req_queue;
+blk_resp_queue_t *blk_resp_queue;
+uint8_t *blk_data;
+
+// Patched by microkit.
+hotplug_info_t *hotplug_client0_info;
+static hotplug_info_t **clients_info[] = { &hotplug_client0_info };
+#define NUM_CLIENTS (ARRAY_SIZE(clients_info))
+static int clients_safe_to_eject[NUM_CLIENTS] = { 0 };
+static int num_clients_safe_to_eject = 0;
+
+void hotplug_notify_clients(bool pending_eject)
+{
+    num_clients_safe_to_eject = 0;
+    for (int i = 0; i < NUM_CLIENTS; i++) {
+        clients_safe_to_eject[i] = false;
+        hotplug_set_pending_eject(*clients_info[i], CLIS_BASE_CH + i, pending_eject);
+    }
+}
+
+void notified_serial()
+{
+    bool reprocess = true;
+
+    microkit_msginfo msginfo;
+    char c;
+    while (reprocess) {
+        while (!serial_dequeue(&rx_queue_handle, &rx_queue_handle.queue->head, &c)) {
+            if (c == '[') {
+                PLUG_PRINT("Notifying clients of pending EJECT...\n");
+                hotplug_notify_clients(/* pending eject */ true);
+
+            } else if (c == '/') {
+
+                PLUG_PRINT("Forcing ejection...\n");
+                msginfo = microkit_ppcall(BLK_STATE_CH, microkit_msginfo_new(SDDF_HOTPLUG_REQ_EJECT, 0));
+                PLUG_PRINT("-> response: %lu\n", microkit_msginfo_get_label(msginfo));
+
+            } else if (c == ']') {
+                PLUG_PRINT("Requesting card insert (n.b. driver will usually autodetect)\n");
+                msginfo = microkit_ppcall(BLK_STATE_CH, microkit_msginfo_new(SDDF_HOTPLUG_REQ_INSERT, 0));
+                PLUG_PRINT("-> response: %lu\n", microkit_msginfo_get_label(msginfo));
+            }
+        }
+
+        // I have no idea what this is.
+        serial_request_producer_signal(&rx_queue_handle);
+        reprocess = false;
+
+        if (!serial_queue_empty(&rx_queue_handle, rx_queue_handle.queue->head)) {
+            serial_cancel_producer_signal(&rx_queue_handle);
+            reprocess = true;
+        }
+    }
+}
+
+void notified_blk_state(void)
+{
+    if (blk_storage_is_ready(blk_storage_info)) {
+        PLUG_PRINT("Storage is now ready\n");
+    } else {
+        PLUG_PRINT("Storage is now not ready\n");
+    }
+
+    /* reset the pending eject states */
+    hotplug_notify_clients(false);
+}
+
+void notified(microkit_channel ch)
+{
+    switch (ch) {
+    case SERIAL_RX_CH:
+        notified_serial();
+        break;
+
+    case SERIAL_TX_CH:
+        /* huh ? */
+        break;
+
+    case BLK_QUEUE_CH:
+        assert(!"unexpected");
+        break;
+
+    case BLK_STATE_CH:
+        notified_blk_state();
+        break;
+
+    default:
+        assert(!"unknown channel");
+    }
+}
+
+microkit_msginfo protected(microkit_channel ch, microkit_msginfo msginfo)
+{
+    /* we only set up clients with ppcall ability, so channel is always OK. */
+    int client_index = ch - CLIS_BASE_CH;
+    PLUG_PRINT("Safe to eject from client number %d\n", client_index);
+    clients_safe_to_eject[client_index] = true;
+    num_clients_safe_to_eject++;
+
+    if (num_clients_safe_to_eject == NUM_CLIENTS) {
+        PLUG_PRINT("All clients responded... ejecting\n");
+        microkit_msginfo msginfo = microkit_ppcall(BLK_STATE_CH, microkit_msginfo_new(SDDF_HOTPLUG_REQ_EJECT, 0));
+        PLUG_PRINT("-> response: %lu\n", microkit_msginfo_get_label(msginfo));
+    }
+
+    /* return: void */
+    return microkit_msginfo_new(0, 0);
+}
+
+void init(void)
+{
+    serial_cli_queue_init_sys("plug_controller", &rx_queue_handle, rx_queue, rx_data, &tx_queue_handle, tx_queue,
+                              tx_data);
+    serial_putchar_init(SERIAL_TX_CH, &tx_queue_handle);
+    // This is unnecessary for this client...
+    blk_queue_init(&blk_queue, blk_req_queue, blk_resp_queue, BLK_QUEUE_CAPACITY_CLI1);
+
+    sddf_printf("Hello from plug controller\n");
+}

--- a/include/sddf/blk/config.h
+++ b/include/sddf/blk/config.h
@@ -24,6 +24,7 @@ typedef struct blk_connection_resource {
     region_resource_t resp_queue;
     uint16_t num_buffers;
     uint8_t id;
+    uint8_t id_state;
 } blk_connection_resource_t;
 
 typedef struct blk_driver_config {

--- a/include/sddf/blk/storage_info.h
+++ b/include/sddf/blk/storage_info.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <microkit.h>
 
 #define BLK_STORAGE_INFO_REGION_SIZE 0x1000
 
@@ -37,6 +38,12 @@ _Static_assert(sizeof(blk_storage_info_t) <= BLK_STORAGE_INFO_REGION_SIZE,
  * Load from shared memory whether the block storage device is ready.
  * This does an atomic acquire operation.
  *
+ * @attention Due to the asynchronous nature of this system, even if the state
+ * has not "changed", the notification about it would have derived from a
+ * change...For instance, Ready -> Not Ready -> Ready could be seen as just the
+ * sequence Ready -> Ready, but the block device may have changed. Clients
+ * should reperform any initialisation necessary.
+ *
  * @param storage_info the block storage device to check
  * @return true the block storage device is ready to use
  * @return false the block storage device is not ready (removed, or initialising)
@@ -44,4 +51,23 @@ _Static_assert(sizeof(blk_storage_info_t) <= BLK_STORAGE_INFO_REGION_SIZE,
 static inline bool blk_storage_is_ready(blk_storage_info_t *storage_info)
 {
     return __atomic_load_n(&storage_info->ready, __ATOMIC_ACQUIRE);
+}
+
+/**
+ * Store in shared memory the block storage device ready state, and notify on
+ * the Block State notification channel that we had a state change.
+ *
+ * @param storage_info
+ * @param ch
+ * @param ready
+ */
+static inline void blk_storage_notify_ready(blk_storage_info_t *storage_info, microkit_channel ch, bool ready)
+{
+    __atomic_store_n(&storage_info->ready, ready, __ATOMIC_RELEASE);
+
+    /* Correctness: We always want to notify on a state change, even if it
+       appears to be a noop, because if we had IRQs showing In -> Out -> In,
+       we might only see the In->In states.
+    */
+    microkit_notify(ch);
 }

--- a/include/sddf/hotplug/clients.h
+++ b/include/sddf/hotplug/clients.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <microkit.h>
+
+/**
+ * For inter-client communication & safe ejection.
+ */
+
+typedef struct hotplug_info {
+    bool pending_eject;
+} hotplug_info_t;
+
+#define SDDF_HOTPLUG_CLIENT_READY_FOR_EJECT 1
+
+// TODO: Doc Comments
+
+static inline bool hotplug_is_pending_eject(hotplug_info_t *hotplug_info)
+{
+    return __atomic_load_n(&hotplug_info->pending_eject, __ATOMIC_ACQUIRE);
+}
+
+static inline void hotplug_set_pending_eject(hotplug_info_t *hotplug_info, microkit_channel client_ch,
+                                             bool pending_eject)
+{
+    __atomic_store_n(&hotplug_info->pending_eject, pending_eject, __ATOMIC_RELEASE);
+    if (pending_eject) {
+        /* only for setting pending */
+        microkit_notify(client_ch);
+    }
+}
+
+static inline void hotplug_ready_for_eject(microkit_channel controller_ch)
+{
+    (void)microkit_ppcall(controller_ch, microkit_msginfo_new(SDDF_HOTPLUG_CLIENT_READY_FOR_EJECT, 0));
+}

--- a/include/sddf/hotplug/control.h
+++ b/include/sddf/hotplug/control.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <microkit.h>
+
+/**
+ * For the controller and drivers to communicate.
+ */
+
+#define SDDF_HOTPLUG_REQ_INSERT  1
+#define SDDF_HOTPLUG_REQ_EJECT   2
+
+/* wait for an state change interrupt  */
+#define SDDF_HOTPLUG_RESP_OK      1
+/* we're already in this state */
+#define SDDF_HOTPLUG_RESP_NOOP    2
+/* we couldn't do this as we were already doing something else */
+#define SDDF_HOTPLUG_RESP_INVALID_OPERATION   3
+/* there is no device */
+#define SDDF_HOTPLUG_RESP_NO_DEV  4


### PR DESCRIPTION
- Virtualiser reading the MBR and assigning partitions with a static partition index <-> client index mapping is split out into a separate virtualiser policy interface, implemented by mbr.c (& virt.h)
- Added a hotplugging example that plays a "game" with a "safe" ejection state (see its README)
- ~~Split out `blk_storage_info_t` to a `storage_info.h` header with some helper functions~~
- New interclient hotplug interface (sddf/hotplug/clients.h) and driver control interface (sddf/hotplug/control.h)
- uSDHC driver polls GPIO pins for card detection

To-Do:
- [x] ~~Design document (in progress)~~ added to design doc
- [ ] use gpio driver when it exists
- [ ] integration with sdfgen tooling