### PR TITLE
blk: Make the i.MX8 mmc driver more robust to errors

### DIFF
--- a/drivers/blk/mmc/imx/README.md
+++ b/drivers/blk/mmc/imx/README.md
@@ -24,10 +24,10 @@ This is a driver for the MaaXBoard SD host controller, based on the following do
 ## Not Implemented
 - Voltage Negotiation (anything but 3.3V)
 - Version 1 SD cards (the initialisation flow)
-- Version 2 SDSC / SDXC cards (only because I haven't implemented support for calculating card capacity)
+- Version 2 SDSC / SDXC cards (card capacity calculation)
 - Higher speed operation (even Default Speed / 25 MHz ($f_{PP}$)) and DDR
 - Setting as RO when write protect is set on the SD card
 - Clock setup (currently inherits 150MHz clock from U-Boot)
 - Pinmux setup (again, inherits from U-Boot)
-- Timeouts as required by various commands & a lot of error cases
-- Card detect on the MaaXboard doesn't seem to work (even in U-Boot/Linux)
+- Timeouts as required by some SD commands
+- Card detection

--- a/examples/mmc/mmc.mk
+++ b/examples/mmc/mmc.mk
@@ -49,6 +49,7 @@ CFLAGS := -mcpu=$(CPU) \
 		  -ffreestanding \
 		  -g3 \
 		  -O3 \
+		  -MD \
 		  -Wall -Wno-unused-function -Werror -Wno-unused-command-line-argument \
 		  -I$(BOARD_DIR)/include \
 		  -I$(SDDF)/include \

--- a/include/sddf/blk/queue.h
+++ b/include/sddf/blk/queue.h
@@ -49,6 +49,8 @@ typedef enum blk_resp_status {
     BLK_RESP_ERR_UNSPEC,
     /* invalid request parameters */
     BLK_RESP_ERR_INVALID_PARAM,
+    /* the device is not inserted */
+    BLK_RESP_ERR_NO_DEVICE,
 } blk_resp_status_t;
 
 /* Request struct contained in request queue */
@@ -355,4 +357,3 @@ static inline bool blk_queue_plugged_req(blk_queue_handle_t *h)
 {
     return h->req_queue->plugged;
 }
-


### PR DESCRIPTION
*  The in-tree code relied on a lot of assertions and would crash in
   the presence of any sort of errors, e.g. card removal.

*  This new implementation handles command errors uniformly in a new
   `handle_interrupt_status()` function, and returns varying error types
   up the call stack and to the block queues.

Further/more detailed changes are:

*  The INT_STATUS register is now only read once on an interrupt, to
   prevent subtle race conditions.

*  Soft failures from:
   -  Card not expecting an APP_CMD following CMD55
   -  Incompatible voltage ranges, or unsupported card types
   -  Incorrect card check commands from CMD8

*  sDDF Block queues are only ever initialised once

*  Indefinite busy-wait loops on Command Inhibit fields are replaced
   with an error return, as they never happen in usual operation.
   Similarly, busy wait on DAT[0] following R1b commands are handled
   by the IP, so it never happens.

*  On failed initialisation, reset (most) of the driver state, so we can
   try again in future. This is prep work for hotplugging support.

*  Add a stub `card_detected()` function which currently always returns
   `true`, but if implemented will correctly send "Gone" errors responses.

*  Add BLK_RESP_DEV_GONE error to the block queue
   This handles the case where the block device has been unplugged
   or is otherwise unavailable.

*  Add -MD to the example CFLAGS to track header-file dependencies

Split out the error-handling code from #180 to make my life easier.