### PR TITLE
Fix cache bug

### DIFF
--- a/network/components/virt_rx.c
+++ b/network/components/virt_rx.c
@@ -93,7 +93,7 @@ void rx_return(void)
             // usermode CleanInvalidate (faster than a Invalidate via syscall).
             //
             // [1]: https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Instructions/DC-IVAC--Data-or-unified-Cache-line-Invalidate-by-VA-to-PoC
-            cache_clean_and_invalidate(buffer_vaddr, buffer_vaddr + ROUND_UP(buffer.len, 1 << CONFIG_L1_CACHE_LINE_SIZE_BITS));
+            cache_clean_and_invalidate(buffer_vaddr, buffer_vaddr + buffer.len);
             int client = get_mac_addr_match((struct ethernet_header *) buffer_vaddr);
             if (client == BROADCAST_ID) {
                 int ref_index = buffer.io_or_offset / NET_BUFFER_SIZE;

--- a/util/cache.c
+++ b/util/cache.c
@@ -55,6 +55,8 @@ void cache_clean_and_invalidate(unsigned long start, unsigned long end)
     unsigned long vaddr;
     unsigned long index;
 
+    assert(start != end);
+
     /* If the end address is not on a cache line boundary, we want to perform
      * the cache operation on that cache line as well. */
     unsigned long end_rounded = ROUND_UP(end, CONFIG_L1_CACHE_LINE_SIZE_BITS);
@@ -76,6 +78,8 @@ void cache_clean(unsigned long start, unsigned long end)
 {
     unsigned long vaddr;
     unsigned long index;
+
+    assert(start != end);
 
     /* If the end address is not on a cache line boundary, we want to perform
      * the cache operation on that cache line as well. */

--- a/util/cache.c
+++ b/util/cache.c
@@ -50,7 +50,7 @@ void cache_clean_and_invalidate(unsigned long start, unsigned long end)
     unsigned long line;
     unsigned long index;
 
-    for (index = LINE_INDEX(start); index < LINE_INDEX(end) + 1; index++) {
+    for (index = LINE_INDEX(start); index < LINE_INDEX(end); index++) {
         line = index << CONFIG_L1_CACHE_LINE_SIZE_BITS;
         clean_and_invalidate_by_va(line);
     }
@@ -61,7 +61,7 @@ void cache_clean(unsigned long start, unsigned long end)
     unsigned long line;
     unsigned long index;
 
-    for (index = LINE_INDEX(start); index < LINE_INDEX(end) + 1; index++) {
+    for (index = LINE_INDEX(start); index < LINE_INDEX(end); index++) {
         line = index << CONFIG_L1_CACHE_LINE_SIZE_BITS;
         clean_by_va(line);
     }

--- a/util/cache.c
+++ b/util/cache.c
@@ -2,7 +2,13 @@
 #include <stdint.h>
 #include <sddf/util/cache.h>
 #include <sddf/util/util.h>
-/* This is a small utility library for performing manual cache operations on AArch64 from user-level. The primary use-case is for managing regions of memory that are mapped as cached but are accessible by DMA capable devices. */
+
+/*
+ * This is a small utility library for performing manual cache operations on
+ * AArch64 from user-level. The primary use-case is for managing regions of
+ * memory that are mapped as cached but are accessible by DMA capable devices.
+ */
+
 #ifndef CONFIG_AARCH64_USER_CACHE_ENABLE
 #error "CONFIG_AARCH64_USER_CACHE_ENABLE must be enabled"
 #error "seL4 must be configured with CONFIG_AARCH64_USER_CACHE_ENABLE"
@@ -43,12 +49,7 @@ void cache_clean_and_invalidate(unsigned long start, unsigned long end)
 {
     unsigned long line;
     unsigned long index;
-    /* Clean the L1 range */
 
-    /* Finally clean and invalidate the L1 range. The extra clean is only strictly neccessary
-     * in a multiprocessor environment to prevent a write being lost if another core is
-     * attempting a store at the same time. As the range should already be clean asking
-     * it to clean again should not affect performance */
     for (index = LINE_INDEX(start); index < LINE_INDEX(end) + 1; index++) {
         line = index << CONFIG_L1_CACHE_LINE_SIZE_BITS;
         clean_and_invalidate_by_va(line);


### PR DESCRIPTION
These functions were copy-and-pasted from the seL4 kernel where
they are intended to be *inclusive* ranges, this is not the case
for us though. We want to clean the cache *up to* the value of
`end`.

Bug noticed by @midnightveil because the block virtualiser does cache clean on a single data region and hence the last virtual address would have been memory that the virtualiser does not have.

I suspect this issue hasn't occurred before because we have contiguous memory and so the last virtual address would have just overlapped with another region of memory. I need to double check this though.

Closes https://github.com/au-ts/sddf/issues/182.