### PR TITLE
Add Synopsis DesignWare ABP UART driver

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,6 +10,7 @@ const DriverClass = struct {
         arm,
         meson,
         imx,
+        snps,
     };
 
     const Timer = enum {

--- a/drivers/serial/snps/include/uart.h
+++ b/drivers/serial/snps/include/uart.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define LOG_DRIVER(...) do{ microkit_dbg_puts(microkit_name); microkit_dbg_puts("|INFO: "); microkit_dbg_puts(__VA_ARGS__); }while(0)
+#define LOG_DRIVER_ERR(...) do{ microkit_dbg_puts(microkit_name); microkit_dbg_puts("|ERROR: "); microkit_dbg_puts(__VA_ARGS__); }while(0)
+
+/*
+ * Divide positive or negative dividend by positive divisor and round
+ * to closest integer. Result is undefined for negative divisors and
+ * for negative dividends if the divisor variable type is unsigned.
+ */
+#define DIV_ROUND_CLOSEST(x, divisor)(          \
+{                           \
+    typeof(x) __x = x;              \
+    typeof(divisor) __d = divisor;          \
+    (((typeof(x))-1) > 0 ||             \
+     ((typeof(divisor))-1) > 0 || (__x) > 0) ?  \
+        (((__x) + ((__d) / 2)) / (__d)) :   \
+        (((__x) - ((__d) / 2)) / (__d));    \
+}                           \
+)
+
+/*  This reference clock value is taken from Pine64 u-boot.
+    This value will be board specific. */
+#define UART_CLK 24000000
+
+/* UART Receive Buffer Register */
+#define UART_RBR 0x00
+/* UART Transmit Holding Register */
+#define UART_THR 0x00
+/* UART Interrupt Enable Register */
+#define UART_IER 0x04
+/* UART Interrupt Identity Register */
+#define UART_IIR 0x08
+/* Transmit Holding Register Empty */
+#define UART_IIR_THR_EMPTY 0x2
+/* Received Data Available */
+#define UART_IIR_RX 0x4
+/* Enable Received Data Available Interrupt */
+#define UART_IER_ERBFI 0x1
+/* Enable Transmit Holding Register Empty Interrupt */
+#define UART_IER_ETBEI 0x2
+/* UART Line Status Register */
+#define UART_LSR 0x14
+/* Data Ready */
+#define UART_LSR_DR 0x1
+/* Transmit Holding Register Empty */
+#define UART_LSR_THRE 0x20
+/* Parity Error Bit */
+#define UART_LSR_PE (1 << 2)
+/* Framing Error Bit */
+#define UART_LSR_FE (1 << 3)
+/* Recv FIFO Error Bit */
+#define UART_LSR_RFE (1 << 7)
+/* Abnormal Status */
+#define UART_ABNORMAL (UART_LSR_PE | UART_LSR_FE | UART_LSR_RFE)
+/* UART Software Reset Register */
+#define UART_SSR 0x88
+/* UART Reset */
+#define UART_SSR_UR (1 << 0)
+/* UART Modem Control Register */
+#define UART_MCR 0x10
+/* Data Terminal Ready */
+#define UART_MCR_DTR (1 << 0)
+/* Request to Send */
+#define UART_MCR_RTS (1 << 1)
+/* UART FIFO Control Register NOTE - This is the same offset as
+the IIR, but the IIR is read-only, and the FCR is write-only. */
+#define UART_FCR 0x08
+/* Transmit FIFO Reset */
+#define UART_FCR_XFIFOR (1 << 2)
+/* Receive FIFO Reset */
+#define UART_FCR_RFIFOR (1 << 1)
+/* FIFO Enable */
+#define UART_FCR_FIFOE (1 << 0)
+/* FIFO Clear and Enable */
+#define UART_FCR_CE (UART_FCR_XFIFOR | UART_FCR_RFIFOR | UART_FCR_FIFOE)
+/* UART Line Control Register */
+#define UART_LCR 0x0C
+/* Default for LCR. 8 bit data length and 2 stop bits*/
+#define UART_LCR_DEFAULT 0x03
+/* Divisor Latch Access Bit */
+#define UART_LCR_DLAB (1 << 7)
+/* UART Divisor High Latch */
+#define UART_DLH 0x04
+/* UART Divisor Low Latch */
+#define UART_DLL 0x00
+/* Divisor Latch Mask */
+#define DL_MASK 0xff

--- a/drivers/serial/snps/uart.c
+++ b/drivers/serial/snps/uart.c
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <microkit.h>
+#include <sddf/serial/queue.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <serial_config.h>
+#include "uart.h"
+
+#define IRQ_CH 0
+#define TX_CH  1
+#define RX_CH  2
+
+serial_queue_t *rx_queue;
+serial_queue_t *tx_queue;
+
+char *rx_data;
+char *tx_data;
+
+serial_queue_handle_t rx_queue_handle;
+serial_queue_handle_t tx_queue_handle;
+
+/* UART device registers */
+volatile uintptr_t uart_base;
+
+#define REG_PTR(off)     ((volatile uint32_t *)((uart_base) + (off)))
+
+static void set_baud(unsigned long baud)
+{
+    /*  Divisor Latch Access Bit (DLAB) of the LCR must be set.
+    *   These registers share their address with the FIFO's.
+    */
+
+    uint32_t lcr_val = *REG_PTR(UART_LCR);
+
+    *REG_PTR(UART_LCR) |= UART_LCR_DLAB;
+
+    /* baud rate = (serial_clock_freq) / (16 * divisor) */
+    uint16_t divisor = DIV_ROUND_CLOSEST(UART_CLK, 16 * baud);
+
+    *REG_PTR(UART_DLH) |= (divisor >> 8) & DL_MASK;
+    *REG_PTR(UART_DLL) |= divisor & DL_MASK;
+
+    /* Restore the LCR */
+    *REG_PTR(UART_LCR) = lcr_val;
+}
+
+static void tx_provide(void)
+{
+    bool reprocess = true;
+    bool transferred = false;
+    while (reprocess) {
+        char c;
+
+        while ((*REG_PTR(UART_LSR) & UART_LSR_THRE)
+               && !serial_dequeue(&tx_queue_handle, &tx_queue_handle.queue->head, &c)) {
+            *REG_PTR(UART_THR) = c;
+            transferred = true;
+        }
+
+        serial_request_producer_signal(&tx_queue_handle);
+        /* If transmit FIFO is full and we still have data to be sent, enable TX IRQ */
+        if ((*REG_PTR(UART_LSR) & UART_LSR_THRE) == 0
+            && !serial_queue_empty(&tx_queue_handle, tx_queue_handle.queue->head)) {
+            *REG_PTR(UART_IER) |= UART_IER_ETBEI;
+        } else {
+            *REG_PTR(UART_IER) &= ~UART_IER_ETBEI;
+        }
+        reprocess = false;
+
+        if ((*REG_PTR(UART_LSR) & UART_LSR_THRE)
+            && !serial_queue_empty(&tx_queue_handle, tx_queue_handle.queue->head)) {
+            serial_cancel_producer_signal(&tx_queue_handle);
+            *REG_PTR(UART_IER) &= ~UART_IER_ETBEI;
+            reprocess = true;
+        }
+    }
+
+    if (transferred && serial_require_consumer_signal(&tx_queue_handle)) {
+        serial_cancel_consumer_signal(&tx_queue_handle);
+        microkit_notify(TX_CH);
+    }
+}
+
+static void rx_return(void)
+{
+    bool reprocess = true;
+    bool enqueued = false;
+    while (reprocess) {
+        while ((*REG_PTR(UART_LSR) & UART_LSR_DR)
+               && !serial_queue_full(&rx_queue_handle, rx_queue_handle.queue->tail)) {
+            char c = *REG_PTR(UART_RBR);
+            int err = serial_enqueue(&rx_queue_handle, &rx_queue_handle.queue->tail, c);
+            assert(!err);
+            enqueued = true;
+        }
+
+        /* If we have more RX device data available, but no space in the queue with the virtualiser,
+         * we disable RX IRQs until space becomes available. */
+        if ((*REG_PTR(UART_LSR) & UART_LSR_DR) && serial_queue_full(&rx_queue_handle, rx_queue_handle.queue->tail)) {
+            *REG_PTR(UART_IER) &= ~UART_IER_ERBFI;
+            serial_request_consumer_signal(&rx_queue_handle);
+        }
+        reprocess = false;
+
+        /* While RX data is still available, we enable the RX IRQ and continue processing */
+        if ((*REG_PTR(UART_LSR) & UART_LSR_DR) && !serial_queue_full(&rx_queue_handle, rx_queue_handle.queue->tail)) {
+            serial_cancel_consumer_signal(&rx_queue_handle);
+            *REG_PTR(UART_LSR) |= UART_IER_ERBFI;
+            reprocess = true;
+        }
+    }
+
+    if (enqueued && serial_require_producer_signal(&rx_queue_handle)) {
+        serial_cancel_producer_signal(&rx_queue_handle);
+        microkit_notify(RX_CH);
+    }
+}
+
+static void handle_irq(void)
+{
+    uint32_t irq_status = *REG_PTR(UART_IIR);
+    uint32_t line_status = *REG_PTR(UART_LSR);
+    if (irq_status & UART_IIR_RX) {
+        rx_return();
+    }
+
+    if (irq_status & UART_IIR_THR_EMPTY) {
+        tx_provide();
+    }
+
+    if (line_status & UART_ABNORMAL) {
+        sddf_dprintf("UART|ERROR: Uart device encountered an error with status register %u\n", line_status);
+        /* Clear the UART errors */
+        line_status |= UART_ABNORMAL;
+    }
+}
+
+void init(void)
+{
+    LOG_DRIVER("initialising\n");
+
+    /* Ensure that the FIFO's are empty */
+    while (!(*REG_PTR(UART_LSR) & UART_LSR_THRE));
+
+    /* Reset the UART device - this disables RX and TX */
+    *REG_PTR(UART_SSR) |= UART_SSR_UR;
+
+    /* Setup the Modem Control Register */
+    *REG_PTR(UART_MCR) |= (UART_MCR_DTR | UART_MCR_RTS);
+
+    /* Clear and enable the FIFO's*/
+    *REG_PTR(UART_FCR) = UART_FCR_CE;
+
+    /* Set defaults for the UART Line control register */
+    *REG_PTR(UART_LCR) |= UART_LCR_DEFAULT;
+
+    /* Reset IIR */
+    *REG_PTR(UART_IIR) = 0x1;
+
+    /* Set the baud rate */
+    set_baud(UART_DEFAULT_BAUD);
+
+    /* Enable both Recieve Data Available and Transmit Holding Register Empty IRQs. */
+    *REG_PTR(UART_IER) = (UART_IER_ERBFI | UART_IER_ETBEI);
+
+#if !SERIAL_TX_ONLY
+    serial_queue_init(&rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_DRIV, rx_data);
+#endif
+    serial_queue_init(&tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_DRIV, tx_data);
+}
+
+void notified(microkit_channel ch)
+{
+    switch (ch) {
+    case IRQ_CH:
+        handle_irq();
+        microkit_deferred_irq_ack(IRQ_CH);
+        return;
+    case TX_CH:
+        tx_provide();
+        break;
+    case RX_CH:
+        rx_return();
+        break;
+    default:
+        LOG_DRIVER("received notification on unexpected channel\n");
+        break;
+    }
+}

--- a/drivers/serial/snps/uart_driver.mk
+++ b/drivers/serial/snps/uart_driver.mk
@@ -1,0 +1,27 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Include this snippet in your project Makefile to build
+#    the Synopsis DesignWare ABP UART driver
+# Requires uart_base to be set to the mapped address of the UART
+#    registers in the system description file
+
+UART_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+uart_driver.elf: serial/snps/uart_driver.o
+	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
+
+serial/snps/uart_driver.o: ${UART_DRIVER_DIR}/uart.c |serial/snps
+	$(CC) -c $(CFLAGS) -I${UART_DRIVER_DIR}/include -o $@ $<
+
+serial/snps:
+	mkdir -p $@
+
+-include serial/snps/uart_driver.d
+
+clean::
+	rm -f serial/snps/uart_driver.[do]
+clobber:: clean
+	rm -rf uart_driver.elf serial

--- a/examples/serial/board/star64/serial.system
+++ b/examples/serial/board/star64/serial.system
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2024, UNSW
+
+    SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="uart" size="0x1_000" phys_addr="0x10000000" />
+
+    <memory_region name="rx_data_driver" size="0x2_000" />
+    <memory_region name="tx_data_driver" size="0x2_000" />
+    <memory_region name="rx_data_client0" size="0x2_000" />
+    <memory_region name="tx_data_client0" size="0x2_000" />
+    <memory_region name="rx_data_client1" size="0x2_000" />
+    <memory_region name="tx_data_client1" size="0x2_000" />
+
+    <memory_region name="rx_queue_driver" size="0x1_000" />
+    <memory_region name="tx_queue_driver" size="0x1_000" />
+    <memory_region name="rx_queue_client0" size="0x1_000" />
+    <memory_region name="tx_queue_client0" size="0x1_000" />
+    <memory_region name="rx_queue_client1" size="0x1_000" />
+    <memory_region name="tx_queue_client1" size="0x1_000" />
+
+    <protection_domain name="uart" priority="100">
+        <program_image path="uart_driver.elf" />
+
+        <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
+
+        <map mr="rx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue" />
+        <map mr="tx_queue_driver" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue" />
+
+        <map mr="rx_data_driver" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_driver" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+
+        <irq irq="32" id="0" /> <!-- UART interrupt -->
+    </protection_domain>
+
+    <protection_domain name="client0" priority="97">
+        <program_image path="serial_server.elf" />
+        <map mr="rx_queue_client0" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue" />
+        <map mr="tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue" />
+
+        <map mr="rx_data_client0" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_client0" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+    </protection_domain>
+
+    <protection_domain name="client1" priority="97">
+    <program_image path="serial_server.elf" />
+        <map mr="rx_queue_client1" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue" />
+        <map mr="tx_queue_client1" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue" />
+
+        <map mr="rx_data_client1" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="rx_data" />
+        <map mr="tx_data_client1" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+    </protection_domain>
+
+    <protection_domain name="serial_virt_tx" priority="99">
+        <program_image path="serial_virt_tx.elf" />
+        <map mr="tx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
+        <map mr="tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
+        <map mr="tx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>
+
+        <map mr="tx_data_driver" vaddr="0x4_003_000" perms="rw" cached="true" setvar_vaddr="tx_data_drv" />
+        <map mr="tx_data_client0" vaddr="0x4_005_000" perms="r" cached="true" setvar_vaddr="tx_data_cli0" />
+        <map mr="tx_data_client1" vaddr="0x4_007_000" perms="r" cached="true"/>
+    </protection_domain>
+
+    <protection_domain name="serial_virt_rx" priority="98">
+        <program_image path="serial_virt_rx.elf" />
+        <map mr="rx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="rx_queue_drv" />
+        <map mr="rx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="rx_queue_cli0" />
+        <map mr="rx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>
+
+        <map mr="rx_data_driver" vaddr="0x4_003_000" perms="r" cached="true" setvar_vaddr="rx_data_drv" />
+        <map mr="rx_data_client0" vaddr="0x4_005_000" perms="rw" cached="true" setvar_vaddr="rx_data_cli0" />
+        <map mr="rx_data_client1" vaddr="0x4_007_000" perms="rw" cached="true"/>
+    </protection_domain>
+
+    <channel>
+        <end pd="uart" id="1"/>
+        <end pd="serial_virt_tx" id="0"/>
+    </channel>
+
+    <channel>
+        <end pd="uart" id="2"/>
+        <end pd="serial_virt_rx" id="0"/>
+    </channel>
+
+    <channel>
+        <end pd="serial_virt_tx" id="1"/>
+        <end pd="client0" id="0"/>
+    </channel>
+
+    <channel>
+        <end pd="serial_virt_tx" id="2"/>
+        <end pd="client1" id="0"/>
+    </channel>
+
+   <channel>
+        <end pd="serial_virt_rx" id="1"/>
+        <end pd="client0" id="1"/>
+    </channel>
+
+   <channel>
+        <end pd="serial_virt_rx" id="2"/>
+        <end pd="client1" id="1"/>
+    </channel>
+</system>

--- a/examples/serial/build.zig
+++ b/examples/serial/build.zig
@@ -4,7 +4,7 @@
 //
 const std = @import("std");
 
-const MicrokitBoard = enum { qemu_virt_aarch64, odroidc4, maaxboard };
+const MicrokitBoard = enum { qemu_virt_aarch64, odroidc4, maaxboard, star64 };
 
 const Target = struct {
     board: MicrokitBoard,
@@ -38,7 +38,16 @@ const targets = [_]Target{
             .os_tag = .freestanding,
             .abi = .none,
         },
-    }
+    },
+    .{
+        .board = MicrokitBoard.star64,
+        .zig_target = std.Target.Query{
+            .cpu_arch = .riscv64,
+            .cpu_model = .{ .explicit = &std.Target.riscv.cpu.baseline_rv64 },
+            .os_tag = .freestanding,
+            .abi = .none,
+        }
+    },
 };
 
 fn findTarget(board: MicrokitBoard) std.Target.Query {
@@ -99,6 +108,7 @@ pub fn build(b: *std.Build) void {
         .qemu_virt_aarch64 => "arm",
         .odroidc4 => "meson",
         .maaxboard => "imx",
+        .star64 => "snps",
     };
 
     const driver = sddf_dep.artifact(b.fmt("driver_uart_{s}.elf", .{ driver_class }));


### PR DESCRIPTION
Developed based on the 'DesignWare DW_apb_uart Databook', retrieved from
https://linux-sunxi.org/File:Dw_apb_uart_db.pdf. Version 3.04a,
January 20, 2006.

Also adds support for the Pine64 Star64 to the serial example.