### PR TITLE
Various fixes to block subsystem

### DIFF
--- a/drivers/blk/virtio/block.c
+++ b/drivers/blk/virtio/block.c
@@ -48,7 +48,7 @@
 
 uintptr_t blk_regs;
 
-blk_storage_info_t *blk_config;
+blk_storage_info_t *blk_storage_info;
 uintptr_t blk_request;
 uintptr_t blk_response;
 
@@ -332,16 +332,16 @@ void virtio_blk_init(void)
     }
 
     /* This driver does not support Read-Only devices, so we always leave this as false */
-    blk_config->read_only = false;
-    blk_config->capacity = (virtio_config->capacity * VIRTIO_BLK_SECTOR_SIZE) / BLK_TRANSFER_SIZE;
-    blk_config->cylinders = virtio_config->geometry.cylinders;
-    blk_config->heads = virtio_config->geometry.heads;
-    blk_config->blocks = virtio_config->geometry.sectors;
-    blk_config->block_size = 1;
-    blk_config->sector_size = VIRTIO_BLK_SECTOR_SIZE;
+    blk_storage_info->read_only = false;
+    blk_storage_info->capacity = (virtio_config->capacity * VIRTIO_BLK_SECTOR_SIZE) / BLK_TRANSFER_SIZE;
+    blk_storage_info->cylinders = virtio_config->geometry.cylinders;
+    blk_storage_info->heads = virtio_config->geometry.heads;
+    blk_storage_info->blocks = virtio_config->geometry.sectors;
+    blk_storage_info->block_size = 1;
+    blk_storage_info->sector_size = VIRTIO_BLK_SECTOR_SIZE;
 
     /* Finished populating configuration */
-    __atomic_store_n(&blk_config->ready, true, __ATOMIC_RELEASE);
+    __atomic_store_n(&blk_storage_info->ready, true, __ATOMIC_RELEASE);
 
 #ifdef DEBUG_DRIVER
     uint32_t features_low = regs->DeviceFeatures;

--- a/examples/blk/blk_config.h
+++ b/examples/blk/blk_config.h
@@ -9,31 +9,24 @@
 #include <sddf/blk/storage_info.h>
 #include <sddf/util/string.h>
 
-#define BLK_NUM_CLIENTS 1
+#define BLK_NUM_CLIENTS                         1
 
-#define BLK_NAME_CLI0                      "client"
+#define BLK_NAME_CLI0                           "client"
 
-#define BLK_QUEUE_SIZE_CLI0                 1024
-#define BLK_QUEUE_SIZE_DRIV                 BLK_QUEUE_SIZE_CLI0
+#define BLK_QUEUE_CAPACITY_CLI0                 1024
+#define BLK_QUEUE_CAPACITY_DRIV                 BLK_QUEUE_CAPACITY_CLI0
 
-#define BLK_REGION_SIZE                     0x200000
-#define BLK_CONFIG_REGION_SIZE_CLI0         BLK_REGION_SIZE
+#define BLK_QUEUE_REGION_SIZE                   0x200000
+#define BLK_DATA_REGION_SIZE_CLI0               BLK_QUEUE_REGION_SIZE
+#define BLK_DATA_REGION_SIZE_DRIV               BLK_QUEUE_REGION_SIZE
 
-#define BLK_DATA_REGION_SIZE_CLI0           BLK_REGION_SIZE
-#define BLK_DATA_REGION_SIZE_DRIV           BLK_REGION_SIZE
-
-#define BLK_QUEUE_REGION_SIZE_CLI0          BLK_REGION_SIZE
-#define BLK_QUEUE_REGION_SIZE_DRIV          BLK_REGION_SIZE
-
-_Static_assert(BLK_DATA_REGION_SIZE_CLI0 >= BLK_TRANSFER_SIZE && BLK_DATA_REGION_SIZE_CLI0 % BLK_TRANSFER_SIZE == 0,
-               "Client0 data region size must be a multiple of the transfer size");
-_Static_assert(BLK_DATA_REGION_SIZE_DRIV >= BLK_TRANSFER_SIZE && BLK_DATA_REGION_SIZE_DRIV % BLK_TRANSFER_SIZE == 0,
-               "Driver data region size must be a multiple of the transfer size");
+#define BLK_QUEUE_REGION_SIZE_CLI0              BLK_QUEUE_REGION_SIZE
+#define BLK_QUEUE_REGION_SIZE_DRIV              BLK_QUEUE_REGION_SIZE
 
 /* Mapping from client index to disk partition that the client will have access to. */
 static const int blk_partition_mapping[BLK_NUM_CLIENTS] = { 0 };
 
-static inline blk_storage_info_t *blk_virt_cli_config_info(blk_storage_info_t *info, unsigned int id)
+static inline blk_storage_info_t *blk_virt_cli_storage_info(blk_storage_info_t *info, unsigned int id)
 {
     switch (id) {
     case 0:
@@ -87,7 +80,7 @@ static inline uint32_t blk_virt_cli_queue_size(unsigned int id)
 {
     switch (id) {
     case 0:
-        return BLK_QUEUE_SIZE_CLI0;
+        return BLK_QUEUE_CAPACITY_CLI0;
     default:
         return 0;
     }
@@ -96,7 +89,7 @@ static inline uint32_t blk_virt_cli_queue_size(unsigned int id)
 static inline uint32_t blk_cli_queue_size(char *pd_name)
 {
     if (!sddf_strcmp(pd_name, BLK_NAME_CLI0)) {
-        return BLK_QUEUE_SIZE_CLI0;
+        return BLK_QUEUE_CAPACITY_CLI0;
     } else {
         return 0;
     }

--- a/examples/blk/board/qemu_virt_aarch64/blk.system
+++ b/examples/blk/board/qemu_virt_aarch64/blk.system
@@ -12,12 +12,12 @@
     <memory_region name="blk_virtio_headers" size="0x10000" />
     <memory_region name="blk_driver_metadata" size="0x200000" />
 
-    <memory_region name="blk_driver_config" size="0x1000" page_size="0x1000" />
+    <memory_region name="blk_driver_storage_info" size="0x1000" page_size="0x1000" />
     <memory_region name="blk_driver_request" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="blk_driver_response" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="blk_driver_data" size="0x200_000" page_size="0x200_000" />
 
-    <memory_region name="blk_client_config" size="0x1000" page_size="0x1000" />
+    <memory_region name="blk_client_storage_info" size="0x1000" page_size="0x1000" />
     <memory_region name="blk_client_request" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="blk_client_response" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="blk_client_data" size="0x200_000" page_size="0x200_000" />
@@ -28,7 +28,7 @@
         <setvar symbol="virtio_headers_paddr" region_paddr="blk_virtio_headers" />
         <setvar symbol="requests_paddr" region_paddr="blk_driver_metadata" />
 
-        <map mr="blk_driver_config" vaddr="0x40_000_000" perms="rw" cached="true" setvar_vaddr="blk_config" />
+        <map mr="blk_driver_storage_info" vaddr="0x40_000_000" perms="rw" cached="true" setvar_vaddr="blk_storage_info" />
         <map mr="blk_driver_request" vaddr="0x40_200_000" perms="rw" cached="true" setvar_vaddr="blk_request" />
         <map mr="blk_driver_response" vaddr="0x40_400_000" perms="rw" cached="true" setvar_vaddr="blk_response" />
 
@@ -41,23 +41,24 @@
     <protection_domain name="virt" priority="99">
         <program_image path="blk_virt.elf" />
 
-        <map mr="blk_driver_config" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_config_driver"     />
-        <map mr="blk_driver_request" vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue_driver"  />
-        <map mr="blk_driver_response" vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue_driver" />
-        <map mr="blk_driver_data" vaddr="0x40600000" perms="rw" cached="false" setvar_vaddr="blk_data_driver" />
-        <setvar symbol="blk_data_driver_paddr" region_paddr="blk_driver_data" />
+        <map mr="blk_driver_storage_info" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_driver_storage_info"     />
+        <map mr="blk_driver_request" vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_driver_req_queue"  />
+        <map mr="blk_driver_response" vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_driver_resp_queue" />
+        <map mr="blk_driver_data" vaddr="0x40600000" perms="rw" cached="false" setvar_vaddr="blk_driver_data" />
+        <setvar symbol="blk_data_paddr_driver" region_paddr="blk_driver_data" />
 
-        <map mr="blk_client_config" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
-        <map mr="blk_client_request" vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
-        <map mr="blk_client_response" vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
-        <map mr="blk_client_data" vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_client_data_start" />
+        <map mr="blk_client_storage_info" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_client_storage_info"     />
+        <map mr="blk_client_request" vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_client_req_queue"  />
+        <map mr="blk_client_response" vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_client_resp_queue" />
+        <map mr="blk_client_data" vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_client_data" />
+        <setvar symbol="blk_client0_data_paddr" region_paddr="blk_client_data" />
     </protection_domain>
 
     <protection_domain name="client" priority="1">
         <program_image path="client.elf" />
 
         <!-- The client should not be able to write to the config page -->
-        <map mr="blk_client_config" vaddr="0x40_000_000" perms="r" cached="true" setvar_vaddr="blk_config" />
+        <map mr="blk_client_storage_info" vaddr="0x40_000_000" perms="r" cached="true" setvar_vaddr="blk_storage_info" />
 
         <map mr="blk_client_request" vaddr="0x40_200_000" perms="rw" cached="true" setvar_vaddr="blk_request" />
         <map mr="blk_client_response" vaddr="0x40_400_000" perms="rw" cached="true" setvar_vaddr="blk_response" />

--- a/examples/blk/client.c
+++ b/examples/blk/client.c
@@ -22,7 +22,7 @@
 #define QUEUE_SIZE 128
 #define VIRT_CH 0
 
-blk_storage_info_t *blk_config;
+blk_storage_info_t *blk_storage_info;
 uintptr_t blk_request;
 uintptr_t blk_response;
 uintptr_t blk_data;
@@ -123,10 +123,10 @@ void init(void)
     blk_queue_init(&blk_queue, (blk_req_queue_t *)blk_request, (blk_resp_queue_t *)blk_response, QUEUE_SIZE);
 
     /* Want to print out configuration information, so wait until the config is ready. */
-    while (!blk_storage_is_ready(blk_config));
+    while (!blk_storage_is_ready(blk_storage_info));
     LOG_CLIENT("device config ready\n");
 
-    LOG_CLIENT("device size: 0x%lx bytes\n", blk_config->capacity * BLK_TRANSFER_SIZE);
+    LOG_CLIENT("device size: 0x%lx bytes\n", blk_storage_info->capacity * BLK_TRANSFER_SIZE);
 
     test_basic();
     microkit_notify(VIRT_CH);

--- a/examples/mmc/board/imx8mm_evk/mmc.system
+++ b/examples/mmc/board/imx8mm_evk/mmc.system
@@ -8,15 +8,15 @@
     <memory_region name="usdhc2" size="0x10_000" phys_addr="0x30b5_0000" />
 
     <!-- sDDF Block -->
-    <memory_region name="blk_driver_config" size="0x1000"   page_size="0x1000"   />
-    <memory_region name="blk_driver_req"    size="0x200000" page_size="0x200000" />
-    <memory_region name="blk_driver_resp"   size="0x200000" page_size="0x200000" />
-    <memory_region name="blk_driver_data"   size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_driver_storage_info" size="0x1000"   page_size="0x1000"   />
+    <memory_region name="blk_driver_req"          size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_driver_resp"         size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_driver_data"         size="0x200000" page_size="0x200000" />
 
-    <memory_region name="blk_client_config" size="0x1000"   page_size="0x1000"   />
-    <memory_region name="blk_client_req"    size="0x200000" page_size="0x200000" />
-    <memory_region name="blk_client_resp"   size="0x200000" page_size="0x200000" />
-    <memory_region name="blk_client_data"   size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client_storage_info" size="0x1000"   page_size="0x1000"   />
+    <memory_region name="blk_client_req"          size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client_resp"         size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client_data"         size="0x200000" page_size="0x200000" />
 
     <protection_domain name="mmc_driver" priority="100" >
         <program_image path="mmc_driver.elf" />
@@ -24,9 +24,9 @@
         <irq irq="55" id="1" />
 
         <!-- sDDF block -->
-        <map mr="blk_driver_config" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
-        <map mr="blk_driver_req"    vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
-        <map mr="blk_driver_resp"   vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
+        <map mr="blk_driver_storage_info" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_storage_info" />
+        <map mr="blk_driver_req"          vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"    />
+        <map mr="blk_driver_resp"         vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue"   />
     </protection_domain>
 
     <protection_domain name="timer" priority="101" pp="true" passive="true">
@@ -44,10 +44,10 @@
         <program_image path="client.elf" />
 
         <!-- sDDF Block -->
-        <map mr="blk_client_config" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
-        <map mr="blk_client_req"    vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
-        <map mr="blk_client_resp"   vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
-        <map mr="blk_client_data"   vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_data"       />
+        <map mr="blk_client_storage_info" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_storage_info" />
+        <map mr="blk_client_req"          vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"    />
+        <map mr="blk_client_resp"         vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue"   />
+        <map mr="blk_client_data"         vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_data"         />
     </protection_domain>
 
     <channel>
@@ -59,16 +59,17 @@
     <protection_domain name="blk_virt" priority="99">
         <program_image path="blk_virt.elf" />
 
-        <map mr="blk_driver_config" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_config_driver"     />
-        <map mr="blk_driver_req"    vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue_driver"  />
-        <map mr="blk_driver_resp"   vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue_driver" />
-        <map mr="blk_driver_data"   vaddr="0x40600000" perms="rw" cached="false" setvar_vaddr="blk_data_driver" />
-        <setvar symbol="blk_data_driver_paddr" region_paddr="blk_driver_data" />
+        <map mr="blk_driver_storage_info" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_driver_storage_info" />
+        <map mr="blk_driver_req"          vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_driver_req_queue"    />
+        <map mr="blk_driver_resp"         vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_driver_resp_queue"   />
+        <map mr="blk_driver_data"         vaddr="0x40600000" perms="rw" cached="false" setvar_vaddr="blk_driver_data"         />
+        <setvar symbol="blk_data_paddr_driver" region_paddr="blk_driver_data" />
 
-        <map mr="blk_client_config" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
-        <map mr="blk_client_req"    vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
-        <map mr="blk_client_resp"   vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
-        <map mr="blk_client_data"   vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_client_data_start" />
+        <map mr="blk_client_storage_info" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_client_storage_info" />
+        <map mr="blk_client_req"          vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_client_req_queue"    />
+        <map mr="blk_client_resp"         vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_client_resp_queue"   />
+        <map mr="blk_client_data"         vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_client_data"         />
+        <setvar symbol="blk_client0_data_paddr" region_paddr="blk_client_data" />
     </protection_domain>
 
     <channel>

--- a/examples/mmc/board/maaxboard/mmc.system
+++ b/examples/mmc/board/maaxboard/mmc.system
@@ -8,15 +8,15 @@
     <memory_region name="usdhc1" size="0x10_000" phys_addr="0x30b4_0000" />
 
     <!-- sDDF Block -->
-    <memory_region name="blk_driver_config" size="0x1000"   page_size="0x1000"   />
-    <memory_region name="blk_driver_req"    size="0x200000" page_size="0x200000" />
-    <memory_region name="blk_driver_resp"   size="0x200000" page_size="0x200000" />
-    <memory_region name="blk_driver_data"   size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_driver_storage_info" size="0x1000"   page_size="0x1000"   />
+    <memory_region name="blk_driver_req"          size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_driver_resp"         size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_driver_data"         size="0x200000" page_size="0x200000" />
 
-    <memory_region name="blk_client_config" size="0x1000"   page_size="0x1000"   />
-    <memory_region name="blk_client_req"    size="0x200000" page_size="0x200000" />
-    <memory_region name="blk_client_resp"   size="0x200000" page_size="0x200000" />
-    <memory_region name="blk_client_data"   size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client_storage_info" size="0x1000"   page_size="0x1000"   />
+    <memory_region name="blk_client_req"          size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client_resp"         size="0x200000" page_size="0x200000" />
+    <memory_region name="blk_client_data"         size="0x200000" page_size="0x200000" />
 
     <protection_domain name="mmc_driver" priority="100" >
         <program_image path="mmc_driver.elf" />
@@ -24,9 +24,9 @@
         <irq irq="54" id="1"  />
 
         <!-- sDDF block -->
-        <map mr="blk_driver_config" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
-        <map mr="blk_driver_req"    vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
-        <map mr="blk_driver_resp"   vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
+        <map mr="blk_driver_storage_info" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_storage_info" />
+        <map mr="blk_driver_req"          vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"    />
+        <map mr="blk_driver_resp"         vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue"   />
     </protection_domain>
 
     <protection_domain name="timer" priority="101" pp="true" passive="true">
@@ -44,10 +44,10 @@
         <program_image path="client.elf" />
 
         <!-- sDDF Block -->
-        <map mr="blk_client_config" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
-        <map mr="blk_client_req"    vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
-        <map mr="blk_client_resp"   vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
-        <map mr="blk_client_data"   vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_data"       />
+        <map mr="blk_client_storage_info" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_storage_info" />
+        <map mr="blk_client_req"          vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"    />
+        <map mr="blk_client_resp"         vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue"   />
+        <map mr="blk_client_data"         vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_data"         />
     </protection_domain>
 
     <channel>
@@ -59,16 +59,17 @@
     <protection_domain name="blk_virt" priority="99">
         <program_image path="blk_virt.elf" />
 
-        <map mr="blk_driver_config" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_config_driver"     />
-        <map mr="blk_driver_req"    vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue_driver"  />
-        <map mr="blk_driver_resp"   vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue_driver" />
-        <map mr="blk_driver_data"   vaddr="0x40600000" perms="rw" cached="false" setvar_vaddr="blk_data_driver" />
-        <setvar symbol="blk_data_driver_paddr" region_paddr="blk_driver_data" />
+        <map mr="blk_driver_storage_info" vaddr="0x40000000" perms="rw" cached="false" setvar_vaddr="blk_driver_storage_info" />
+        <map mr="blk_driver_req"          vaddr="0x40200000" perms="rw" cached="false" setvar_vaddr="blk_driver_req_queue"    />
+        <map mr="blk_driver_resp"         vaddr="0x40400000" perms="rw" cached="false" setvar_vaddr="blk_driver_resp_queue"   />
+        <map mr="blk_driver_data"         vaddr="0x40600000" perms="rw" cached="false" setvar_vaddr="blk_driver_data"         />
+        <setvar symbol="blk_data_paddr_driver" region_paddr="blk_driver_data" />
 
-        <map mr="blk_client_config" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_config"     />
-        <map mr="blk_client_req"    vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_req_queue"  />
-        <map mr="blk_client_resp"   vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_resp_queue" />
-        <map mr="blk_client_data"   vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_client_data_start" />
+        <map mr="blk_client_storage_info" vaddr="0x30000000" perms="rw" cached="false" setvar_vaddr="blk_client_storage_info" />
+        <map mr="blk_client_req"          vaddr="0x30200000" perms="rw" cached="false" setvar_vaddr="blk_client_req_queue"    />
+        <map mr="blk_client_resp"         vaddr="0x30400000" perms="rw" cached="false" setvar_vaddr="blk_client_resp_queue"   />
+        <map mr="blk_client_data"         vaddr="0x30600000" perms="rw" cached="false" setvar_vaddr="blk_client_data"         />
+        <setvar symbol="blk_client0_data_paddr" region_paddr="blk_client_data" />
     </protection_domain>
 
     <channel>

--- a/examples/mmc/client.c
+++ b/examples/mmc/client.c
@@ -16,7 +16,7 @@
 
 blk_queue_handle_t blk_queue;
 /* set by microkit */
-blk_storage_info_t *blk_config;
+blk_storage_info_t *blk_storage_info;
 blk_req_queue_t *blk_req_queue;
 blk_resp_queue_t *blk_resp_queue;
 uintptr_t blk_data;
@@ -173,10 +173,10 @@ void notified(microkit_channel ch)
 
 void init(void)
 {
-    blk_queue_init(&blk_queue, blk_req_queue, blk_resp_queue, BLK_QUEUE_SIZE_CLI0);
+    blk_queue_init(&blk_queue, blk_req_queue, blk_resp_queue, BLK_QUEUE_CAPACITY_CLI0);
 
     /* Busy wait until blk device is ready */
-    while (!blk_storage_is_ready(blk_config));
+    while (!blk_storage_is_ready(blk_storage_info));
 
     sddf_printf("Hello from client\n");
 

--- a/examples/mmc/include/configs/blk_config.h
+++ b/examples/mmc/include/configs/blk_config.h
@@ -9,37 +9,30 @@
 #include <sddf/blk/storage_info.h>
 #include <sddf/util/string.h>
 
-#define BLK_NUM_CLIENTS 1
+#define BLK_NUM_CLIENTS                         1
 
-#define BLK_NAME_CLI0                       "CLIENT_MMC"
+#define BLK_NAME_CLI0                           "CLIENT_MMC"
 
-#define BLK_QUEUE_SIZE_CLI0                 1024
-#define BLK_QUEUE_SIZE_DRIV                 (BLK_QUEUE_SIZE_CLI0)
+#define BLK_QUEUE_CAPACITY_CLI0                 1024
+#define BLK_QUEUE_CAPACITY_DRIV                 BLK_QUEUE_CAPACITY_CLI0
 
-#define BLK_REGION_SIZE                     0x200000
-#define BLK_CONFIG_REGION_SIZE_CLI0         BLK_REGION_SIZE
+#define BLK_QUEUE_REGION_SIZE                   0x200000
+#define BLK_DATA_REGION_SIZE_CLI0               BLK_QUEUE_REGION_SIZE
+#define BLK_DATA_REGION_SIZE_DRIV               BLK_QUEUE_REGION_SIZE
 
-#define BLK_DATA_REGION_SIZE_CLI0           BLK_REGION_SIZE
-#define BLK_DATA_REGION_SIZE_DRIV           BLK_REGION_SIZE
-
-#define BLK_QUEUE_REGION_SIZE_CLI0          BLK_REGION_SIZE
-#define BLK_QUEUE_REGION_SIZE_DRIV          BLK_REGION_SIZE
-
-_Static_assert(BLK_DATA_REGION_SIZE_CLI0 >= BLK_TRANSFER_SIZE && BLK_DATA_REGION_SIZE_CLI0 % BLK_TRANSFER_SIZE == 0,
-               "Client0 data region size must be a multiple of the transfer size");
-_Static_assert(BLK_DATA_REGION_SIZE_DRIV >= BLK_TRANSFER_SIZE && BLK_DATA_REGION_SIZE_DRIV % BLK_TRANSFER_SIZE == 0,
-               "Driver data region size must be a multiple of the transfer size");
+#define BLK_QUEUE_REGION_SIZE_CLI0              BLK_QUEUE_REGION_SIZE
+#define BLK_QUEUE_REGION_SIZE_DRIV              BLK_QUEUE_REGION_SIZE
 
 /* Mapping from client index to disk partition that the client will have access to. */
 static const int blk_partition_mapping[BLK_NUM_CLIENTS] = { 2 };
 
-static inline blk_storage_info_t *blk_virt_cli_config_info(blk_storage_info_t *info, unsigned int id)
+static inline blk_storage_info_t *blk_virt_cli_storage_info(blk_storage_info_t *info, unsigned int id)
 {
     switch (id) {
     case 0:
         return info;
     case 1:
-        return (blk_storage_info_t *)((uintptr_t)info + BLK_CONFIG_REGION_SIZE_CLI0);
+        return (blk_storage_info_t *)((uintptr_t)info + BLK_STORAGE_INFO_REGION_SIZE);
     default:
         return NULL;
     }
@@ -89,7 +82,7 @@ static inline uint32_t blk_virt_cli_queue_size(unsigned int id)
 {
     switch (id) {
     case 0:
-        return BLK_QUEUE_SIZE_CLI0;
+        return BLK_QUEUE_CAPACITY_CLI0;
     default:
         return 0;
     }
@@ -98,7 +91,7 @@ static inline uint32_t blk_virt_cli_queue_size(unsigned int id)
 static inline uint32_t blk_cli_queue_size(char *pd_name)
 {
     if (!sddf_strcmp(pd_name, BLK_NAME_CLI0)) {
-        return BLK_QUEUE_SIZE_CLI0;
+        return BLK_QUEUE_CAPACITY_CLI0;
     } else {
         return 0;
     }

--- a/include/sddf/blk/queue.h
+++ b/include/sddf/blk/queue.h
@@ -30,6 +30,8 @@ typedef enum blk_resp_status {
     BLK_RESP_ERR_UNSPEC,
     /* invalid request parameters */
     BLK_RESP_ERR_INVALID_PARAM,
+    /* device failed to complete request */
+    BLK_RESP_ERR_IO,
     /* the device is not inserted */
     BLK_RESP_ERR_NO_DEVICE,
 } blk_resp_status_t;

--- a/include/sddf/blk/storage_info.h
+++ b/include/sddf/blk/storage_info.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#define BLK_STORAGE_INFO_REGION_SIZE 0x1000
+
 /* Device serial number max string length */
 #define BLK_MAX_SERIAL_NUMBER 63
 


### PR DESCRIPTION
This PR changes blk virt to use io addresses from client data regions instead of the one shared with the driver. Refer to commit message for more details.

Note: I haven't been able to test this on the hardware examples in examples/mmc