### PR TITLE
Serial tx virt signal client when space available

### DIFF
--- a/serial/components/virt_tx.c
+++ b/serial/components/virt_tx.c
@@ -183,7 +183,12 @@ void tx_provide(microkit_channel ch)
 
     if (transferred && serial_require_producer_signal(&tx_queue_handle_drv)) {
         serial_cancel_producer_signal(&tx_queue_handle_drv);
-        microkit_deferred_notify(DRIVER_CH);
+        microkit_notify(DRIVER_CH);
+    }
+
+    if (transferred && serial_require_consumer_signal(&tx_queue_handle_cli[active_client])) {
+        serial_cancel_consumer_signal(&tx_queue_handle_cli[active_client]);
+        microkit_deferred_notify(ch);
     }
 }
 


### PR DESCRIPTION
This PR changes the serial tx virtualiser to signal a client after their data has been transmitted to the driver's data region. The primary purpose for this is to enable clients to wait on a notification from the virtualiser if they wish to transmit data but their data region is currently full. 

The signalling of the client is dependent on whether the client sets their notify consumer flag, thus receiving a signal from the tx virtualiser is opt in depending on the client's behaviour.