### PR TITLE
Rework the ethernet_config file

### DIFF
--- a/examples/echo_server/include/ethernet_config/ethernet_config.h
+++ b/examples/echo_server/include/ethernet_config/ethernet_config.h
@@ -90,6 +90,8 @@ static inline uint64_t net_cli_mac_addr(char *pd_name)
     } else if (!sddf_strcmp(pd_name, NET_CLI1_NAME)) {
         return MAC_ADDR_CLI1;
     }
+
+    return 0;
 }
 
 static inline void net_virt_mac_addrs(char *pd_name, uint64_t macs[NUM_NETWORK_CLIENTS])
@@ -122,29 +124,29 @@ static inline void net_copy_queue_size(char *pd_name, size_t *cli_queue_size, si
     }
 }
 
-typedef struct queue_info {
+typedef struct net_queue_info {
     net_queue_t *free;
     net_queue_t *active;
     size_t size;
-} queue_info_t;
+} net_queue_info_t;
 
 static inline void net_virt_queue_info(char *pd_name, net_queue_t *cli0_free, net_queue_t *cli0_active,
-                                       queue_info_t ret[NUM_NETWORK_CLIENTS])
+                                       net_queue_info_t ret[NUM_NETWORK_CLIENTS])
 {
     if (!sddf_strcmp(pd_name, NET_VIRT_RX_NAME)) {
-        ret[0] = (queue_info_t) {
+        ret[0] = (net_queue_info_t) {
             .free = cli0_free, .active = cli0_active, .size = NET_RX_QUEUE_SIZE_COPY0
         };
-        ret[1] = (queue_info_t) {
+        ret[1] = (net_queue_info_t) {
             .free = (net_queue_t *)((uintptr_t)cli0_free + 2 * NET_DATA_REGION_SIZE),
             .active = (net_queue_t *)((uintptr_t)cli0_active + 2 * NET_DATA_REGION_SIZE),
             .size = NET_RX_QUEUE_SIZE_COPY1
         };
     } else if (!sddf_strcmp(pd_name, NET_VIRT_TX_NAME)) {
-        ret[0] = (queue_info_t) {
+        ret[0] = (net_queue_info_t) {
             .free = cli0_free, .active = cli0_active, .size = NET_TX_QUEUE_SIZE_CLI0
         };
-        ret[1] = (queue_info_t) {
+        ret[1] = (net_queue_info_t) {
             .free = (net_queue_t *)((uintptr_t)cli0_free + 2 * NET_DATA_REGION_SIZE),
             .active = (net_queue_t *)((uintptr_t)cli0_active + 2 * NET_DATA_REGION_SIZE),
             .size = NET_TX_QUEUE_SIZE_CLI1

--- a/examples/echo_server/include/ethernet_config/ethernet_config.h
+++ b/examples/echo_server/include/ethernet_config/ethernet_config.h
@@ -83,77 +83,94 @@ _Static_assert(NET_RX_QUEUE_SIZE_COPY1 >= NET_RX_QUEUE_SIZE_DRIV,
 _Static_assert(sizeof(net_queue_t) + NET_MAX_QUEUE_SIZE *sizeof(net_buff_desc_t) <= NET_DATA_REGION_SIZE,
                "net_queue_t must fit into a single data region.");
 
-static void __net_set_mac_addr(uint8_t *mac, uint64_t val)
-{
-    mac[0] = val >> 40 & 0xff;
-    mac[1] = val >> 32 & 0xff;
-    mac[2] = val >> 24 & 0xff;
-    mac[3] = val >> 16 & 0xff;
-    mac[4] = val >> 8 & 0xff;
-    mac[5] = val & 0xff;
-}
-
-static inline void net_cli_mac_addr_init_sys(char *pd_name, uint8_t *macs)
+static inline uint64_t net_cli_mac_addr(char *pd_name)
 {
     if (!sddf_strcmp(pd_name, NET_CLI0_NAME)) {
-        __net_set_mac_addr(macs, MAC_ADDR_CLI0);
+        return MAC_ADDR_CLI0;
+#if NUM_NETWORK_CLIENTS > 1
     } else if (!sddf_strcmp(pd_name, NET_CLI1_NAME)) {
-        __net_set_mac_addr(macs, MAC_ADDR_CLI1);
+        return MAC_ADDR_CLI1;
+#endif /* NUM_NETWORK_CLIENTS > 1 */
     }
 }
 
-static inline void net_virt_mac_addr_init_sys(char *pd_name, uint8_t *macs)
+static inline void net_virt_mac_addrs(char *pd_name, uint64_t macs[NUM_NETWORK_CLIENTS])
 {
     if (!sddf_strcmp(pd_name, NET_VIRT_RX_NAME)) {
-        __net_set_mac_addr(macs, MAC_ADDR_CLI0);
-        __net_set_mac_addr(&macs[ETH_HWADDR_LEN], MAC_ADDR_CLI1);
+        macs[0] = MAC_ADDR_CLI0;
+#if NUM_NETWORK_CLIENTS > 1
+        macs[1] = MAC_ADDR_CLI1;
+#endif /* NUM_NETWORK_CLIENTS > 1 */
     }
 }
 
-static inline void net_cli_queue_init_sys(char *pd_name, net_queue_handle_t *rx_queue, net_queue_t *rx_free,
-                                          net_queue_t *rx_active, net_queue_handle_t *tx_queue, net_queue_t *tx_free,
-                                          net_queue_t *tx_active)
+static inline void net_cli_queue_size(char *pd_name, size_t *rx_queue_size, size_t *tx_queue_size)
 {
     if (!sddf_strcmp(pd_name, NET_CLI0_NAME)) {
-        net_queue_init(rx_queue, rx_free, rx_active, NET_RX_QUEUE_SIZE_CLI0);
-        net_queue_init(tx_queue, tx_free, tx_active, NET_TX_QUEUE_SIZE_CLI0);
+        *rx_queue_size = NET_RX_QUEUE_SIZE_CLI0;
+        *tx_queue_size = NET_TX_QUEUE_SIZE_CLI0;
+#if NUM_NETWORK_CLIENTS > 1
     } else if (!sddf_strcmp(pd_name, NET_CLI1_NAME)) {
-        net_queue_init(rx_queue, rx_free, rx_active, NET_RX_QUEUE_SIZE_CLI1);
-        net_queue_init(tx_queue, tx_free, tx_active, NET_TX_QUEUE_SIZE_CLI1);
+        *rx_queue_size = NET_RX_QUEUE_SIZE_CLI1;
+        *tx_queue_size = NET_TX_QUEUE_SIZE_CLI1;
+#endif /* NUM_NETWORK_CLIENTS > 1 */
     }
 }
 
-static inline void net_copy_queue_init_sys(char *pd_name, net_queue_handle_t *cli_queue, net_queue_t *cli_free,
-                                           net_queue_t *cli_active, net_queue_handle_t *virt_queue, net_queue_t *virt_free,
-                                           net_queue_t *virt_active)
+static inline void net_copy_queue_size(char *pd_name, size_t *cli_queue_size, size_t *virt_queue_size)
 {
     if (!sddf_strcmp(pd_name, NET_COPY0_NAME)) {
-        net_queue_init(cli_queue, cli_free, cli_active, NET_RX_QUEUE_SIZE_CLI0);
-        net_queue_init(virt_queue, virt_free, virt_active, NET_RX_QUEUE_SIZE_COPY0);
+        *cli_queue_size = NET_RX_QUEUE_SIZE_CLI0;
+        *virt_queue_size = NET_RX_QUEUE_SIZE_COPY0;
+#if NUM_NETWORK_CLIENTS > 1
     } else if (!sddf_strcmp(pd_name, NET_COPY1_NAME)) {
-        net_queue_init(cli_queue, cli_free, cli_active, NET_RX_QUEUE_SIZE_CLI1);
-        net_queue_init(virt_queue, virt_free, virt_active, NET_RX_QUEUE_SIZE_COPY1);
+        *cli_queue_size = NET_RX_QUEUE_SIZE_CLI1;
+        *virt_queue_size = NET_RX_QUEUE_SIZE_COPY1;
+#endif /* NUM_NETWORK_CLIENTS > 1 */
     }
 }
 
-static inline void net_virt_queue_init_sys(char *pd_name, net_queue_handle_t *cli_queue, net_queue_t *cli_free,
-                                           net_queue_t *cli_active)
+typedef struct queue_info {
+    net_queue_t *free;
+    net_queue_t *active;
+    size_t size;
+} queue_info_t;
+
+static inline void net_virt_queue_info(char *pd_name, net_queue_t *cli0_free, net_queue_t *cli0_active,
+                                       queue_info_t ret[NUM_NETWORK_CLIENTS])
 {
     if (!sddf_strcmp(pd_name, NET_VIRT_RX_NAME)) {
-        net_queue_init(cli_queue, cli_free, cli_active, NET_RX_QUEUE_SIZE_COPY0);
-        net_queue_init(&cli_queue[1], (net_queue_t *)((uintptr_t)cli_free + 2 * NET_DATA_REGION_SIZE),
-                       (net_queue_t *)((uintptr_t)cli_active + 2 * NET_DATA_REGION_SIZE), NET_RX_QUEUE_SIZE_COPY1);
+        ret[0] = (queue_info_t) {
+            .free = cli0_free, .active = cli0_active, .size = NET_RX_QUEUE_SIZE_COPY0
+        };
+#if NUM_NETWORK_CLIENTS > 1
+        ret[1] = (queue_info_t) {
+            .free = (net_queue_t *)((uintptr_t)cli0_free + 2 * NET_DATA_REGION_SIZE),
+            .active = (net_queue_t *)((uintptr_t)cli0_active + 2 * NET_DATA_REGION_SIZE),
+            .size = NET_RX_QUEUE_SIZE_COPY1
+        };
+#endif /* NUM_NETWORK_CLIENTS > 1 */
     } else if (!sddf_strcmp(pd_name, NET_VIRT_TX_NAME)) {
-        net_queue_init(cli_queue, cli_free, cli_active, NET_TX_QUEUE_SIZE_CLI0);
-        net_queue_init(&cli_queue[1], (net_queue_t *)((uintptr_t)cli_free + 2 * NET_DATA_REGION_SIZE),
-                       (net_queue_t *)((uintptr_t)cli_active + 2 * NET_DATA_REGION_SIZE), NET_TX_QUEUE_SIZE_CLI1);
+        ret[0] = (queue_info_t) {
+            .free = cli0_free, .active = cli0_active, .size = NET_TX_QUEUE_SIZE_CLI0
+        };
+#if NUM_NETWORK_CLIENTS > 1
+        ret[1] = (queue_info_t) {
+            .free = (net_queue_t *)((uintptr_t)cli0_free + 2 * NET_DATA_REGION_SIZE),
+            .active = (net_queue_t *)((uintptr_t)cli0_active + 2 * NET_DATA_REGION_SIZE),
+            .size = NET_TX_QUEUE_SIZE_CLI1
+        };
+#endif /* NUM_NETWORK_CLIENTS > 1 */
     }
 }
 
-static inline void net_mem_region_init_sys(char *pd_name, uintptr_t *mem_regions, uintptr_t start_region)
+static inline void net_mem_region_vaddr(char *pd_name, uintptr_t mem_regions[NUM_NETWORK_CLIENTS],
+                                        uintptr_t start_region)
 {
     if (!sddf_strcmp(pd_name, NET_VIRT_TX_NAME)) {
         mem_regions[0] = start_region;
+#if NUM_NETWORK_CLIENTS > 1
         mem_regions[1] = start_region + NET_DATA_REGION_SIZE;
+#endif /* NUM_NETWORK_CLIENTS > 1 */
     }
 }

--- a/examples/echo_server/include/ethernet_config/ethernet_config.h
+++ b/examples/echo_server/include/ethernet_config/ethernet_config.h
@@ -87,10 +87,8 @@ static inline uint64_t net_cli_mac_addr(char *pd_name)
 {
     if (!sddf_strcmp(pd_name, NET_CLI0_NAME)) {
         return MAC_ADDR_CLI0;
-#if NUM_NETWORK_CLIENTS > 1
     } else if (!sddf_strcmp(pd_name, NET_CLI1_NAME)) {
         return MAC_ADDR_CLI1;
-#endif /* NUM_NETWORK_CLIENTS > 1 */
     }
 }
 
@@ -98,9 +96,7 @@ static inline void net_virt_mac_addrs(char *pd_name, uint64_t macs[NUM_NETWORK_C
 {
     if (!sddf_strcmp(pd_name, NET_VIRT_RX_NAME)) {
         macs[0] = MAC_ADDR_CLI0;
-#if NUM_NETWORK_CLIENTS > 1
         macs[1] = MAC_ADDR_CLI1;
-#endif /* NUM_NETWORK_CLIENTS > 1 */
     }
 }
 
@@ -109,11 +105,9 @@ static inline void net_cli_queue_size(char *pd_name, size_t *rx_queue_size, size
     if (!sddf_strcmp(pd_name, NET_CLI0_NAME)) {
         *rx_queue_size = NET_RX_QUEUE_SIZE_CLI0;
         *tx_queue_size = NET_TX_QUEUE_SIZE_CLI0;
-#if NUM_NETWORK_CLIENTS > 1
     } else if (!sddf_strcmp(pd_name, NET_CLI1_NAME)) {
         *rx_queue_size = NET_RX_QUEUE_SIZE_CLI1;
         *tx_queue_size = NET_TX_QUEUE_SIZE_CLI1;
-#endif /* NUM_NETWORK_CLIENTS > 1 */
     }
 }
 
@@ -122,11 +116,9 @@ static inline void net_copy_queue_size(char *pd_name, size_t *cli_queue_size, si
     if (!sddf_strcmp(pd_name, NET_COPY0_NAME)) {
         *cli_queue_size = NET_RX_QUEUE_SIZE_CLI0;
         *virt_queue_size = NET_RX_QUEUE_SIZE_COPY0;
-#if NUM_NETWORK_CLIENTS > 1
     } else if (!sddf_strcmp(pd_name, NET_COPY1_NAME)) {
         *cli_queue_size = NET_RX_QUEUE_SIZE_CLI1;
         *virt_queue_size = NET_RX_QUEUE_SIZE_COPY1;
-#endif /* NUM_NETWORK_CLIENTS > 1 */
     }
 }
 
@@ -143,24 +135,20 @@ static inline void net_virt_queue_info(char *pd_name, net_queue_t *cli0_free, ne
         ret[0] = (queue_info_t) {
             .free = cli0_free, .active = cli0_active, .size = NET_RX_QUEUE_SIZE_COPY0
         };
-#if NUM_NETWORK_CLIENTS > 1
         ret[1] = (queue_info_t) {
             .free = (net_queue_t *)((uintptr_t)cli0_free + 2 * NET_DATA_REGION_SIZE),
             .active = (net_queue_t *)((uintptr_t)cli0_active + 2 * NET_DATA_REGION_SIZE),
             .size = NET_RX_QUEUE_SIZE_COPY1
         };
-#endif /* NUM_NETWORK_CLIENTS > 1 */
     } else if (!sddf_strcmp(pd_name, NET_VIRT_TX_NAME)) {
         ret[0] = (queue_info_t) {
             .free = cli0_free, .active = cli0_active, .size = NET_TX_QUEUE_SIZE_CLI0
         };
-#if NUM_NETWORK_CLIENTS > 1
         ret[1] = (queue_info_t) {
             .free = (net_queue_t *)((uintptr_t)cli0_free + 2 * NET_DATA_REGION_SIZE),
             .active = (net_queue_t *)((uintptr_t)cli0_active + 2 * NET_DATA_REGION_SIZE),
             .size = NET_TX_QUEUE_SIZE_CLI1
         };
-#endif /* NUM_NETWORK_CLIENTS > 1 */
     }
 }
 
@@ -169,8 +157,6 @@ static inline void net_mem_region_vaddr(char *pd_name, uintptr_t mem_regions[NUM
 {
     if (!sddf_strcmp(pd_name, NET_VIRT_TX_NAME)) {
         mem_regions[0] = start_region;
-#if NUM_NETWORK_CLIENTS > 1
         mem_regions[1] = start_region + NET_DATA_REGION_SIZE;
-#endif /* NUM_NETWORK_CLIENTS > 1 */
     }
 }

--- a/examples/echo_server/lwip.c
+++ b/examples/echo_server/lwip.c
@@ -301,7 +301,7 @@ void init(void)
     LWIP_MEMPOOL_INIT(RX_POOL);
 
     uint64_t mac_addr = net_cli_mac_addr(microkit_name);
-    __net_set_mac_addr(state.mac, mac_addr);
+    net_set_mac_addr(state.mac, mac_addr);
 
     /* Set dummy IP configuration values to get lwIP bootstrapped  */
     struct ip4_addr netmask, ipaddr, gw, multicast;

--- a/examples/echo_server/lwip.c
+++ b/examples/echo_server/lwip.c
@@ -9,6 +9,7 @@
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
 #include <sddf/network/queue.h>
+#include <sddf/network/util.h>
 #include <sddf/serial/queue.h>
 #include <sddf/timer/client.h>
 #include <sddf/benchmark/sel4bench.h>
@@ -288,7 +289,10 @@ void init(void)
     serial_cli_queue_init_sys(microkit_name, NULL, NULL, NULL, &serial_tx_queue_handle, serial_tx_queue, serial_tx_data);
     serial_putchar_init(SERIAL_TX_CH, &serial_tx_queue_handle);
 
-    net_cli_queue_init_sys(microkit_name, &state.rx_queue, rx_free, rx_active, &state.tx_queue, tx_free, tx_active);
+    size_t rx_size, tx_size;
+    net_cli_queue_size(microkit_name, &rx_size, &tx_size);
+    net_queue_init(&state.rx_queue, rx_free, rx_active, rx_size);
+    net_queue_init(&state.tx_queue, tx_free, tx_active, tx_size);
     net_buffers_init(&state.tx_queue, 0);
 
     lwip_init();
@@ -296,7 +300,8 @@ void init(void)
 
     LWIP_MEMPOOL_INIT(RX_POOL);
 
-    net_cli_mac_addr_init_sys(microkit_name, state.mac);
+    uint64_t mac_addr = net_cli_mac_addr(microkit_name);
+    __net_set_mac_addr(state.mac, mac_addr);
 
     /* Set dummy IP configuration values to get lwIP bootstrapped  */
     struct ip4_addr netmask, ipaddr, gw, multicast;

--- a/include/sddf/network/util.h
+++ b/include/sddf/network/util.h
@@ -12,3 +12,13 @@
 #else
 #define HTONS(x) ((uint16_t)((((x) & (uint16_t)0x00ffU) << 8) | (((x) & (uint16_t)0xff00U) >> 8)))
 #endif
+
+static void __net_set_mac_addr(uint8_t *mac, uint64_t val)
+{
+    mac[0] = val >> 40 & 0xff;
+    mac[1] = val >> 32 & 0xff;
+    mac[2] = val >> 24 & 0xff;
+    mac[3] = val >> 16 & 0xff;
+    mac[4] = val >> 8 & 0xff;
+    mac[5] = val & 0xff;
+}

--- a/include/sddf/network/util.h
+++ b/include/sddf/network/util.h
@@ -13,7 +13,7 @@
 #define HTONS(x) ((uint16_t)((((x) & (uint16_t)0x00ffU) << 8) | (((x) & (uint16_t)0xff00U) >> 8)))
 #endif
 
-static void __net_set_mac_addr(uint8_t *mac, uint64_t val)
+static void net_set_mac_addr(uint8_t *mac, uint64_t val)
 {
     mac[0] = val >> 40 & 0xff;
     mac[1] = val >> 32 & 0xff;

--- a/network/components/copy.c
+++ b/network/components/copy.c
@@ -97,7 +97,12 @@ void notified(microkit_channel ch)
 
 void init(void)
 {
-    net_copy_queue_init_sys(microkit_name, &rx_queue_cli, rx_free_cli, rx_active_cli, &rx_queue_virt, rx_free_virt,
-                            rx_active_virt);
+    size_t cli_queue_size, virt_queue_size = 0;
+    net_copy_queue_size(microkit_name, &cli_queue_size, &virt_queue_size);
+
+    /* Set up the queues */
+    net_queue_init(&rx_queue_cli, rx_free_cli, rx_active_cli, cli_queue_size);
+    net_queue_init(&rx_queue_virt, rx_free_virt, rx_active_virt, virt_queue_size);
+
     net_buffers_init(&rx_queue_cli, 0);
 }

--- a/network/components/virt_rx.c
+++ b/network/components/virt_rx.c
@@ -211,7 +211,7 @@ void init(void)
 
     /* Set up client queues */
     for (int i = 0; i < NUM_NETWORK_CLIENTS; i++) {
-        __net_set_mac_addr((uint8_t *) &state.mac_addrs[i], macs[i]);
+        net_set_mac_addr((uint8_t *) &state.mac_addrs[i], macs[i]);
         net_queue_init(&state.rx_queue_clients[i], queue_info[i].free, queue_info[i].active,
                        queue_info[i].size);
     }

--- a/network/components/virt_rx.c
+++ b/network/components/virt_rx.c
@@ -204,7 +204,7 @@ void notified(microkit_channel ch)
 void init(void)
 {
     uint64_t macs[NUM_NETWORK_CLIENTS] = {0};
-    queue_info_t queue_info[NUM_NETWORK_CLIENTS] = {0};
+    net_queue_info_t queue_info[NUM_NETWORK_CLIENTS] = {0};
 
     net_virt_mac_addrs(microkit_name, macs);
     net_virt_queue_info(microkit_name, rx_free_cli0, rx_active_cli0, queue_info);

--- a/network/components/virt_tx.c
+++ b/network/components/virt_tx.c
@@ -135,7 +135,7 @@ void init(void)
     net_queue_init(&state.tx_queue_drv, tx_free_drv, tx_active_drv, NET_TX_QUEUE_SIZE_DRIV);
 
     /* Setup client queues and state */
-    queue_info_t queue_info[NUM_NETWORK_CLIENTS] = {0};
+    net_queue_info_t queue_info[NUM_NETWORK_CLIENTS] = {0};
     uintptr_t client_vaddrs[NUM_NETWORK_CLIENTS] = {0};
     net_virt_queue_info(microkit_name, tx_free_cli0, tx_active_cli0, queue_info);
     net_mem_region_vaddr(microkit_name, client_vaddrs, buffer_data_region_cli0_vaddr);
@@ -146,11 +146,10 @@ void init(void)
         state.buffer_region_vaddrs[i] = client_vaddrs[i];
     }
 
-    /* CDTODO: Can we make this system agnostic? */
     state.buffer_region_paddrs[0] = buffer_data_region_cli0_paddr;
-#ifdef NUM_NETWORK_CLIENTS > 1
+#if NUM_NETWORK_CLIENTS > 1
     state.buffer_region_paddrs[1] = buffer_data_region_cli1_paddr;
-#endif /* NUM_NETWORK_CLIENTS > 1 */
+#endif
 
     tx_provide();
 }

--- a/network/components/virt_tx.c
+++ b/network/components/virt_tx.c
@@ -131,14 +131,26 @@ void notified(microkit_channel ch)
 
 void init(void)
 {
+    /* Set up driver queues */
     net_queue_init(&state.tx_queue_drv, tx_free_drv, tx_active_drv, NET_TX_QUEUE_SIZE_DRIV);
-    net_virt_queue_init_sys(microkit_name, state.tx_queue_clients, tx_free_cli0, tx_active_cli0);
 
-    net_mem_region_init_sys(microkit_name, state.buffer_region_vaddrs, buffer_data_region_cli0_vaddr);
+    /* Setup client queues and state */
+    queue_info_t queue_info[NUM_NETWORK_CLIENTS] = {0};
+    uintptr_t client_vaddrs[NUM_NETWORK_CLIENTS] = {0};
+    net_virt_queue_info(microkit_name, tx_free_cli0, tx_active_cli0, queue_info);
+    net_mem_region_vaddr(microkit_name, client_vaddrs, buffer_data_region_cli0_vaddr);
+
+    for (int i = 0; i < NUM_NETWORK_CLIENTS; i++) {
+        net_queue_init(&state.tx_queue_clients[i], queue_info[i].free, queue_info[i].active,
+                       queue_info[i].size);
+        state.buffer_region_vaddrs[i] = client_vaddrs[i];
+    }
 
     /* CDTODO: Can we make this system agnostic? */
     state.buffer_region_paddrs[0] = buffer_data_region_cli0_paddr;
+#ifdef NUM_NETWORK_CLIENTS > 1
     state.buffer_region_paddrs[1] = buffer_data_region_cli1_paddr;
+#endif /* NUM_NETWORK_CLIENTS > 1 */
 
     tx_provide();
 }


### PR DESCRIPTION
The ethernet_config file currently initializes queues and data structures for the different components. This patch shifts more of the initialization into the components and leaves the bare minimum inside the config file.

The primary motivation behind this for making the sDDF microkit-independent in the future. When this occurs, the assumptions that the sDDF implementation in microkit holds about the relative position of certain buffers and things like this may no longer hold. Changing the implementation to something like this allows us to seperate queue configuration from queue initialization, so that the same initialization code (in the components) can be used by different OS environments, even if parameters about the queues are from different places.