### PR TITLE
Add new error codes to sddf block

### DIFF
--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -324,14 +324,14 @@ static void handle_client(int cli_id)
             // Check if client request offset is within its allocated bounds and is aligned to transfer size
             if (cli_offset % BLK_TRANSFER_SIZE != 0 || (cli_offset + BLK_TRANSFER_SIZE * cli_count) > cli_data_region_size) {
                 LOG_BLK_VIRT_ERR("client %d request offset 0x%lx is invalid\n", cli_id, cli_offset);
-                err = blk_enqueue_resp(&h, BLK_RESP_ERR_SEEK, 0, cli_req_id);
+                err = blk_enqueue_resp(&h, BLK_RESP_ERR_INVALID_PARAM, 0, cli_req_id);
                 assert(!err);
                 continue;
             }
 
             if (cli_count == 0) {
                 LOG_BLK_VIRT_ERR("client %d requested zero blocks\n", cli_id);
-                err = blk_enqueue_resp(&h, BLK_RESP_ERR_SEEK, 0, cli_req_id);
+                err = blk_enqueue_resp(&h, BLK_RESP_ERR_INVALID_PARAM, 0, cli_req_id);
                 assert(!err);
                 continue;
             }

--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -331,7 +331,7 @@ static void handle_client(int cli_id)
 
             if (cli_count == 0) {
                 LOG_BLK_VIRT_ERR("client %d requested zero blocks\n", cli_id);
-                err = blk_enqueue_resp(&h, BLK_RESP_SEEK_ERROR, 0, cli_req_id);
+                err = blk_enqueue_resp(&h, BLK_RESP_ERR_SEEK, 0, cli_req_id);
                 assert(!err);
                 continue;
             }

--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -316,7 +316,7 @@ static void handle_client(int cli_id)
             unsigned long client_start_sector = clients[cli_id].start_sector / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE);
             if (drv_block_number < client_start_sector || drv_block_number + cli_count > client_start_sector + client_sectors) {
                 LOG_BLK_VIRT_ERR("client %d request for block %d is out of bounds\n", cli_id, cli_block_number);
-                err = blk_enqueue_resp(&h, BLK_RESP_ERR_SEEK, 0, cli_req_id);
+                err = blk_enqueue_resp(&h, BLK_RESP_ERR_INVALID_PARAM, 0, cli_req_id);
                 assert(!err);
                 continue;
             }

--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -316,7 +316,7 @@ static void handle_client(int cli_id)
             unsigned long client_start_sector = clients[cli_id].start_sector / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE);
             if (drv_block_number < client_start_sector || drv_block_number + cli_count > client_start_sector + client_sectors) {
                 LOG_BLK_VIRT_ERR("client %d request for block %d is out of bounds\n", cli_id, cli_block_number);
-                err = blk_enqueue_resp(&h, BLK_RESP_SEEK_ERROR, 0, cli_req_id);
+                err = blk_enqueue_resp(&h, BLK_RESP_ERR_SEEK, 0, cli_req_id);
                 assert(!err);
                 continue;
             }
@@ -324,7 +324,7 @@ static void handle_client(int cli_id)
             // Check if client request offset is within its allocated bounds and is aligned to transfer size
             if (cli_offset % BLK_TRANSFER_SIZE != 0 || (cli_offset + BLK_TRANSFER_SIZE * cli_count) > cli_data_region_size) {
                 LOG_BLK_VIRT_ERR("client %d request offset 0x%lx is invalid\n", cli_id, cli_offset);
-                err = blk_enqueue_resp(&h, BLK_RESP_SEEK_ERROR, 0, cli_req_id);
+                err = blk_enqueue_resp(&h, BLK_RESP_ERR_SEEK, 0, cli_req_id);
                 assert(!err);
                 continue;
             }

--- a/drivers/blk/virtio/block.c
+++ b/drivers/blk/virtio/block.c
@@ -113,7 +113,7 @@ void handle_response()
         if (hdr->status == VIRTIO_BLK_S_OK) {
             status = BLK_RESP_OK;
         } else {
-            status = BLK_RESP_ERR_SEEK;
+            status = BLK_RESP_ERR_UNSPEC;
         }
         int err = blk_enqueue_resp(&blk_queue, status, data_len / BLK_TRANSFER_SIZE, virtio_header_to_id[hdr_used.id]);
         assert(!err);

--- a/drivers/blk/virtio/block.c
+++ b/drivers/blk/virtio/block.c
@@ -113,7 +113,7 @@ void handle_response()
         if (hdr->status == VIRTIO_BLK_S_OK) {
             status = BLK_RESP_OK;
         } else {
-            status = BLK_RESP_SEEK_ERROR;
+            status = BLK_RESP_ERR_SEEK;
         }
         int err = blk_enqueue_resp(&blk_queue, status, data_len / BLK_TRANSFER_SIZE, virtio_header_to_id[hdr_used.id]);
         assert(!err);

--- a/include/sddf/blk/queue.h
+++ b/include/sddf/blk/queue.h
@@ -47,7 +47,6 @@ typedef enum blk_resp_status {
     BLK_RESP_ERR_UNSPEC,        /* unspecified miscellaneous errors */
     BLK_RESP_ERR_INVALID_PARAM, /* invalid request parameters */
     BLK_RESP_ERR_SEEK,          /* seek error */
-    BLK_RESP_ERR_NO_DEVICE,     /* device is unplugged */
 } blk_resp_status_t;
 
 /* Request struct contained in request queue */

--- a/include/sddf/blk/queue.h
+++ b/include/sddf/blk/queue.h
@@ -43,8 +43,11 @@ typedef enum blk_req_code {
 
 /* Response status for block */
 typedef enum blk_resp_status {
-    BLK_RESP_OK,
-    BLK_RESP_SEEK_ERROR,
+    BLK_RESP_OK,                /* success status */
+    BLK_RESP_ERR_UNSPEC,        /* unspecified miscellaneous errors */
+    BLK_RESP_ERR_INVALID_PARAM, /* invalid request parameters */
+    BLK_RESP_ERR_SEEK,          /* seek error */
+    BLK_RESP_ERR_NO_DEVICE,     /* device is unplugged */
 } blk_resp_status_t;
 
 /* Request struct contained in request queue */

--- a/include/sddf/blk/queue.h
+++ b/include/sddf/blk/queue.h
@@ -49,8 +49,6 @@ typedef enum blk_resp_status {
     BLK_RESP_ERR_UNSPEC,
     /* invalid request parameters */
     BLK_RESP_ERR_INVALID_PARAM,
-    /* out of bounds block number access error */
-    BLK_RESP_ERR_SEEK,
 } blk_resp_status_t;
 
 /* Request struct contained in request queue */

--- a/include/sddf/blk/queue.h
+++ b/include/sddf/blk/queue.h
@@ -43,10 +43,14 @@ typedef enum blk_req_code {
 
 /* Response status for block */
 typedef enum blk_resp_status {
-    BLK_RESP_OK,                /* success status */
-    BLK_RESP_ERR_UNSPEC,        /* unspecified miscellaneous errors */
-    BLK_RESP_ERR_INVALID_PARAM, /* invalid request parameters */
-    BLK_RESP_ERR_SEEK,          /* seek error */
+    /* success status */
+    BLK_RESP_OK,
+    /* unspecified miscellaneous errors */
+    BLK_RESP_ERR_UNSPEC,
+    /* invalid request parameters */
+    BLK_RESP_ERR_INVALID_PARAM,
+    /* out of bounds block number access error */
+    BLK_RESP_ERR_SEEK,
 } blk_resp_status_t;
 
 /* Request struct contained in request queue */


### PR DESCRIPTION
- BLK_RESP_OK: When request succeeds
- BLK_RESP_ERR_UNSPEC: Miscelleanous errors
- BLK_RESP_ERR_INVALID_PARAM: Request gives invalid parameters, e.g. passing a physical address thats out of bounds
- BLK_RESP_ERR_SEEK: read/write request block number is invalid
- BLK_RESP_ERR_NO_DEVICE: can't handle request because the device is unplugged