### PR TITLE
examples/blk: Add a imx8mm_evk system to the example

### DIFF
--- a/ci/examples.sh
+++ b/ci/examples.sh
@@ -179,7 +179,7 @@ serial() {
 }
 
 blk() {
-    BOARDS=("maaxboard")
+    BOARDS=("maaxboard" "imx8mm_evk")
     CONFIGS=("debug" "release")
     for BOARD in "${BOARDS[@]}"
     do

--- a/examples/blk/mmc/README.md
+++ b/examples/blk/mmc/README.md
@@ -7,8 +7,7 @@
 
 This is an example to show a single client reading & writing from an SD card.
 
-This example is intended to be used with an Avnet MaaXBoard.
-It has been tested and developed on that platform.
+It has been developed on an Avnet MaaXBoard, and tested on an IMX8MM_EVK board.
 
 The client reads & writes to the 3rd partition on the SD card (0-index = 2).
 It _will_ overwrite data in this partition.
@@ -22,7 +21,10 @@ The example has been tested using a Class 4 SanDisk 8GiB microSD card formatted 
 make MICROKIT_SDK=<path/to/sdk> MICROKIT_BOARD=<board> MICROKIT_CONFIG=<debug/release>
 ```
 
-Currently the only option for `MICROKIT_BOARD` is "maaxboard".
+Currently the options for `MICROKIT_BOARD` are:
+
+* maaxboard
+* imx8mm_evk
 
 ## Running
 

--- a/examples/blk/mmc/README.md
+++ b/examples/blk/mmc/README.md
@@ -7,7 +7,7 @@
 
 This is an example to show a single client reading & writing from an SD card.
 
-It has been developed on an Avnet MaaXBoard, and tested on an IMX8MM_EVK board.
+It has been developed on an Avnet MaaXBoard. It has been tested on both the MaaXBoard and NXP i.MX8MM-EVK platforms.
 
 The client reads & writes to the 3rd partition on the SD card (0-index = 2).
 It _will_ overwrite data in this partition.

--- a/examples/blk/mmc/board/imx8mm_evk/mmc.system
+++ b/examples/blk/mmc/board/imx8mm_evk/mmc.system
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2024, UNSW
+    SPDX-License-Identifier: BSD-2-Clause
+-->
+<system>
+    <memory_region name="timer"  size="0x10_000" phys_addr="0x302d_0000" />
+    <memory_region name="usdhc2" size="0x10_000" phys_addr="0x30b5_0000" />
+
+    <!-- sDDF Block -->
+    <memory_region name="blk_driver_config" size="0x1000"   page_size="0x1000"   />
+    <memory_region name="blk_driver_req"    size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_driver_resp"   size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_driver_data"   size="0x200000" page_size="0x200000" />
+
+    <memory_region name="blk_client_config" size="0x1000"   page_size="0x1000"   />
+    <memory_region name="blk_client_req"    size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client_resp"   size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client_data"   size="0x200000" page_size="0x200000" />
+
+    <protection_domain name="mmc_driver" priority="100" >
+        <program_image path="mmc_driver.elf" />
+        <map mr="usdhc2" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="usdhc_regs" />
+        <irq irq="55" id="1" />
+
+        <!-- sDDF block -->
+        <map mr="blk_driver_config" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
+        <map mr="blk_driver_req"    vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
+        <map mr="blk_driver_resp"   vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
+    </protection_domain>
+
+    <protection_domain name="timer" priority="101" pp="true" passive="true">
+        <program_image path="timer_driver.elf" />
+        <map mr="timer" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
+        <irq irq="87" id="0" />
+    </protection_domain>
+
+    <channel>
+        <end pd="timer"      id="1" />
+        <end pd="mmc_driver" id="2" />
+    </channel>
+
+    <protection_domain name="client" priority="1" >
+        <program_image path="client.elf" />
+
+        <!-- sDDF Block -->
+        <map mr="blk_client_config" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
+        <map mr="blk_client_req"    vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
+        <map mr="blk_client_resp"   vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
+        <map mr="blk_client_data"   vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_data"       />
+    </protection_domain>
+
+    <channel>
+        <end pd="client"     id="0" />
+        <end pd="blk_virt"   id="1" />
+    </channel>
+
+    <!-- sDDF Block -->
+    <protection_domain name="blk_virt" priority="99">
+        <program_image path="blk_virt.elf" />
+
+        <map mr="blk_driver_config" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_config_driver"     />
+        <map mr="blk_driver_req"    vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue_driver"  />
+        <map mr="blk_driver_resp"   vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue_driver" />
+        <map mr="blk_driver_data"   vaddr="0x40600000" perms="rw" cached="false" setvar_vaddr="blk_data_driver" />
+        <setvar symbol="blk_data_driver_paddr" region_paddr="blk_driver_data" />
+
+        <map mr="blk_client_config" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
+        <map mr="blk_client_req"    vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
+        <map mr="blk_client_resp"   vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
+        <map mr="blk_client_data"   vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_client_data_start" />
+    </protection_domain>
+
+    <channel>
+        <end pd="mmc_driver" id="0" />
+        <end pd="blk_virt"   id="0" />
+    </channel>
+
+</system>


### PR DESCRIPTION
I tested that the basic MMC example works on the iMX8 Mini EVK, and it does, so might as well include the system file.