### PR TITLE
Add Dwmac 5.10a Ethernet Driver

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -19,6 +19,7 @@ Files:
     drivers/network/imx/config.json
     drivers/network/meson/config.json
     drivers/network/virtio/config.json
+    drivers/network/dwmac-5.10a/config.json
     drivers/serial/arm/config.json
     drivers/serial/imx/config.json
     drivers/serial/meson/config.json

--- a/build.zig
+++ b/build.zig
@@ -24,7 +24,8 @@ const DriverClass = struct {
     const Network = enum {
         imx,
         meson,
-        virtio
+        virtio,
+        @"dwmac-5.10a",
     };
 
     const I2cHost = enum {

--- a/drivers/network/dwmac-5.10a/config.json
+++ b/drivers/network/dwmac-5.10a/config.json
@@ -1,0 +1,30 @@
+{
+    "compatible": [
+        "nxp,imx8mp-dwmac-eqos",
+        "snps,dwmac-5.10a",
+        "snps,dwmac-5.20"
+    ],
+    "resources": {
+        "regions": [
+            {
+                "name": "regs",
+                "perms": "rw",
+                "size": 65536,
+                "dt_index": 0
+            },
+            {
+                "name": "device_rx_ring",
+                "size": 32768
+            },
+            {
+                "name": "device_tx_ring",
+                "size": 32768
+            }
+        ],
+        "irqs": [
+            {
+                "dt_index": 0
+            }
+        ]
+    }
+}

--- a/drivers/network/dwmac-5.10a/eth_driver.mk
+++ b/drivers/network/dwmac-5.10a/eth_driver.mk
@@ -1,0 +1,28 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Include this snippet in your project Makefile to build
+# the Synopsys dwmac 5.10a NIC driver
+#
+# NOTES:
+#   Generates eth_driver.elf
+#   Assumes libsddf_util_debug.a is in LIBS
+
+ETHERNET_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+CHECK_NETDRV_FLAGS_MD5:=.netdrv_cflags-$(shell echo -- ${CFLAGS} ${CFLAGS_network} | shasum | sed 's/ *-//')
+
+${CHECK_NETDRV_FLAGS_MD5}:
+	-rm -f .netdrv_cflags-*
+	touch $@
+
+eth_driver.elf: network/starfive/ethernet.o
+	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
+
+network/starfive/ethernet.o: ${ETHERNET_DRIVER_DIR}ethernet.c ${CHECK_NETDRV_FLAGS}
+	mkdir -p network/starfive
+	${CC} -c ${CFLAGS} ${CFLAGS_network} -I ${ETHERNET_DRIVER_DIR} -o $@ $<
+
+-include starfive/ethernet.d

--- a/drivers/network/dwmac-5.10a/ethernet.c
+++ b/drivers/network/dwmac-5.10a/ethernet.c
@@ -1,0 +1,457 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <microkit.h>
+#include <sddf/resources/device.h>
+#include <sddf/network/queue.h>
+#include <sddf/network/config.h>
+#include <sddf/util/util.h>
+#include <sddf/util/fence.h>
+#include <sddf/util/printf.h>
+
+#include "ethernet.h"
+
+__attribute__((__section__(".device_resources"))) device_resources_t device_resources;
+
+__attribute__((__section__(".net_driver_config"))) net_driver_config_t config;
+
+#ifdef CONFIG_PLAT_STAR64
+// @kwinter: Figure out how to get this to work with the new elf patching.
+uintptr_t resets = 0x3000000;
+#endif /* CONFIG_PLAT_STAR64 */
+
+#define RX_COUNT 256
+#define TX_COUNT 256
+#define MAX_COUNT MAX(RX_COUNT, TX_COUNT)
+
+struct descriptor {
+    uint32_t d0;
+    uint32_t d1;
+    uint32_t d2;
+    uint32_t d3;
+};
+
+typedef struct {
+    uint32_t tail; /* index to insert at */
+    uint32_t head; /* index to remove from */
+    uint32_t capacity; /* capacity of the ring */
+    volatile struct descriptor *descr; /* buffer descripter array */
+    net_buff_desc_t descr_mdata[MAX_COUNT]; /* associated meta data array */
+} hw_ring_t;
+
+hw_ring_t rx;
+hw_ring_t tx;
+
+uintptr_t rx_desc_base;
+uintptr_t tx_desc_base;
+
+net_queue_handle_t rx_queue;
+net_queue_handle_t tx_queue;
+
+uintptr_t eth_regs;
+
+static inline bool hw_ring_full(hw_ring_t *ring)
+{
+    return ring->tail - ring->head == ring->capacity;
+}
+
+static inline bool hw_ring_empty(hw_ring_t *ring)
+{
+    return ring->tail - ring->head == 0;
+}
+
+static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uint32_t d0, uint32_t d1, uint32_t d2, uint32_t d3)
+{
+    volatile struct descriptor *d = &(ring->descr[idx]);
+    d->d0 = d0;
+    d->d1 = d1;
+    d->d2 = d2;
+    /* Ensure all writes to the descriptor complete, before we set the flags
+     * that makes hardware aware of this slot.
+     */
+    THREAD_MEMORY_RELEASE();
+    d->d3 = d3;
+}
+
+size_t free_dequeued = 0;
+
+static void rx_provide()
+{
+    bool reprocess = true;
+    while (reprocess) {
+        while (!hw_ring_full(&rx) && !net_queue_empty_free(&rx_queue)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_free(&rx_queue, &buffer);
+            assert(!err);
+            free_dequeued += 1;
+
+            uint32_t idx = rx.tail % rx.capacity;
+            rx.descr_mdata[idx] = buffer;
+            update_ring_slot(&rx, idx, (uint32_t)(buffer.io_or_offset & 0xffffffff),
+                             (uint32_t)(buffer.io_or_offset >> 32), 0,
+                             (uint32_t)(DESC_RXSTS_OWNBYDMA | DESC_RXSTS_BUFFER1_ADDR_VALID | DESC_RXSTS_IOC));
+            /* We will update the hardware register that stores the tail address. This tells
+            the device that we have new descriptors to use. */
+            THREAD_MEMORY_RELEASE();
+            *DMA_REG(DMA_CH0_RXDESC_TAIL_PTR) = rx_desc_base + sizeof(struct descriptor) * rx.tail;
+            rx.tail++;
+        }
+
+        net_request_signal_free(&rx_queue);
+        reprocess = false;
+
+        if (!net_queue_empty_free(&rx_queue) && !hw_ring_full(&rx)) {
+            net_cancel_signal_free(&rx_queue);
+            reprocess = true;
+        }
+    }
+}
+
+static void rx_return(void)
+{
+    bool packets_transferred = false;
+    while (!hw_ring_empty(&rx)) {
+        /* If buffer slot is still empty, we have processed all packets the device has filled */
+        uint32_t idx = rx.head % rx.capacity;
+        volatile struct descriptor *d = &(rx.descr[idx]);
+        if (d->d3 & DESC_RXSTS_OWNBYDMA) {
+            break;
+        }
+
+        THREAD_MEMORY_ACQUIRE();
+
+        net_buff_desc_t buffer = rx.descr_mdata[idx];
+        if (d->d3 & DESC_RXSTS_ERROR) {
+            sddf_dprintf("ETH|ERROR: RX descriptor returned with error status %x\n", d->d3);
+            idx = rx.tail % rx.capacity;
+            rx.descr_mdata[idx] = buffer;
+            update_ring_slot(&rx, idx, (uint32_t)(buffer.io_or_offset & 0xffffffff),
+                             (uint32_t)(buffer.io_or_offset >> 32), 0,
+                             (uint32_t)(DESC_RXSTS_OWNBYDMA | DESC_RXSTS_BUFFER1_ADDR_VALID | DESC_RXSTS_IOC));
+
+            /* We will update the hardware register that stores the tail address. This tells
+            the device that we have new descriptors to use. */
+            *DMA_REG(DMA_CH0_RXDESC_TAIL_PTR) = rx_desc_base + sizeof(struct descriptor) * idx;
+            /* @krishnan: check why I was incrementing head here and not tail. */
+            // rx.head = (rx.head + 1) % RX_COUNT;
+            rx.tail++;
+        } else {
+            /* Read 0-14 bits to get length of received packet, manual pg 4081, table 11-152, RDES3 Normal Descriptor */
+            buffer.len = (d->d3 & 0x7FFF);
+            int err = net_enqueue_active(&rx_queue, buffer);
+            assert(!err);
+            packets_transferred = true;
+            /* @krishnan: Check why i was doing this here. */
+            // rx.head = (rx.head + 1) % RX_COUNT;
+        }
+        rx.head++;
+    }
+
+    if (packets_transferred && net_require_signal_active(&rx_queue)) {
+        net_cancel_signal_active(&rx_queue);
+        microkit_notify(config.virt_rx.id);
+    }
+}
+
+static void tx_provide(void)
+{
+    bool reprocess = true;
+    int i = 0;
+    while (reprocess) {
+        while (!(hw_ring_full(&tx)) && !net_queue_empty_active(&tx_queue)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_active(&tx_queue, &buffer);
+            assert(!err);
+
+            // For normal transmit descriptors, tdes2 needs to be set to generate an IRQ on transmit
+            // completion. We also need to provide the length of the buffer data in bits 13:0.
+            uint32_t tdes2 = DESC_TXCTRL_TXINT | buffer.len;
+
+            uint32_t idx = tx.tail % tx.capacity;
+            // For normal transmit descritpors, we need to give ownership to DMA, as well as indicate
+            // that this is the first and last parts of the current packet.
+            uint32_t tdes3 = (DESC_TXSTS_OWNBYDMA | DESC_TXCTRL_TXFIRST | DESC_TXCTRL_TXLAST | DESC_TXCTRL_TXCIC
+                              | buffer.len);
+            tx.descr_mdata[idx] = buffer;
+
+            update_ring_slot(&tx, idx, buffer.io_or_offset & 0xffffffff, buffer.io_or_offset >> 32, tdes2, tdes3);
+
+            tx.tail++;
+            i++;
+            /* Set the tail in hardware to the latest tail we have inserted in.
+             * This tells the hardware that it has new buffers to send.
+             * NOTE: Setting this on every enqueued packet for sanity, change this to once per bactch.
+             */
+            *DMA_REG(DMA_CH0_TXDESC_TAIL_PTR) = tx_desc_base + sizeof(struct descriptor) * (idx);
+        }
+
+        net_request_signal_active(&tx_queue);
+        reprocess = false;
+
+        if (!hw_ring_full(&tx) && !net_queue_empty_active(&tx_queue)) {
+            net_cancel_signal_active(&tx_queue);
+            reprocess = true;
+        }
+    }
+}
+
+static void tx_return(void)
+{
+    bool enqueued = false;
+    while (!hw_ring_empty(&tx)) {
+        /* Ensure that this buffer has been sent by the device */
+        uint32_t idx = tx.head % tx.capacity;
+        volatile struct descriptor *d = &(tx.descr[idx]);
+        if (d->d3 & DESC_TXSTS_OWNBYDMA) {
+            break;
+        }
+        THREAD_MEMORY_ACQUIRE();
+
+        net_buff_desc_t buffer = tx.descr_mdata[idx];
+        int err = net_enqueue_free(&tx_queue, buffer);
+        assert(!err);
+        enqueued = true;
+        tx.head++;
+    }
+
+    if (enqueued && net_require_signal_free(&tx_queue)) {
+        net_cancel_signal_free(&tx_queue);
+        microkit_notify(config.virt_tx.id);
+    }
+}
+
+static void handle_irq()
+{
+    uint32_t e = *DMA_REG(DMA_CH0_STATUS);
+    *DMA_REG(DMA_CH0_STATUS) &= e;
+
+    while (e & DMA_INTR_MASK) {
+        if (e & DMA_CH0_INTERRUPT_EN_RIE) {
+            rx_return();
+        }
+        if (e & DMA_CH0_INTERRUPT_EN_TIE) {
+            tx_return();
+            tx_provide();
+        }
+        if (e & DMA_INTR_ABNORMAL) {
+            if (e & DMA_CH0_INTERRUPT_EN_FBEE) {
+                sddf_dprintf("Ethernet device fatal bus error\n");
+            }
+        }
+        e = *DMA_REG(DMA_CH0_STATUS);
+        *DMA_REG(DMA_CH0_STATUS) &= e;
+    }
+}
+
+static void eth_init()
+{
+    // Software reset -- This will reset the MAC internal registers.
+    volatile uint32_t *mode = DMA_REG(DMA_MODE);
+    *mode |= DMA_MODE_SWR;
+
+    // Poll on BIT 0. This bit is cleared by the device when the reset is complete.
+    while (1) {
+        mode = DMA_REG(DMA_MODE);
+        if (!(*mode & DMA_MODE_SWR)) {
+            break;
+        }
+    }
+
+    /* Configure MTL */
+
+    // Enable store and forward mode for TX, and enable the TX queue.
+    *MTL_REG(MTL_TXQ0_OPERATION_MODE) |= MTL_TXQ_OP_MODE_TSF | MTL_TXQ_OP_MODE_TXQEN;
+
+    // Enable store and forward mode for rx
+    *MTL_REG(MTL_RXQ0_OPERATION_MODE) |= MTL_RXQ_OP_MODE_RSF;
+
+    // Program the rx queue to the DMA mapping.
+    uint32_t map0 = *MTL_REG(MTL_RXQ_DMA_MAP0);
+    // We only have one queue, and we map it onto DMA channel 0
+    map0 &= ~MTL_RXQ_DMA_MAP0_Q0_MDMACH_MASK;
+    map0 |= MTL_RXQ_DMA_MAP0_Q0_DMA0;
+    *MTL_REG(MTL_RXQ_DMA_MAP0) = map0;
+
+    // Transmit/receive queue fifo size, use all RAM for 1 queue
+    uint32_t val = *MAC_REG(MAC_HW_FEATURE1);
+    uint32_t tx_fifo_sz;
+    uint32_t rx_fifo_sz;
+    // These sizes of the tx and rx FIFO are encoded in the hardware feature 1 register.
+    // These values are expressed as: Log2(FIFO_SIZE) -7
+    tx_fifo_sz = (val >> 6) & 0x1f;
+    rx_fifo_sz = (val >> 0) & 0x1f;
+
+    /* r/tx_fifo_sz is encoded as log2(n / 128). Undo that by shifting */
+    tx_fifo_sz = 128 << tx_fifo_sz;
+    rx_fifo_sz = 128 << rx_fifo_sz;
+
+    /* r/tqs is encoded as (n / 256) - 1 */
+    uint32_t tqs = tx_fifo_sz / 256 - 1;
+    uint32_t rqs = rx_fifo_sz / 256 - 1;
+
+    *MTL_REG(MTL_TXQ0_OPERATION_MODE) &= ~(MTL_TXQ_OP_MODE_TQS_MASK);
+    *MTL_REG(MTL_TXQ0_OPERATION_MODE) |= tqs << MTL_TXQ_OP_MODE_TQS_POS;
+    *MTL_REG(MTL_RXQ0_OPERATION_MODE) &= ~(MTL_RXQ_OP_MODE_RQS_MASK);
+    *MTL_REG(MTL_RXQ0_OPERATION_MODE) |= rqs << MTL_RXQ_OP_MODE_RQS_POS;
+
+    // NOTE - more stuff in dwc_eth_qos that we are skipping regarding to tuning the tqs
+
+    /* Configure MAC */
+    *MAC_REG(MAC_RXQ_CTRL0) &= MAC_RXQ_CTRL0_Q0_CLEAR;
+    *MAC_REG(MAC_RXQ_CTRL0) |= MAC_RXQ_CTRL0_Q0_DCB_GEN_EN;
+
+    uint32_t filter = MAC_PACKET_FILTER_PR;
+
+    *MAC_REG(MAC_PACKET_FILTER) = filter;
+
+    // For now, disabling all flow control.
+
+    *MAC_REG(MAC_Q0_TX_FLOW_CTRL) = 0;
+
+    // Program all other appropriate fields in MAC_CONFIGURATION
+    //       (ie. inter-packet gap, jabber disable).
+    uint32_t conf = *MAC_REG(MAC_CONFIGURATION);
+    // Set full duplex mode
+    conf |= MAC_CONFIG_DM;
+    // Enable checksum offload
+    conf |= MAC_CONFIG_IPC;
+
+    // Setting the speed of our device to 1000mbps
+    conf &= ~(MAC_CONFIG_PS | MAC_CONFIG_FES);
+    *MAC_REG(MAC_CONFIGURATION) = conf;
+
+    // Set the MAC Address.
+
+    /* NOTE: We are hardcoding this MAC address to the hardware MAC address of the
+    Star64 in the TS machine queue. This address is resident the boards EEPROM, however,
+    we need I2C to read from this ROM. */
+    *MAC_REG(MAC_ADDRESS0_HIGH) = 0x00005b75;
+    *MAC_REG(MAC_ADDRESS0_LOW) = 0x0039cf6c;
+
+    /* Configure DMA */
+
+    // Enable operate on second packet
+    *DMA_REG(DMA_CH0_TX_CONTROL) |= DMA_CH0_TX_CONTROL_OSF;
+
+    // Set the max packet size for rx
+    *DMA_REG(DMA_CH0_RX_CONTROL) &= ~(DMA_CH0_RX_RBSZ_MASK);
+    *DMA_REG(DMA_CH0_RX_CONTROL) |= (MAX_RX_FRAME_SZ << DMA_CH0_RX_RBSZ_POS);
+
+    // Program the descriptor length. This is to tell the device that when
+    // we reach the base addr + count, we should then wrap back around to
+    // the base.
+
+    *DMA_REG(DMA_CH0_TXDESC_RING_LENGTH) = TX_COUNT - 1;
+    *DMA_REG(DMA_CH0_RXDESC_RING_LENGTH) = RX_COUNT - 1;
+
+    // Init rx and tx descriptor list addresses.
+    rx_desc_base = device_resources.regions[1].io_addr;
+    tx_desc_base = device_resources.regions[2].io_addr;
+
+    *DMA_REG(DMA_CH0_RXDESC_LIST_ADDR) = rx_desc_base & 0xffffffff;
+    *DMA_REG(DMA_CH0_TXDESC_LIST_ADDR) = tx_desc_base & 0xffffffff;
+
+    // Enable interrupts.
+    *DMA_REG(DMA_CH0_INTERRUPT_EN) = DMA_INTR_NORMAL;
+
+    // Populate the rx and tx hardware rings.
+    rx_provide();
+    tx_provide();
+
+    // Start DMA and MAC
+    *DMA_REG(DMA_CH0_TX_CONTROL) |= DMA_CH0_TX_CONTROL_ST;
+    *DMA_REG(DMA_CH0_RX_CONTROL) |= DMA_CH0_RX_CONTROL_SR;
+    *MAC_REG(MAC_CONFIGURATION) |= (MAC_CONFIG_RE | MAC_CONFIG_TE);
+
+    /* NOTE ------ FROM U-BOOT SOURCE CODE dwc_eth_qos.c:995 */
+
+    /* TX tail pointer not written until we need to TX a packet */
+    /*
+	 * Point RX tail pointer at last descriptor. Ideally, we'd point at the
+	 * first descriptor, implying all descriptors were available. However,
+	 * that's not distinguishable from none of the descriptors being
+	 * available.
+	 */
+    *DMA_REG(DMA_CH0_RXDESC_TAIL_PTR) = rx_desc_base + (sizeof(struct descriptor) * (RX_COUNT - 1));
+}
+
+static void eth_setup(void)
+{
+    assert((device_resources.regions[1].io_addr & 0xFFFFFFFF) == device_resources.regions[1].io_addr);
+
+    rx.capacity = RX_COUNT;
+    rx.descr = (volatile struct descriptor *)device_resources.regions[1].region.vaddr;
+    tx.capacity = TX_COUNT;
+    tx.descr = (volatile struct descriptor *)device_resources.regions[2].region.vaddr;
+
+    eth_init();
+}
+
+void init(void)
+{
+    assert(net_config_check_magic((void *)&config));
+    assert(device_resources_check_magic(&device_resources));
+    assert(device_resources.num_irqs == 1);
+    assert(device_resources.num_regions == 3);
+    // All buffers should fit within our DMA region
+    assert(RX_COUNT * sizeof(struct descriptor) <= device_resources.regions[1].region.size);
+    assert(TX_COUNT * sizeof(struct descriptor) <= device_resources.regions[2].region.size);
+
+    eth_regs = (void *)device_resources.regions[0].region.vaddr;
+
+    /* De-assert the reset signals that u-boot left asserted. */
+#ifdef CONFIG_PLAT_STAR64
+    volatile uint32_t *reset_eth = (volatile uint32_t *)(resets + 0x38);
+    uint32_t reset_val = *reset_eth;
+    uint32_t mask = 0;
+    /* U-Boot de-asserts BIT(0) first then BIT(1) when starting up eth0.
+        NOTE: This will be different per-board, but this is correct for the
+        Pine64 Star64. */
+    for (int i = 0; i < 2; i++) {
+        reset_val = *reset_eth;
+        mask = BIT(i);
+        reset_val &= ~mask;
+        *reset_eth = reset_val;
+    }
+#endif /* CONFIG_PLAT_STAR64 */
+
+    // Check if the PHY device is up
+    uint32_t phy_stat = *MAC_REG(MAC_PHYIF_CONTROL_STATUS);
+    if (phy_stat & MAC_PHYIF_CONTROL_LINKSTS) {
+        sddf_dprintf("PHY device is up and running\n");
+    } else {
+        sddf_dprintf("PHY device is currently down\n");
+    }
+
+    if (phy_stat & BIT(16)) {
+        sddf_dprintf("PHY device is operating in full duplex mode\n");
+    } else {
+        sddf_dprintf("PHY device is operating in half duplex mode\n");
+    }
+
+    net_queue_init(&rx_queue, config.virt_rx.free_queue.vaddr, config.virt_rx.active_queue.vaddr,
+                   config.virt_rx.num_buffers);
+    net_queue_init(&tx_queue, config.virt_tx.free_queue.vaddr, config.virt_tx.active_queue.vaddr,
+                   config.virt_tx.num_buffers);
+    eth_setup();
+
+    microkit_irq_ack(device_resources.irqs[0].id);
+}
+
+void notified(microkit_channel ch)
+{
+    if (ch == device_resources.irqs[0].id) {
+        handle_irq();
+        microkit_deferred_irq_ack(ch);
+    } else if (ch == config.virt_rx.id) {
+        rx_provide();
+    } else if (ch == config.virt_tx.id) {
+        tx_provide();
+    } else {
+        sddf_dprintf("ETH|LOG: received notification on unexpected channel %u\n", ch);
+    }
+}

--- a/drivers/network/dwmac-5.10a/ethernet.h
+++ b/drivers/network/dwmac-5.10a/ethernet.h
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#pragma once
+
+/* This register description is from the NXP i.MX8MP SoC TRM. */
+
+/* NOTE: This is a subset of the registers available. */
+
+/* Helper macros */
+
+#define BIT(x) (1U << x)
+#define MAC_REG(x) ((volatile uint32_t *)(eth_regs + x))
+#define MTL_REG(x) ((volatile uint32_t *)(eth_regs + x))
+#define DMA_REG(x) ((volatile uint32_t *)(eth_regs + x))
+#define MAX_RX_FRAME_SZ             (0x600)
+
+/* MAC Registers */
+
+#define MAC_CONFIGURATION           0x0         /* Establishes the operating mode of the MAC. */
+#define MAC_PACKET_FILTER           0x8         /* Contains the filter controls for receiving packets. */
+#define MAC_Q0_TX_FLOW_CTRL         0x70        /* Controls the generation and reception of the Control (pause command) packets by the flow control module to the MAC.*/
+#define MAC_RX_FLOW_CTRL            0x90        /* Controls the pausing of MAC transmit based on the received Pause packet. */
+#define MAC_TXQ_PRTY_MAP0           0x98        /* Contains the priority values assigned to the tx queues. */
+#define MAC_RXQ_CTRL0               0xA0        /* Controls the queue management in the MAC receiver. */
+#define MAC_INTERRUPT_STATUS        0xB0        /* Contains the status of interrupts. */
+#define MAC_INTERRUPT_ENABLE        0xB4        /* Contains the mask for generating the interrupts. */
+#define MAC_PHYIF_CONTROL_STATUS    0xF8        /* Indicates the status signals received by the interface from the PHY. */
+#define MAC_HW_FEATURE1             0x120       /* Indicates the presence of first set of the optional features of this device. */
+#define MAC_ADDRESS0_HIGH           0x300       /* Holds the upper 16 bits of the first 6-byte MAC address. */
+#define MAC_ADDRESS0_LOW            0x304       /* Holds the lower 32 bits of the first 6-byte MAC address.*/
+
+/* MAC Configuration Bits */
+#define MAC_CONFIG_RE               BIT(0)      /* Receiver enable. 0 = disabled, 1 = enabled. */
+#define MAC_CONFIG_TE               BIT(1)      /* Transmitter enable. 0 = disabled, 1 = enabled. */
+#define MAC_CONFIG_DM               BIT(13)     /* Duplex mode. 0 = Half-duplex, 1 = Full-duplex. */
+#define MAC_CONFIG_FES              BIT(14)     /* This bit, in conjunction with PS selects the speed. */
+#define MAC_CONFIG_PS               BIT(15)     /* Port select, selects the ethernet line speed. Used in conjunction with FES. */
+#define MAC_CONFIG_JE               BIT(16)     /* Jumbo packet enable, allows packet size of 9018 bytes. 0 = disabled, 1 = enabled. */
+#define MAC_CONFIG_JB               BIT(17)     /* Jabber disable. 0 = enabled, 1 = disabled. */
+#define MAC_CONFIG_WB               BIT(19)     /* Watchdog disable. 0 = enabled, 1 = disabled. */
+#define MAC_CONFIG_ACS              BIT(20)     /* Automatic PAD or CRC stripping. 0 = disabled, 1 = enabled. */
+#define MAC_CONFIG_CST              BIT(21)     /* CRC stripping for Type packets. 0 = disabled, 1 = enabled. */
+#define MAC_CONFIG_GPSLCE           BIT(23)     /* Giant packet size limit control enable. 0 = disabled, 1 = enabled. */
+#define MAC_CONFIG_IPC              BIT(27)     /* Checksum offload. 0 = disabled, 1 = enabled. */
+
+/* MAC Packet Filter Bits */
+
+#define MAC_PACKET_FILTER_PR        BIT(0)      /* Promiscuous mode. */
+
+/* MAC Receive Queue Control 0 Bits */
+
+#define MAC_RXQ_CTRL0_Q0_CLEAR      (BIT(0) | BIT(1))   /* Clear the bits of the RXQ0EN field. */
+#define MAC_RXQ_CTRL0_Q0_DCB_GEN_EN BIT(1)      /* Queue enabled for DCB/Generic. */
+
+/* MAC Phy Control Bits */
+
+#define MAC_PHYIF_CONTROL_LINKSTS	BIT(19)		/* Link status, indicates if the link is up (0b1) or down (0b0). */
+
+/* MTL Registers */
+
+#define MTL_OPERATION_MODE          0xC00       /* Establishes the tx and rx operating modes and command. */
+#define MTL_RXQ_DMA_MAP0            0xC30       /* Receive Queue and DMA channel mapping 0 register. */
+#define MTL_TXQ0_OPERATION_MODE     0xD00       /* Establishes the tx queue 0 operating modes and commands. */
+#define MTL_TXQ0_DEBUG              0xD08       /* Gives the debug status of various blocks related to the transmit queue 0. */
+#define MTL_Q0_INT_CTRL_STATUS      0xD2C       /* Contains the interrupt enable and status bits for the queue 0 interrupts. */
+#define MTL_RXQ0_OPERATION_MODE     0xD30       /* Establishes the receive queue operating modes and command. */
+#define MTL_RXQ0_DEBUG              0xD38       /* Gives the debug status of various blocks related ot the receive queue 0. */
+#define MTL_RXQ0_CONTROL            0xD3C       /* Controls the receive arbitration and passing of the recv'd packets to the app. */
+
+/* MTL RXQ DMA Map 0 Bits */
+
+#define MTL_RXQ_DMA_MAP0_Q0_MDMACH_MASK  (BIT(0) | BIT(1) | BIT(2)) /* Mask the bits of the Q0MDMACH field (Bits 2 - 0). */
+#define MTL_RXQ_DMA_MAP0_Q0_DMA0   ~(MTL_RXQ_DMA_MAP0_Q0_MDMACH_MASK) /* Bits 000 of this field maps MTL queue 0 to DMA channel 0. */
+
+/* MTL TXQ0 Operation Mode Bits */
+
+#define MTL_TXQ_OP_MODE_TSF         BIT(1)      /* Transmit store and forward enable. */
+#define MTL_TXQ_OP_MODE_TXQEN       BIT(3)      /* Transmit queue enable. */
+#define MTL_TXQ_OP_MODE_TQS_POS     16          /* The position of the TQS field to bit shift with. */
+#define MTL_TXQ_OP_MODE_TQS_MASK    (0b11111 << MTL_TXQ_OP_MODE_TQS_POS) /* Mask for the TQS field. */
+
+/* MTL RXQ0 Control Bits */
+
+#define MTL_RXQ_OP_MODE_RSF         BIT(5)      /* Receive queue store and forward mode. */
+#define MTL_RXQ_OP_MODE_RQS_POS     20          /* The position of the RQS field to bit shift with. */
+#define MTL_RXQ_OP_MODE_RQS_MASK    (0b11111 << MTL_RXQ_OP_MODE_RQS_POS) /* Mask for the RQS field. */
+
+/* DMA Registers */
+
+#define DMA_MODE                    0x1000      /* Establishes the bus operating modes for the DMA. */
+#define DMA_CH0_TX_CONTROL          0x1104      /* Controls the Tx features such as PBL, TCP segmentation and Tx channel weights. */
+#define DMA_CH0_RX_CONTROL          0x1108      /* Controls the Rx features such as PBL, buffer size and extended status. */
+#define DMA_CH0_TXDESC_LIST_ADDR    0x1114      /* Points the DMA to the start of the tx descriptor list. Can only write to this register when tx is stopped. */
+#define DMA_CH0_RXDESC_LIST_ADDR    0x111C      /* Points the DMA to the start of the rx descriptor list. Can only write to this register when rx is sopped. */
+#define DMA_CH0_TXDESC_TAIL_PTR     0x1120      /* Points to an offset from the base and indicates the location of the last valid tx descriptor. */
+#define DMA_CH0_RXDESC_TAIL_PTR     0x1128      /* Points to an offset from the base and indicates the location of the last valid rx descriptor. */
+#define DMA_CH0_TXDESC_RING_LENGTH	0x112C		/* Contains the length of the transmit descriptor ring. */
+#define DMA_CH0_RXDESC_RING_LENGTH	0x1130		/* Contains the length of the receive descriptor ring. */
+#define DMA_CH0_INTERRUPT_EN        0x1134      /* Enables the interrupts that are reported by the DMA_CH0_STATUS register. */
+#define DMA_CH0_STATUS              0x1160      /* Software must read this register to get the status during the ISR to determine the status of the DMA device. */
+
+/* DMA Mode Bits */
+
+#define DMA_MODE_SWR                BIT(0)      /* Software reset when this bit is set. */
+
+/* DMA CH0 Tx Control Bits */
+
+#define DMA_CH0_TX_CONTROL_ST       BIT(0)      /* Start or stop transmission. When set, tx is placed in the 'Running' state. */
+#define DMA_CH0_TX_CONTROL_OSF      BIT(4)      /* Operate on second packet when this bit is set. */
+
+/* DMA CH0 Rx Control Bits */
+
+#define DMA_CH0_RX_CONTROL_SR       BIT(0)      /* Start or stop receive. When this bit is set DMA attempts to acquire a rx descriptor. */
+#define DMA_CH0_RX_RBSZ_POS         1           /* The position of the RBSZ field to use for bit shifting. */
+#define DMA_CH0_RX_RBSZ_MASK        (0b11111111111111 << DMA_CH0_RX_RBSZ_POS) /* Mask for the RBSZ field. */
+
+/* DMA CH0 Interrupt Enable Bits */
+
+#define DMA_CH0_INTERRUPT_EN_TIE    BIT(0)      /* Transmit interrupt enable. */
+#define DMA_CH0_INTERRUPT_EN_TBUE   BIT(1)      /* Transmit buffer unavailable. Needs to be set with NIE. */
+#define DMA_CH0_INTERRUPT_EN_RIE    BIT(6)      /* Receive interrupt enable. */
+#define DMA_CH0_INTERRUPT_EN_RBUE   BIT(7)      /* Receive buffer unavailable. Needs to be set with AIE. */
+#define DMA_CH0_INTERRUPT_EN_RSE    BIT(8)      /* Receive stopped enable. Needs to be set with AIE. */
+#define DMA_CH0_INTERRUPT_EN_RWTE   BIT(9)      /* Receive watchdog timeout enable. Needs to be set with AIE. */
+#define DMA_CH0_INTERRUPT_EN_ETIE   BIT(10)     /* Early transmit interrupt enable. Needs to be set with AIE. */
+#define DMA_CH0_INTERRUPT_EN_ERIE   BIT(11)     /* Early receive interrupt enable. Needs to be set with NIE. */
+#define DMA_CH0_INTERRUPT_EN_FBEE   BIT(12)     /* Fatal bus error enable. Needs to be set with AIE. */
+#define DMA_CH0_INTERRUPT_EN_CDEE   BIT(13)     /* Context descriptor error enable. Needs to be set with AIE. */
+#define DMA_CH0_INTERRUPT_EN_AIE    BIT(14)     /* Abnormal interrupt summary enable. */
+#define DMA_CH0_INTERRUPT_EN_NIE    BIT(15)     /* Normal interrupt summary enable. */
+
+#define DMA_INTR_NORMAL (DMA_CH0_INTERRUPT_EN_TIE | DMA_CH0_INTERRUPT_EN_RIE | DMA_CH0_INTERRUPT_EN_NIE)
+#define DMA_INTR_ABNORMAL (DMA_CH0_INTERRUPT_EN_FBEE | DMA_CH0_INTERRUPT_EN_AIE)
+#define DMA_INTR_MASK (DMA_INTR_NORMAL | DMA_INTR_ABNORMAL)
+
+/* Rx status bit definitions */
+#define DESC_RXSTS_OWNBYDMA         (1 << 31)           /* Descriptor is owned by the DMA of the GMAC Subsystem. */
+#define DESC_RXSTS_BUFFER1_ADDR_VALID (1 << 24)			/* Indicates to the DMA that the buffer 1 address specified in RDES1 is valid. */
+#define DESC_RXSTS_IOC     			(1 << 30)           /* Interrupt enable on completion. */
+#define DESC_RXSTS_LENMSK           (0x3fff0000)        /* Byte length of the received frame that was transferred to Host memory. */
+#define DESC_RXSTS_LENSHFT          (16)
+#define DESC_RXSTS_ERROR            (1 << 15)           /* Error Summary. */
+#define DESC_RXSTS_RXTRUNCATED      (1 << 14)           /* Frame truncation caused by a frame that does not fit within the current descriptor buffers. */
+#define DESC_RXSTS_SAFILTERFAIL     (1 << 13)           /* Source Address Filter Fail. */
+#define DESC_RXSTS_RXIPC_GIANTFRAME (1 << 12)           /* Length Error. */
+#define DESC_RXSTS_RXDAMAGED        (1 << 11)           /* Overflow Error. When set, this bit indicates that the received frame was damaged due to buffer overflow in MTL. */
+#define DESC_RXSTS_RXVLANTAG        (1 << 10)           /* Frame pointed to by this descriptor is a VLAN frame tagged by the GMAC Core. */
+#define DESC_RXSTS_RXFIRST          (1 << 9)            /* This descriptor contains the first buffer of the frame. */
+#define DESC_RXSTS_RXLAST           (1 << 8)            /* The buffers pointed to by this descriptor are the last buffers of the frame. */
+#define DESC_RXSTS_RXIPC_GIANT      (1 << 7)            /* IPC Checksum Error/Giant Frame. */
+#define DESC_RXSTS_RXCOLLISION      (1 << 6)            /* Late collision has occurred while receiving the frame in Half-duplex mode. */
+#define DESC_RXSTS_RXFRAMEETHER     (1 << 5)            /* Indicates that the Receive Frame is an Ethernet-type frame. When this bit is reset, it indicates that the received frame is an IEEE802.3 frame. */
+#define DESC_RXSTS_RXWATCHDOG       (1 << 4)            /* The Receive Watchdog Timer has expired while receiving the current frame and the current frame is truncated after the Watchdog Timeout. */
+#define DESC_RXSTS_RXMIIERROR       (1 << 3)
+#define DESC_RXSTS_RXDRIBBLING      (1 << 2)
+#define DESC_RXSTS_RXCRC            (1 << 1)            /* Cyclic Redundancy Check Error. */
+#define DESC_RXSTS_RXMAC            (1)                 /* Rx MAC Address registers value matched the DA field of the frame. */
+
+/* Rx control bit definitions */
+#define DESC_RXCTRL_RXINTDIS        (1 << 31)           /* Disable Interrupt on Completion. */
+#define DESC_RXCTRL_RXRINGEND       (1 << 25)           /* Descriptor list reached its final descriptor. DMA must loop around. */
+#define DESC_RXCTRL_RXCHAIN         (1 << 24)           /* Second address in the descriptor is the Next Descriptor address rather than the second buffer address. */
+#define DESC_RXCTRL_SIZE2MASK       (0x3ff800)          /* Receive Buffer 2 Size. */
+#define DESC_RXCTRL_SIZE2SHFT       (11)
+#define DESC_RXCTRL_SIZE1MASK       (0x7FF)             /* Receive Buffer 1 Size. */
+#define DESC_RXCTRL_SIZE1SHFT       (0)
+
+/* Tx status bit definitions */
+#define DESC_TXSTS_OWNBYDMA         (1 << 31)           /* Descriptor is owned by the DMA of the GMAC Subsystem. */
+
+/* Tx control bit definitions */
+#define DESC_TXCTRL_TXINT		    (1 << 31)           /* Sets Transmit Interrupt after the present frame has been transmitted. */
+#define DESC_TXCTRL_TXLAST		    (1 << 28)           /* Buffer contains the last segment of the frame. */
+#define DESC_TXCTRL_TXFIRST		    (1 << 29)           /* Buffer contains the first segment of a frame. */
+#define DESC_TXCTRL_TXCRCDIS		(1 << 26)           /* GMAC does not append the Cyclic Redundancy Check (CRC) to the end of the transmitted frame.*/
+#define DESC_TXCTRL_TXRINGEND		(1 << 25)           /* Descriptor list reached its final descriptor. DMA must loop around. */
+#define DESC_TXCTRL_TXCHAIN		    (1 << 24)           /* Second address in the descriptor is the Next Descriptor address rather than the second buffer address. */
+#define DESC_TXCTRL_TXCIC			(3 << 16)			/* IP header checksum and payload checksum insertion are enabled. Pseudo-header checksum is caclculated in hardware. */
+#define DESC_TXCTRL_SIZE2MASK		(0x3ff800)
+#define DESC_TXCTRL_SIZE2SHFT		(11)
+#define DESC_TXCTRL_SIZE1MASK		(0x7FF)
+#define DESC_TXCTRL_SIZE1SHFT		(0)


### PR DESCRIPTION
This PR adds support for dwmac 5.10a ethernet driver, primarily tested on the Pine64 Star64.

These are preliminary performance figures when running the echo_server example. There is still considerable performance improvements to be made.
```
100000000,99984012,100000009,1472,114,298,596,125.48,264,0,0,0
200000000,199901305,200000256,1472,526,726,1022,103.90,727,0,0,0
300000000,299862749,299999187,1472,593,741,913,77.90,737,0,0,0
400000000,399407536,400000656,1472,660,7716,17033,3880.44,7840,0,0,0
500000000,399606637,499999812,1472,20432,23028,25471,1369.32,23418,0,0,0
600000000,400844578,600000198,1472,17411,20281,21603,1078.68,20957,0,0,0
700000000,397171569,699999003,1472,21293,21660,22086,96.94,21646,0,0,0
800000000,403385132,799999446,1472,14940,16987,19086,1257.58,16937,0,0,0
900000000,396167909,899998410,1472,17099,18860,21215,1406.38,18444,0,0,0
1000000000,383013407,814230967,1472,28458,28874,29394,132.36,28817,0,0,0
```
