### PR TITLE
Add JH7110 timer driver

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -17,6 +17,7 @@ const DriverClass = struct {
         arm,
         meson,
         imx,
+        jh7110,
     };
 
     const I2cHost = enum {

--- a/ci/examples.sh
+++ b/ci/examples.sh
@@ -181,7 +181,7 @@ i2c() {
 }
 
 timer() {
-    BOARDS=("odroidc4" "qemu_virt_aarch64")
+    BOARDS=("odroidc4" "qemu_virt_aarch64" "star64")
     CONFIGS=("debug" "release")
     for BOARD in "${BOARDS[@]}"
     do

--- a/drivers/timer/jh7110/timer.c
+++ b/drivers/timer/jh7110/timer.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <microkit.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <sddf/timer/protocol.h>
+
+/*
+ * The JH7110 SoC contains a timer with four 32-bit counters. Each one of these
+ * counters is referred to as a "channel". These are not to be confused with
+ * Microkit channels. Anything with a prefix STARFIVE_TIMER_* is to do with the
+ * hardware.
+ */
+#define STARFIVE_TIMER_NUM_CHANNELS 4
+
+#define STARFIVE_TIMER_CHANNEL_REGS_SIZE 0x40
+
+#ifndef STARFIVE_TIMER_CHANNEL
+#define STARFIVE_TIMER_CHANNEL 1
+#endif
+
+#if STARFIVE_TIMER_CHANNEL >= STARFIVE_TIMER_NUM_CHANNELS
+#error "Invalid StarFive timer device channel"
+#endif
+
+#define COUNTER_IRQ_CH 0
+#define TIMEOUT_IRQ_CH 1
+
+#define CLIENT_CH_START 2
+#define MAX_TIMEOUTS 6
+
+#define STARFIVE_TIMER_MAX_TICKS UINT32_MAX
+#define STARFIVE_TIMER_MODE_CONTINUOUS 0
+#define STARFIVE_TIMER_MODE_SINGLE 1
+#define STARFIVE_TIMER_DISABLED 0
+#define STARFIVE_TIMER_ENABLED 1
+#define STARFIVE_TIMER_INTERRUPT_UNMASKED 0
+#define STARFIVE_TIMER_INTERRUPT_MASKED 1
+#define STARFIVE_TIMER_INTCLR_BUSY (1 << 1)
+
+/* 24 MHz frequency. */
+#define STARFIVE_TIMER_TICKS_PER_SECOND 0x16e3600
+
+typedef struct {
+    /* Registers */
+    uint32_t intstatus; /* 0x00: Interrupt status for channels 0 -4. Read only. */
+    uint32_t ctrl;      /* 0x04: Timer control. 0 - continuous run, 1 - single run. */
+    uint32_t load;      /* 0x08: Load value to counter. */
+    uint32_t unknown1;  /* 0x0b: Unused. */
+    uint32_t enable;    /* 0x10: Timer enable register. */
+    uint32_t reload;    /* 0x14: Write 1 or 0, both reload counter. */
+    uint32_t value;     /* 0x18: Value of timer. Read only. */
+    uint32_t unknown2;  /* 0x1b: Unused. */
+    uint32_t intclr;    /* 0x20: Timer interrupt clear register. */
+    uint32_t intmask;   /* 0x24: Timer interrupt mask register. */
+} starfive_timer_regs_t;
+
+uintptr_t timer_base;
+static volatile starfive_timer_regs_t *counter_regs;
+static volatile starfive_timer_regs_t *timeout_regs;
+
+/* Keep track of how many timer overflows have occured.
+ * Used as the most significant segment of ticks.
+ * We need to keep track of this state as the value register is only
+ * 32 bits as opposed to the common 64 bit timer value regsiters found
+ * on other devices.
+ */
+uint32_t counter_timer_elapses = 0;
+uint32_t timeout_timer_elapses = 0;
+
+/* Right now, we only service a single timeout per client.
+ * This timeout array indicates when a timeout should occur,
+ * indexed by client ID. */
+static uint64_t timeouts[MAX_TIMEOUTS];
+
+static uint64_t get_ticks_in_ns(void)
+{
+    /* the timer value counts down from the load value */
+    uint64_t value_l = (uint64_t)(STARFIVE_TIMER_MAX_TICKS - counter_regs->value);
+    uint64_t value_h = (uint64_t)counter_timer_elapses;
+
+    /* Include unhandled interrupt in value_h */
+    if (counter_regs->intclr == 1) {
+        value_h += 1;
+    }
+
+    uint64_t value_ticks = (value_h << 32) | value_l;
+
+    /* convert from ticks to nanoseconds */
+    uint64_t value_whole_seconds = value_ticks / STARFIVE_TIMER_TICKS_PER_SECOND;
+    uint64_t value_subsecond_ticks = value_ticks % STARFIVE_TIMER_TICKS_PER_SECOND;
+    uint64_t value_subsecond_ns = (value_subsecond_ticks * NS_IN_S) / STARFIVE_TIMER_TICKS_PER_SECOND;
+    uint64_t value_ns = value_whole_seconds * NS_IN_S + value_subsecond_ns;
+
+    return value_ns;
+}
+
+static void process_timeouts(uint64_t curr_time)
+{
+    for (int i = 0; i < MAX_TIMEOUTS; i++) {
+        if (timeouts[i] <= curr_time) {
+            microkit_notify(CLIENT_CH_START + i);
+            timeouts[i] = UINT64_MAX;
+        }
+    }
+
+    uint64_t next_timeout = UINT64_MAX;
+    for (int i = 0; i < MAX_TIMEOUTS; i++) {
+        if (timeouts[i] < next_timeout) {
+            next_timeout = timeouts[i];
+        }
+    }
+
+    if (next_timeout != UINT64_MAX) {
+        uint64_t ns = next_timeout - curr_time;
+        timeout_regs->enable = STARFIVE_TIMER_DISABLED;
+        timeout_timer_elapses = 0;
+        timeout_regs->ctrl = STARFIVE_TIMER_MODE_SINGLE;
+
+        uint64_t ticks_whole_seconds = (ns / NS_IN_S) * STARFIVE_TIMER_TICKS_PER_SECOND;
+        uint64_t ticks_remainder = (ns % NS_IN_S) * STARFIVE_TIMER_TICKS_PER_SECOND / NS_IN_S;
+        uint64_t num_ticks = ticks_whole_seconds + ticks_remainder;
+
+        assert(num_ticks <= STARFIVE_TIMER_MAX_TICKS);
+        if (num_ticks > STARFIVE_TIMER_MAX_TICKS) {
+            sddf_dprintf("ERROR: num_ticks: 0x%lx\n", num_ticks);
+        }
+
+        timeout_regs->load = num_ticks;
+        timeout_regs->enable = STARFIVE_TIMER_ENABLED;
+    }
+}
+
+void notified(microkit_channel ch)
+{
+    switch (ch) {
+    case COUNTER_IRQ_CH: {
+        counter_timer_elapses += 1;
+        while (counter_regs->intclr & STARFIVE_TIMER_INTCLR_BUSY) {
+            /*
+            * Hardware will not currently accept writes to this register.
+            * Wait for this bit to be unset by hardware.
+            */
+        }
+        counter_regs->intclr = 1;
+        break;
+    }
+    case TIMEOUT_IRQ_CH: {
+        timeout_timer_elapses += 1;
+        while (timeout_regs->intclr & STARFIVE_TIMER_INTCLR_BUSY) {
+            /*
+            * Hardware will not currently accept writes to this register.
+            * Wait for this bit to be unset by hardware.
+            */
+        }
+        timeout_regs->intclr = 1;
+
+        uint64_t curr_time = get_ticks_in_ns();
+        process_timeouts(curr_time);
+
+        break;
+    }
+    default: {
+        sddf_dprintf("TIMER DRIVER|LOG: unexpected notification from channel %u\n", ch);
+        return;
+    }
+    }
+
+    microkit_deferred_irq_ack(ch);
+}
+
+seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
+{
+    switch (microkit_msginfo_get_label(msginfo)) {
+    case SDDF_TIMER_GET_TIME: {
+        uint64_t time_ns = get_ticks_in_ns();
+        seL4_SetMR(0, time_ns);
+        return microkit_msginfo_new(0, 1);
+    }
+    case SDDF_TIMER_SET_TIMEOUT: {
+        uint64_t curr_time = get_ticks_in_ns();
+        uint64_t offset_ns = seL4_GetMR(0);
+        timeouts[ch - CLIENT_CH_START] = curr_time + offset_ns;
+        process_timeouts(curr_time);
+        break;
+    }
+    default:
+        sddf_dprintf("TIMER DRIVER|LOG: Unknown request %lu to timer from channel %u\n",
+                     microkit_msginfo_get_label(msginfo), ch);
+        break;
+    }
+
+    return microkit_msginfo_new(0, 0);
+}
+
+void init(void)
+{
+    for (int i = 0; i < MAX_TIMEOUTS; i++) {
+        timeouts[i] = UINT64_MAX;
+    }
+
+    counter_regs = (volatile starfive_timer_regs_t *)timer_base;
+    timeout_regs = (volatile starfive_timer_regs_t *)(timer_base
+                                                      + STARFIVE_TIMER_CHANNEL_REGS_SIZE * STARFIVE_TIMER_CHANNEL);
+    timeout_regs->enable = STARFIVE_TIMER_DISABLED;
+    timeout_regs->ctrl = STARFIVE_TIMER_MODE_CONTINUOUS;
+    timeout_regs->load = STARFIVE_TIMER_MAX_TICKS;
+    timeout_regs->intmask = STARFIVE_TIMER_INTERRUPT_UNMASKED;
+
+    counter_regs->enable = STARFIVE_TIMER_DISABLED;
+    counter_regs->ctrl = STARFIVE_TIMER_MODE_CONTINUOUS;
+    counter_regs->load = STARFIVE_TIMER_MAX_TICKS;
+    counter_regs->intmask = STARFIVE_TIMER_INTERRUPT_UNMASKED;
+
+    counter_regs->enable = STARFIVE_TIMER_ENABLED;
+}

--- a/drivers/timer/jh7110/timer_driver.mk
+++ b/drivers/timer/jh7110/timer_driver.mk
@@ -1,0 +1,27 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Include this snippet in your project Makefile to build
+# the JH7110 timer driver
+#
+# NOTES:
+#  Generates timer_driver.elf
+#  Expects libsddf_util_debug.a to be in ${LIBS}
+
+TIMER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+timer_driver.elf: timer/timer.o
+	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
+
+timer/timer.o: ${TIMER_DIR}/timer.c ${CHECK_FLAGS_BOARD_MD5} |timer
+	${CC} ${CFLAGS} -o $@ -c $<
+
+timer:
+	mkdir -p timer
+
+clean::
+	rm -rf timer
+clobber::
+	rm -f timer_driver.elf

--- a/examples/serial/serial.mk
+++ b/examples/serial/serial.mk
@@ -75,7 +75,7 @@ REPORT_FILE = report.txt
 ifeq ($(ARCH),aarch64)
 	CFLAGS += -mcpu=$(CPU) -mstrict-align -target aarch64-none-elf
 else ifeq ($(ARCH),riscv64)
-	CFLAGS += -march=rv64imafdc -target riscv64-none-elf -DPRINTF_DISABLE_SUPPORT_FLOAT
+	CFLAGS += -march=rv64imafdc -target riscv64-none-elf
 endif
 CFLAGS += -I$(BOARD_DIR)/include \
 	-I${TOP}/include	\

--- a/examples/timer/Makefile
+++ b/examples/timer/Makefile
@@ -14,12 +14,17 @@ BUILD_DIR ?= build
 MICROKIT_CONFIG ?= debug
 
 ifeq ($(strip $(MICROKIT_BOARD)), odroidc4)
+	export ARCH := aarch64
 	export TIMER_DRIVER_DIR := meson
 	export CPU := cortex-a55
 else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_aarch64)
+	export ARCH := aarch64
 	export TIMER_DRIVER_DIR := arm
 	export CPU := cortex-a53
 	QEMU := qemu-system-aarch64
+else ifeq ($(strip $(MICROKIT_BOARD)), star64)
+	export ARCH := riscv64
+	export TIMER_DRIVER_DIR := jh7110
 else
 $(error Unsupported MICROKIT_BOARD given)
 endif

--- a/examples/timer/board/star64/timer.system
+++ b/examples/timer/board/star64/timer.system
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2024, UNSW
+
+    SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="timer_registers" size="0x10_000" phys_addr="0x13050000" />
+
+    <protection_domain name="timer" priority="254" pp="true" >
+        <program_image path="timer_driver.elf" />
+        <map mr="timer_registers" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="timer_base" />
+        <irq irq="69" id="0" trigger="edge" />
+        <irq irq="70" id="1" trigger="edge" />
+    </protection_domain>
+
+    <protection_domain name="client" priority="1" >
+        <program_image path="client.elf" />
+    </protection_domain>
+
+    <channel>
+        <end pd="timer" id="2" />
+        <end pd="client" id="1" />
+    </channel>
+</system>

--- a/examples/timer/build.zig
+++ b/examples/timer/build.zig
@@ -6,7 +6,8 @@ const std = @import("std");
 
 const MicrokitBoard = enum {
     qemu_virt_aarch64,
-    odroidc4
+    odroidc4,
+    star64,
 };
 
 const Target = struct {
@@ -29,6 +30,15 @@ const targets = [_]Target{
         .zig_target = std.Target.Query{
             .cpu_arch = .aarch64,
             .cpu_model = .{ .explicit = &std.Target.arm.cpu.cortex_a55 },
+            .os_tag = .freestanding,
+            .abi = .none,
+        },
+    },
+    .{
+        .board = MicrokitBoard.star64,
+        .zig_target = std.Target.Query{
+            .cpu_arch = .riscv64,
+            .cpu_model = .{ .explicit = &std.Target.riscv.cpu.baseline_rv64 },
             .os_tag = .freestanding,
             .abi = .none,
         },
@@ -89,6 +99,7 @@ pub fn build(b: *std.Build) void {
     const driver_class = switch (microkit_board_option.?) {
         .qemu_virt_aarch64 => "arm",
         .odroidc4 => "meson",
+        .star64 => "jh7110",
     };
 
     const driver = sddf_dep.artifact(b.fmt("driver_timer_{s}.elf", .{ driver_class }));

--- a/examples/timer/timer.mk
+++ b/examples/timer/timer.mk
@@ -29,7 +29,7 @@ IMAGES := timer_driver.elf client.elf
 ifeq ($(ARCH),aarch64)
 	CFLAGS_ARCH := -mcpu=$(CPU) -mstrict-align -target aarch64-none-elf
 else ifeq ($(ARCH),riscv64)
-	CFLAGS_ARCH := -march=rv64imafdc -target riscv64-none-elf -DPRINTF_DISABLE_SUPPORT_FLOAT
+	CFLAGS_ARCH := -march=rv64imafdc -target riscv64-none-elf
 endif
 
 CFLAGS := -nostdlib \

--- a/examples/timer/timer.mk
+++ b/examples/timer/timer.mk
@@ -25,16 +25,21 @@ BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
 UTIL := $(SDDF)/util
 
 IMAGES := timer_driver.elf client.elf
-CFLAGS := -mcpu=$(CPU) \
-		  -mstrict-align \
-		  -nostdlib \
+
+ifeq ($(ARCH),aarch64)
+	CFLAGS_ARCH := -mcpu=$(CPU) -mstrict-align -target aarch64-none-elf
+else ifeq ($(ARCH),riscv64)
+	CFLAGS_ARCH := -march=rv64imafdc -target riscv64-none-elf -DPRINTF_DISABLE_SUPPORT_FLOAT
+endif
+
+CFLAGS := -nostdlib \
 		  -ffreestanding \
 		  -g3 \
 		  -O3 \
 		  -Wall -Wno-unused-function -Werror -Wno-unused-command-line-argument \
 		  -I$(BOARD_DIR)/include \
 		  -I$(SDDF)/include \
-		  -target aarch64-none-elf
+		  $(CFLAGS_ARCH)
 LDFLAGS := -L$(BOARD_DIR)/lib
 LIBS := --start-group -lmicrokit -Tmicrokit.ld libsddf_util_debug.a --end-group
 


### PR DESCRIPTION
Also adds support for the Pine64 Star64 in the timer example.

This example expects the mainline Microkit to be used which is why it has not been added into the CI script. I will do so once sDDF transitions to the mainline Microkit in the next couple of days.