### PR TITLE
Add explicit dependencies on libsddf_util_debug.a

### DIFF
--- a/drivers/serial/meson/uart_driver.mk
+++ b/drivers/serial/meson/uart_driver.mk
@@ -13,7 +13,7 @@
 
 UART_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-uart_driver.elf: serial/meson/uart_driver.o 
+uart_driver.elf: serial/meson/uart_driver.o libsddf_util_debug.a
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 serial/meson/uart_driver.o: ${UART_DRIVER_DIR}/uart.c |serial/meson

--- a/serial/components/serial_components.mk
+++ b/serial/components/serial_components.mk
@@ -21,7 +21,7 @@ ${CHECK_SERIAL_FLAGS_MD5}:
 	touch $@
 
 
-serial_virt_%.elf: virt_%.o
+serial_virt_%.elf: virt_%.o libsddf_util_debug.a
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 virt_tx.o virt_rx.o: ${CHECK_SERIAL_FLAGS_MD5}


### PR DESCRIPTION
We shouldn't be reliant on the parent Makefile to add libsddf_util_debug.a to LIBS, so for the components that need it make this an explicit input to the final link, and tell Make it's needed.