### PR TITLE
ci: fix Zig download link

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -31,7 +31,7 @@ jobs:
           echo "$(pwd)/arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
       - name: Install Zig
         run: |
-          wget https://ziglang.org/builds/zig-linux-x86_64-0.13.0.tar.xz
+          wget https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
           tar xf zig-linux-x86_64-0.13.0.tar.xz
           echo "${PWD}/zig-linux-x86_64-0.13.0/:$PATH" >> $GITHUB_PATH
       - name: Build and run examples
@@ -53,7 +53,7 @@ jobs:
           echo "/usr/local/opt/llvm/bin:$PATH" >> $GITHUB_PATH
       - name: Install Zig
         run: |
-          wget https://ziglang.org/builds/zig-macos-x86_64-0.13.0.tar.xz
+          wget https://ziglang.org/download/0.13.0/zig-macos-x86_64-0.13.0.tar.xz
           tar xf zig-macos-x86_64-0.13.0.tar.xz
           echo "${PWD}/zig-macos-x86_64-0.13.0/:$PATH" >> $GITHUB_PATH
       - name: Download and install AArch64 GCC toolchain


### PR DESCRIPTION
Looks like they changed it recently and didn't add a redirect.