### PR TITLE
Add support for SDSC (≤2GiB) SD cards

### DIFF
--- a/drivers/blk/mmc/imx/README.md
+++ b/drivers/blk/mmc/imx/README.md
@@ -19,7 +19,7 @@ This is a driver for the MaaXBoard SD host controller, based on the following do
 
 ## Implemented
 - IRQ & DMA based driver
-- Supports 3.3V operation of Version 2 SDHC cards (4GiB–32GiB) at $f_{OD}$ (400kHz).
+- Supports Version 2 SD Cards (SDSC, SDHC, SDXC, SDUC) operating at 3.3V / $f_{OD}$ (400kHz).
 
 ## Not Implemented
 - Voltage Negotiation (anything but 3.3V)

--- a/drivers/blk/mmc/imx/include/usdhc.h
+++ b/drivers/blk/mmc/imx/include/usdhc.h
@@ -69,6 +69,7 @@ typedef struct imx_usdhc_regs {
 
 #define _LEN(start, end) ((end - start) + 1)
 #define _MASK(start, end)  ((BIT(_LEN(start, end)) - 1) << (start))
+#define _MASK_128(start, end)  ((__uint128_t)(BIT(_LEN(start, end)) - 1) << (start))
 
 /* [IMX8MDQLQRM] Section 10.3.7.1.3 Block Attributes */
 #define USDHC_BLK_ATT_BLKSIZE_SHIFT 0             /* Transfer block size  */
@@ -260,11 +261,26 @@ typedef struct {
 #define SD_OCR_HCS              BIT(30)  /* Host Capacity Status (HCS) */
 #define SD_OCR_POWER_UP_STATUS  BIT(31)  /* Card power up status bit (busy) */
 
+/* [SD-PHY] Section 5.3.1 CSD Register */
+#define SD_CSD_CSD_STRUCTURE_SHIFT    126             /* CSD Structure (version)      */
+#define SD_CSD_CSD_STRUCTURE_MASK     _MASK_128(126, 127) /* CSD-slice: [127:126]         */
+
+/* [SD-PHY] Section 5.3.2 CSD Register (CSD Version 1.0) */
+#define SD_CSD_V1_READ_BL_LEN_SHIFT   80                 /* max. read data block length  */
+#define SD_CSD_V1_READ_BL_LEN_MASK    _MASK_128(80, 83)  /* CSD-slice: [83:80]           */
+#define SD_CSD_V1_C_SIZE_MULT_SHIFT   47                 /* device size multiplier       */
+#define SD_CSD_V1_C_SIZE_MULT_MASK    _MASK_128(47, 49)  /* CSD-slice: [49:47]           */
+#define SD_CSD_V1_C_SIZE_SHIFT        62                 /* device size (user area size) */
+#define SD_CSD_V1_C_SIZE_MASK         _MASK_128(62, 73)  /* CSD-slice: [75:48]           */
+
+/* [SD-PHY] Section 5.3.3 CSD Register (CSD Version 2.0) */
+#define SD_CSD_V2_C_SIZE_SHIFT        48                 /* device size (user area size) */
+#define SD_CSD_V2_C_SIZE_MASK         _MASK_128(48, 69)  /* CSD-slice: [69:48]           */
+
 /* [SD-PHY] Section 5.3.4 CSD Register (CSD Version 3.0) */
-#define SD_CSD_CSD_STRUCTURE_SHIFT 126              /* CSD Structure (version)      */
-#define SD_CSD_CSD_STRUCTURE_MASK  _MASK(126, 127)  /* CSD-slice: [127:126]         */
-#define SD_CSD_C_SIZE_SHIFT        48               /* device size (user area size) */
-#define SD_CSD_C_SIZE_MASK         _MASK(48, 75)    /* CSD-slice: [75:48]           */
+#define SD_CSD_V3_C_SIZE_SHIFT        48                 /* device size (user area size) */
+#define SD_CSD_V3_C_SIZE_MASK         _MASK_128(48, 75)  /* CSD-slice: [75:48]           */
+
 
 /* [SD-HOST] Section 3.2.3 Clock Frequency Change - timeout is 150ms */
 #define SD_CLOCK_STABLE_TIMEOUT (150 * NS_IN_MS)


### PR DESCRIPTION
Tested on on a 2GiB SDSC Card, matches with mmc-utils on Linux.

```
CSD Version: 0
READ_BL_LEN: a
C_SIZE: eaf
C_SIZE_MULT: 7
uSDHC DRIVER|ERROR: Card size (blocks): 481280
Hello from client
[   0] = 0x3
[   1] = 0x4
[   2] = 0x5
[   3] = 0x6
[ 508] = 0xff
[ 509] = 0x0
[ 510] = 0x1
[ 511] = 0x2
[ 512] = 0x3
[ 513] = 0x4
[ 514] = 0x5
[ 515] = 0x6
[ 516] = 0x7
[4092] = 0xff
[4093] = 0x0
[4094] = 0x1
[4095] = 0x2
[4096] = 0x3
[4097] = 0x4
[NW-3] = 0x0
[NW-2] = 0x1
[NWB-] = 0x2

[NWB=] = 0x0
[NWB+] = 0x0
[NW++] = 0x0
[NR-2] = 0x0
[NR-1] = 0x0

[NRB=] = 0x3
[NR+1] = 0x4
[NR+2] = 0x5
[NR+3] = 0x6
Client read/write data is correct!
```

In theory, should also work on SDXC (32GiB -> 2TiB) and SDUC (> 2TiB), though we don't have cards to test.

Waiting on #206 to merge first.
Part of #187.