### PR TITLE
#176 (I2C) Remove redundant data tokens from transport layer

### DIFF
--- a/drivers/i2c/meson/driver.h
+++ b/drivers/i2c/meson/driver.h
@@ -26,9 +26,7 @@ enum data_direction {
 
 // Driver state
 typedef struct _i2c_ifState {
-    /* Pointer to current request/response data being handled */
-    /* Due to the way the token chain abstraction is done in the request buffer
-     * there will always be at least 1 more byte of request data then response data. */
+    /* Pointer to current request/response being handled */
     uint8_t *curr_data;
     /* Number of bytes in current request (number of tokens) */
     int curr_request_len;
@@ -38,6 +36,10 @@ typedef struct _i2c_ifState {
     size_t remaining;
     /* Flag indicating that there is more independent requests waiting on the queue_handle.request. */
     bool notified;
+
+    /* Number of bytes to read/write if request data offset is in the midst of a buffer. If this is
+       zero, no read/write is in progress and we can interpret the current byte as a token.*/
+    uint8_t rw_remaining;
 
     enum data_direction data_direction;
     /* I2C bus address of the current request being handled */

--- a/i2c/devices/ds3231/ds3231.c
+++ b/i2c/devices/ds3231/ds3231.c
@@ -148,9 +148,9 @@ bool ds3231_write(uint8_t *buffer, uint8_t buffer_len, size_t retries)
         request_init(&req, DS3231_I2C_BUS_ADDRESS);
         request_add(&req, I2C_TOKEN_START);
         request_add(&req, I2C_TOKEN_ADDR_WRITE);
+        request_add(&req, buffer_len); // Add buffer size
 
         for (int i = 0; i < buffer_len; i++) {
-            request_add(&req, I2C_TOKEN_DATA);
             request_add(&req, buffer[i]);
         }
 
@@ -186,12 +186,11 @@ bool ds3231_read(uint8_t *buffer, uint8_t buffer_len, size_t retries)
 
         request_add(&req, I2C_TOKEN_START);
         request_add(&req, I2C_TOKEN_ADDR_READ);
+        request_add(&req, buffer_len);      // Add read length
 
         for (int i = 0; i < buffer_len - 1; i++) {
-            request_add(&req, I2C_TOKEN_DATA);
-        }
-
-        request_add(&req, I2C_TOKEN_DATA_END);
+            request_add(&req, 0x0);             // Temporary - will be changed as part of
+        }                                       // issue 211 https://github.com/au-ts/sddf/issues/211
 
         request_add(&req, I2C_TOKEN_STOP);
 

--- a/include/sddf/i2c/devices/pn532/pn532.h
+++ b/include/sddf/i2c/devices/pn532/pn532.h
@@ -15,6 +15,9 @@
 #define PN532_STARTCODE1              (0x00)
 #define PN532_STARTCODE2              (0xFF)
 #define PN532_POSTAMBLE               (0x00)
+#define PN532_PREAMBLE_LEN            (3)
+#define PN532_DATA_CHK_LEN            (2)
+#define PN532_POSTAMBLE_LEN           (1)
 
 #define PN532_HOSTTOPN532             (0xD4)
 #define PN532_PN532TOHOST             (0xD5)

--- a/include/sddf/i2c/queue.h
+++ b/include/sddf/i2c/queue.h
@@ -42,19 +42,16 @@ enum i2c_token {
     /* START: Begin a transfer. Causes master device to capture bus. */
     I2C_TOKEN_START = 0x1,
     /* ADDRESS WRITE: Used to wake up the target device on the bus.
-     * Sets up and following DATA tokens to be writes. */
+     * The byte immediately following this token is an integer (N) length of the succeeding
+       write. Max 256 (1**8). The next N bytes are the payload. */
     I2C_TOKEN_ADDR_WRITE = 0x2,
-    /* ADDRESS READ: Same as ADDRW but sets up DATA tokens as reads. */
+    /* ADDRESS READ: Same as ADDRW but sets up DATA tokens as reads.
+       FIXME: N bytes must be padded after read to suit current transport layer. This should
+              be replaced, ideally by using a separate shared buffer for return data*/
     I2C_TOKEN_ADDR_READ = 0x3,
-    /* DATA_END: Used for read transactions to write a NACK to alert
-     * the slave device that the read is now over.
-     * this also acts the same way as I2C_TOKEN_DATA (ie it actually requests a token to read so should be treated the same in that regard) */
-    I2C_TOKEN_DATA_END = 0x4,
     /* STOP: Used to send the STOP condition on the bus to end a transaction.
      * Causes master to release the bus. */
-    I2C_TOKEN_STOP = 0x5,
-    /* Read or write one byte - the byte after this is treated as payload. */
-    I2C_TOKEN_DATA = 0x6,
+    I2C_TOKEN_STOP = 0x4,
 };
 
 typedef struct i2c_queue_entry {


### PR DESCRIPTION
This pull request fixes a significant inefficiency in the transport layer - previously, data was transferred by having every write arranged as follows
```
|WRITE|DATA|[data]|DATA|[data] ... | DATA|
```
... where each DATA was an identical token indicating that the byte after this is to be treated as a payload to read or write. 

This is more severe in the case of a read, where it would be:
```
|READ|DATA|DATA|DATA|DATA|DATA|DATA|DATA| ..... DATA_END|
```

This has been refactored to remove this redundancy minimally while retaining the same transport layer semantics - i.e. a buffer is shared for the request and the return data. We now transmit a READ or WRITE followed by a buffer size N between 0 and 255. The following N bytes are treated as payloads. This halves the amount of space required for write operations.

```
|WRITE|SIZE|DATA0| ... |DATA(n-1)|
|READ|SIZE|(N empty bytes)|
```

 This still means that reads must be padded with empty bytes however, since the buffer that supplies instructions is also used to return data. This works by having the READ share the same semantics as write, but the N bytes after are simply ignored and can be arbitrary. There is still a performance benefit however, since we can simply skip these dead bytes when loading and unloading and this only means we waste some space in our block of allocated memory.
 
 The transport layer can be further improved by decoupling the transmit and return path. A separate shared buffer for return data will enable a minimally-sized buffer to be allocated on request. This can be a discussion for later however :)
 