### PR TITLE
examples/timer: add README

### DIFF
--- a/examples/timer/README.md
+++ b/examples/timer/README.md
@@ -1,0 +1,60 @@
+# Timer example
+
+This is a very simple example where a single client program is setting
+timeouts and getting the current time from a timer driver.
+
+## Building
+
+### Make
+
+```sh
+make MICROKIT_SDK=<path/to/sdk> MICROKIT_BOARD=<board>
+```
+
+Currently the options for `MICROKIT_BOARD` are:
+* odroidc4
+* qemu_arm_virt
+
+After building, the system image to load will be `build/loader.img`.
+
+If you wish to simulate on the QEMU ARM virt platform, you can append `qemu` to your make command
+after building for qemu_arm_virt.
+
+### Zig
+
+You can also build this example with the Zig build system:
+```sh
+zig build -Dsdk=/path/to/sdk -Dboard=<board>
+```
+
+The options for `<board>` are the same as the Makefile.
+
+You can simulate QEMU with:
+```sh
+zig build -Dsdk=/path/to/sdk -Dboard=qemu_arm_virt qemu
+```
+
+The final bootable image will be in `zig-out/bin/loader.img`.
+
+## Running
+
+When running the example, you should see something similar to the following
+output:
+```
+CLIENT|INFO: The time now is: 29422640
+CLIENT|INFO: Setting a time out for 1 second
+CLIENT|INFO: Got a timeout!
+CLIENT|INFO: Now the time (in nanoseconds) is: 1031980992
+CLIENT|INFO: Got a timeout!
+CLIENT|INFO: Now the time (in nanoseconds) is: 2032392176
+CLIENT|INFO: Got a timeout!
+CLIENT|INFO: Now the time (in nanoseconds) is: 3032782448
+CLIENT|INFO: Got a timeout!
+CLIENT|INFO: Now the time (in nanoseconds) is: 4033253600
+CLIENT|INFO: Got a timeout!
+CLIENT|INFO: Now the time (in nanoseconds) is: 5033766064
+CLIENT|INFO: Got a timeout!
+CLIENT|INFO: Now the time (in nanoseconds) is: 6034408576
+```
+
+The client will continuously set timeouts and read the current time.


### PR DESCRIPTION
Realised this was missing when adding the JH7110 timer driver to the example.