### PR TITLE
Fix for array out of bound in init() in virt_tx.c when there is only one client

### DIFF
--- a/network/components/virt_tx.c
+++ b/network/components/virt_tx.c
@@ -137,7 +137,7 @@ void init(void)
     net_mem_region_init_sys(microkit_name, state.buffer_region_vaddrs, buffer_data_region_cli0_vaddr);
 
     /* CDTODO: Can we make this system agnostic? */
-    uintptr_t* data_region_paddr[] = {
+    uintptr_t *data_region_paddr[] = {
         &buffer_data_region_cli0_paddr,
         &buffer_data_region_cli1_paddr
     };

--- a/network/components/virt_tx.c
+++ b/network/components/virt_tx.c
@@ -137,8 +137,14 @@ void init(void)
     net_mem_region_init_sys(microkit_name, state.buffer_region_vaddrs, buffer_data_region_cli0_vaddr);
 
     /* CDTODO: Can we make this system agnostic? */
-    state.buffer_region_paddrs[0] = buffer_data_region_cli0_paddr;
-    state.buffer_region_paddrs[1] = buffer_data_region_cli1_paddr;
+    uintptr_t* data_region_paddr[] = {
+        &buffer_data_region_cli0_paddr,
+        &buffer_data_region_cli1_paddr
+    };
+    // Apparently, NUM_NETWORK_CLIENTS must be smaller or equal to 2
+    for (int i = 0; i < NUM_NETWORK_CLIENTS; i++) {
+        state.buffer_region_paddrs[i] = *(data_region_paddr[i]);
+    }
 
     tx_provide();
 }


### PR DESCRIPTION
This PR introduces a small refactor to the initialization of the state.buffer_region_paddrs array. The previous init code assumes there are always two clients. This is needed because my example's eth_virt_tx only has one client.

Changes:
Replaced the hardcoded initialization with a dynamic approach that uses an array of pointers to initialize state.buffer_region_paddrs.
The initialization loop now iterates based on NUM_NETWORK_CLIENTS, ensuring that the code adapts to varying numbers of clients.