### PR TITLE
examples/echo_server: catch notify from serial TX

### DIFF
--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -268,6 +268,9 @@ void notified(microkit_channel ch)
 #endif
 
         break;
+    case SERIAL_TX_CH:
+        // Nothing to do
+        break;
     default:
         sddf_printf("Bench thread notified on unexpected channel\n");
     }

--- a/examples/echo_server/lwip.c
+++ b/examples/echo_server/lwip.c
@@ -360,6 +360,9 @@ void notified(microkit_channel ch)
         transmit();
         receive();
         break;
+    case SERIAL_TX_CH:
+        // Nothing to do
+        break;
     default:
         sddf_dprintf("LWIP|LOG: received notification on unexpected channel: %u\n", ch);
         break;


### PR DESCRIPTION
This avoids an 'unexpected channel' message being printed out, everything is fine and nothing needs to be done if we do get a notification from serial TX.