### PR TITLE
Use capacity/length instead of size in network and serial subsystems

### DIFF
--- a/drivers/network/imx/ethernet.c
+++ b/drivers/network/imx/ethernet.c
@@ -58,14 +58,14 @@ net_queue_handle_t tx_queue;
 
 volatile struct enet_regs *eth;
 
-static inline bool hw_ring_full(hw_ring_t *ring, size_t ring_size)
+static inline bool hw_ring_full(hw_ring_t *ring, size_t ring_capacity)
 {
-    return !((ring->tail - ring->head + 1) % ring_size);
+    return !((ring->tail - ring->head + 1) % ring_capacity);
 }
 
-static inline bool hw_ring_empty(hw_ring_t *ring, size_t ring_size)
+static inline bool hw_ring_empty(hw_ring_t *ring, size_t ring_capacity)
 {
-    return !((ring->tail - ring->head) % ring_size);
+    return !((ring->tail - ring->head) % ring_capacity);
 }
 
 static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys,
@@ -302,8 +302,8 @@ void init(void)
 {
     eth_setup();
 
-    net_queue_init(&rx_queue, rx_free, rx_active, NET_RX_QUEUE_SIZE_DRIV);
-    net_queue_init(&tx_queue, tx_free, tx_active, NET_TX_QUEUE_SIZE_DRIV);
+    net_queue_init(&rx_queue, rx_free, rx_active, NET_RX_QUEUE_CAPACITY_DRIV);
+    net_queue_init(&tx_queue, tx_free, tx_active, NET_TX_QUEUE_CAPACITY_DRIV);
 
     rx_provide();
     tx_provide();

--- a/drivers/network/meson/ethernet.c
+++ b/drivers/network/meson/ethernet.c
@@ -59,14 +59,14 @@ net_queue_handle_t tx_queue;
 volatile struct eth_mac_regs *eth_mac;
 volatile struct eth_dma_regs *eth_dma;
 
-static inline bool hw_ring_full(hw_ring_t *ring, size_t ring_size)
+static inline bool hw_ring_full(hw_ring_t *ring, size_t ring_capacity)
 {
-    return !((ring->tail + 2 - ring->head) % ring_size);
+    return !((ring->tail + 2 - ring->head) % ring_capacity);
 }
 
-static inline bool hw_ring_empty(hw_ring_t *ring, size_t ring_size)
+static inline bool hw_ring_empty(hw_ring_t *ring, size_t ring_capacity)
 {
-    return !((ring->tail - ring->head) % ring_size);
+    return !((ring->tail - ring->head) % ring_capacity);
 }
 
 static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uint32_t status,
@@ -271,8 +271,8 @@ void init(void)
 {
     eth_setup();
 
-    net_queue_init(&rx_queue, (net_queue_t *)rx_free, (net_queue_t *)rx_active, NET_RX_QUEUE_SIZE_DRIV);
-    net_queue_init(&tx_queue, (net_queue_t *)tx_free, (net_queue_t *)tx_active, NET_TX_QUEUE_SIZE_DRIV);
+    net_queue_init(&rx_queue, (net_queue_t *)rx_free, (net_queue_t *)rx_active, NET_RX_QUEUE_CAPACITY_DRIV);
+    net_queue_init(&tx_queue, (net_queue_t *)tx_free, (net_queue_t *)tx_active, NET_TX_QUEUE_CAPACITY_DRIV);
 
     rx_provide();
     tx_provide();

--- a/drivers/network/virtio/ethernet.c
+++ b/drivers/network/virtio/ethernet.c
@@ -443,8 +443,8 @@ void init(void)
     ialloc_init(&rx_ialloc_desc, rx_descriptors, RX_COUNT);
     ialloc_init(&tx_ialloc_desc, tx_descriptors, TX_COUNT);
 
-    net_queue_init(&rx_queue, rx_free, rx_active, NET_RX_QUEUE_SIZE_DRIV);
-    net_queue_init(&tx_queue, tx_free, tx_active, NET_TX_QUEUE_SIZE_DRIV);
+    net_queue_init(&rx_queue, rx_free, rx_active, NET_RX_QUEUE_CAPACITY_DRIV);
+    net_queue_init(&tx_queue, tx_free, tx_active, NET_TX_QUEUE_CAPACITY_DRIV);
 
     eth_setup();
 

--- a/drivers/serial/arm/uart.c
+++ b/drivers/serial/arm/uart.c
@@ -175,9 +175,9 @@ void init(void)
     uart_setup();
 
 #if !SERIAL_TX_ONLY
-    serial_queue_init(&rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_DRIV, rx_data);
+    serial_queue_init(&rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_CAPACITY_DRIV, rx_data);
 #endif
-    serial_queue_init(&tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_DRIV, tx_data);
+    serial_queue_init(&tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_DRIV, tx_data);
 }
 
 void notified(microkit_channel ch)

--- a/drivers/serial/imx/uart.c
+++ b/drivers/serial/imx/uart.c
@@ -181,9 +181,9 @@ void init(void)
     uart_setup();
 
 #if !SERIAL_TX_ONLY
-    serial_queue_init(&rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_DRIV, rx_data);
+    serial_queue_init(&rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_CAPACITY_DRIV, rx_data);
 #endif
-    serial_queue_init(&tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_DRIV, tx_data);
+    serial_queue_init(&tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_DRIV, tx_data);
 }
 
 void notified(microkit_channel ch)

--- a/drivers/serial/meson/uart.c
+++ b/drivers/serial/meson/uart.c
@@ -206,9 +206,9 @@ void init(void)
     uart_setup();
 
 #if !SERIAL_TX_ONLY
-    serial_queue_init(&rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_DRIV, rx_data);
+    serial_queue_init(&rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_CAPACITY_DRIV, rx_data);
 #endif
-    serial_queue_init(&tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_DRIV, tx_data);
+    serial_queue_init(&tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_DRIV, tx_data);
 }
 
 void notified(microkit_channel ch)

--- a/drivers/serial/snps/uart.c
+++ b/drivers/serial/snps/uart.c
@@ -170,9 +170,9 @@ void init(void)
     *REG_PTR(UART_IER) = (UART_IER_ERBFI | UART_IER_ETBEI);
 
 #if !SERIAL_TX_ONLY
-    serial_queue_init(&rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_DRIV, rx_data);
+    serial_queue_init(&rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_CAPACITY_DRIV, rx_data);
 #endif
-    serial_queue_init(&tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_DRIV, tx_data);
+    serial_queue_init(&tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_DRIV, tx_data);
 }
 
 void notified(microkit_channel ch)

--- a/examples/echo_server/include/ethernet_config/ethernet_config.h
+++ b/examples/echo_server/include/ethernet_config/ethernet_config.h
@@ -43,44 +43,44 @@
 #error "Must define MAC addresses for clients in ethernet config"
 #endif
 
-#define NET_TX_QUEUE_SIZE_CLI0                   512
-#define NET_TX_QUEUE_SIZE_CLI1                   512
-#define NET_TX_QUEUE_SIZE_DRIV                   (NET_TX_QUEUE_SIZE_CLI0 + NET_TX_QUEUE_SIZE_CLI1)
+#define NET_TX_QUEUE_CAPACITY_CLI0                   512
+#define NET_TX_QUEUE_CAPACITY_CLI1                   512
+#define NET_TX_QUEUE_CAPACITY_DRIV                   (NET_TX_QUEUE_CAPACITY_CLI0 + NET_TX_QUEUE_CAPACITY_CLI1)
 
 #define NET_TX_DATA_REGION_SIZE_CLI0            NET_DATA_REGION_SIZE
 #define NET_TX_DATA_REGION_SIZE_CLI1            NET_DATA_REGION_SIZE
 
-_Static_assert(NET_TX_DATA_REGION_SIZE_CLI0 >= NET_TX_QUEUE_SIZE_CLI0 *NET_BUFFER_SIZE,
+_Static_assert(NET_TX_DATA_REGION_SIZE_CLI0 >= NET_TX_QUEUE_CAPACITY_CLI0 *NET_BUFFER_SIZE,
                "Client0 TX data region size must fit Client0 TX buffers");
-_Static_assert(NET_TX_DATA_REGION_SIZE_CLI1 >= NET_TX_QUEUE_SIZE_CLI1 *NET_BUFFER_SIZE,
+_Static_assert(NET_TX_DATA_REGION_SIZE_CLI1 >= NET_TX_QUEUE_CAPACITY_CLI1 *NET_BUFFER_SIZE,
                "Client1 TX data region size must fit Client1 TX buffers");
 
-#define NET_RX_QUEUE_SIZE_DRIV                   512
-#define NET_RX_QUEUE_SIZE_CLI0                   512
-#define NET_RX_QUEUE_SIZE_CLI1                   512
-#define NET_MAX_CLIENT_QUEUE_SIZE                MAX(NET_RX_QUEUE_SIZE_CLI0, NET_RX_QUEUE_SIZE_CLI1)
-#define NET_RX_QUEUE_SIZE_COPY0                  NET_RX_QUEUE_SIZE_DRIV
-#define NET_RX_QUEUE_SIZE_COPY1                  NET_RX_QUEUE_SIZE_DRIV
+#define NET_RX_QUEUE_CAPACITY_DRIV                   512
+#define NET_RX_QUEUE_CAPACITY_CLI0                   512
+#define NET_RX_QUEUE_CAPACITY_CLI1                   512
+#define NET_MAX_CLIENT_QUEUE_CAPACITY                MAX(NET_RX_QUEUE_CAPACITY_CLI0, NET_RX_QUEUE_CAPACITY_CLI1)
+#define NET_RX_QUEUE_CAPACITY_COPY0                  NET_RX_QUEUE_CAPACITY_DRIV
+#define NET_RX_QUEUE_CAPACITY_COPY1                  NET_RX_QUEUE_CAPACITY_DRIV
 
 #define NET_RX_DATA_REGION_SIZE_DRIV            NET_DATA_REGION_SIZE
 #define NET_RX_DATA_REGION_SIZE_CLI0            NET_DATA_REGION_SIZE
 #define NET_RX_DATA_REGION_SIZE_CLI1            NET_DATA_REGION_SIZE
 
-_Static_assert(NET_RX_DATA_REGION_SIZE_DRIV >= NET_RX_QUEUE_SIZE_DRIV *NET_BUFFER_SIZE,
+_Static_assert(NET_RX_DATA_REGION_SIZE_DRIV >= NET_RX_QUEUE_CAPACITY_DRIV *NET_BUFFER_SIZE,
                "Driver RX data region size must fit Driver RX buffers");
-_Static_assert(NET_RX_DATA_REGION_SIZE_CLI0 >= NET_RX_QUEUE_SIZE_CLI0 *NET_BUFFER_SIZE,
+_Static_assert(NET_RX_DATA_REGION_SIZE_CLI0 >= NET_RX_QUEUE_CAPACITY_CLI0 *NET_BUFFER_SIZE,
                "Client0 RX data region size must fit Client0 RX buffers");
-_Static_assert(NET_RX_DATA_REGION_SIZE_CLI1 >= NET_RX_QUEUE_SIZE_CLI1 *NET_BUFFER_SIZE,
+_Static_assert(NET_RX_DATA_REGION_SIZE_CLI1 >= NET_RX_QUEUE_CAPACITY_CLI1 *NET_BUFFER_SIZE,
                "Client1 RX data region size must fit Client1 RX buffers");
 
-#define NET_MAX_QUEUE_SIZE MAX(NET_TX_QUEUE_SIZE_DRIV, MAX(NET_RX_QUEUE_SIZE_DRIV, MAX(NET_RX_QUEUE_SIZE_CLI0, NET_RX_QUEUE_SIZE_CLI1)))
-_Static_assert(NET_TX_QUEUE_SIZE_DRIV >= NET_TX_QUEUE_SIZE_CLI0 + NET_TX_QUEUE_SIZE_CLI1,
+#define NET_MAX_QUEUE_CAPACITY MAX(NET_TX_QUEUE_CAPACITY_DRIV, MAX(NET_RX_QUEUE_CAPACITY_DRIV, MAX(NET_RX_QUEUE_CAPACITY_CLI0, NET_RX_QUEUE_CAPACITY_CLI1)))
+_Static_assert(NET_TX_QUEUE_CAPACITY_DRIV >= NET_TX_QUEUE_CAPACITY_CLI0 + NET_TX_QUEUE_CAPACITY_CLI1,
                "Driver TX queue must have capacity to fit all of client's TX buffers.");
-_Static_assert(NET_RX_QUEUE_SIZE_COPY0 >= NET_RX_QUEUE_SIZE_DRIV,
+_Static_assert(NET_RX_QUEUE_CAPACITY_COPY0 >= NET_RX_QUEUE_CAPACITY_DRIV,
                "Copy0 queues must have capacity to fit all RX buffers.");
-_Static_assert(NET_RX_QUEUE_SIZE_COPY1 >= NET_RX_QUEUE_SIZE_DRIV,
+_Static_assert(NET_RX_QUEUE_CAPACITY_COPY1 >= NET_RX_QUEUE_CAPACITY_DRIV,
                "Copy1 queues must have capacity to fit all RX buffers.");
-_Static_assert(sizeof(net_queue_t) + NET_MAX_QUEUE_SIZE *sizeof(net_buff_desc_t) <= NET_DATA_REGION_SIZE,
+_Static_assert(sizeof(net_queue_t) + NET_MAX_QUEUE_CAPACITY *sizeof(net_buff_desc_t) <= NET_DATA_REGION_SIZE,
                "net_queue_t must fit into a single data region.");
 
 static inline uint64_t net_cli_mac_addr(char *pd_name)
@@ -102,32 +102,32 @@ static inline void net_virt_mac_addrs(char *pd_name, uint64_t macs[NUM_NETWORK_C
     }
 }
 
-static inline void net_cli_queue_size(char *pd_name, size_t *rx_queue_size, size_t *tx_queue_size)
+static inline void net_cli_queue_capacity(char *pd_name, size_t *rx_queue_capacity, size_t *tx_queue_capacity)
 {
     if (!sddf_strcmp(pd_name, NET_CLI0_NAME)) {
-        *rx_queue_size = NET_RX_QUEUE_SIZE_CLI0;
-        *tx_queue_size = NET_TX_QUEUE_SIZE_CLI0;
+        *rx_queue_capacity = NET_RX_QUEUE_CAPACITY_CLI0;
+        *tx_queue_capacity = NET_TX_QUEUE_CAPACITY_CLI0;
     } else if (!sddf_strcmp(pd_name, NET_CLI1_NAME)) {
-        *rx_queue_size = NET_RX_QUEUE_SIZE_CLI1;
-        *tx_queue_size = NET_TX_QUEUE_SIZE_CLI1;
+        *rx_queue_capacity = NET_RX_QUEUE_CAPACITY_CLI1;
+        *tx_queue_capacity = NET_TX_QUEUE_CAPACITY_CLI1;
     }
 }
 
-static inline void net_copy_queue_size(char *pd_name, size_t *cli_queue_size, size_t *virt_queue_size)
+static inline void net_copy_queue_capacity(char *pd_name, size_t *cli_queue_capacity, size_t *virt_queue_capacity)
 {
     if (!sddf_strcmp(pd_name, NET_COPY0_NAME)) {
-        *cli_queue_size = NET_RX_QUEUE_SIZE_CLI0;
-        *virt_queue_size = NET_RX_QUEUE_SIZE_COPY0;
+        *cli_queue_capacity = NET_RX_QUEUE_CAPACITY_CLI0;
+        *virt_queue_capacity = NET_RX_QUEUE_CAPACITY_COPY0;
     } else if (!sddf_strcmp(pd_name, NET_COPY1_NAME)) {
-        *cli_queue_size = NET_RX_QUEUE_SIZE_CLI1;
-        *virt_queue_size = NET_RX_QUEUE_SIZE_COPY1;
+        *cli_queue_capacity = NET_RX_QUEUE_CAPACITY_CLI1;
+        *virt_queue_capacity = NET_RX_QUEUE_CAPACITY_COPY1;
     }
 }
 
 typedef struct net_queue_info {
     net_queue_t *free;
     net_queue_t *active;
-    size_t size;
+    size_t capacity;
 } net_queue_info_t;
 
 static inline void net_virt_queue_info(char *pd_name, net_queue_t *cli0_free, net_queue_t *cli0_active,
@@ -135,21 +135,21 @@ static inline void net_virt_queue_info(char *pd_name, net_queue_t *cli0_free, ne
 {
     if (!sddf_strcmp(pd_name, NET_VIRT_RX_NAME)) {
         ret[0] = (net_queue_info_t) {
-            .free = cli0_free, .active = cli0_active, .size = NET_RX_QUEUE_SIZE_COPY0
+            .free = cli0_free, .active = cli0_active, .capacity = NET_RX_QUEUE_CAPACITY_COPY0
         };
         ret[1] = (net_queue_info_t) {
             .free = (net_queue_t *)((uintptr_t)cli0_free + 2 * NET_DATA_REGION_SIZE),
             .active = (net_queue_t *)((uintptr_t)cli0_active + 2 * NET_DATA_REGION_SIZE),
-            .size = NET_RX_QUEUE_SIZE_COPY1
+            .capacity = NET_RX_QUEUE_CAPACITY_COPY1
         };
     } else if (!sddf_strcmp(pd_name, NET_VIRT_TX_NAME)) {
         ret[0] = (net_queue_info_t) {
-            .free = cli0_free, .active = cli0_active, .size = NET_TX_QUEUE_SIZE_CLI0
+            .free = cli0_free, .active = cli0_active, .capacity = NET_TX_QUEUE_CAPACITY_CLI0
         };
         ret[1] = (net_queue_info_t) {
             .free = (net_queue_t *)((uintptr_t)cli0_free + 2 * NET_DATA_REGION_SIZE),
             .active = (net_queue_t *)((uintptr_t)cli0_active + 2 * NET_DATA_REGION_SIZE),
-            .size = NET_TX_QUEUE_SIZE_CLI1
+            .capacity = NET_TX_QUEUE_CAPACITY_CLI1
         };
     }
 }

--- a/examples/echo_server/include/ethernet_config/ethernet_config.h
+++ b/examples/echo_server/include/ethernet_config/ethernet_config.h
@@ -50,9 +50,9 @@
 #define NET_TX_DATA_REGION_SIZE_CLI0            NET_DATA_REGION_SIZE
 #define NET_TX_DATA_REGION_SIZE_CLI1            NET_DATA_REGION_SIZE
 
-_Static_assert(NET_TX_DATA_REGION_SIZE_CLI0 >= NET_TX_QUEUE_CAPACITY_CLI0 *NET_BUFFER_SIZE,
+_Static_assert(NET_TX_DATA_REGION_SIZE_CLI0 >= NET_TX_QUEUE_CAPACITY_CLI0 * NET_BUFFER_SIZE,
                "Client0 TX data region size must fit Client0 TX buffers");
-_Static_assert(NET_TX_DATA_REGION_SIZE_CLI1 >= NET_TX_QUEUE_CAPACITY_CLI1 *NET_BUFFER_SIZE,
+_Static_assert(NET_TX_DATA_REGION_SIZE_CLI1 >= NET_TX_QUEUE_CAPACITY_CLI1 * NET_BUFFER_SIZE,
                "Client1 TX data region size must fit Client1 TX buffers");
 
 #define NET_RX_QUEUE_CAPACITY_DRIV                   512
@@ -66,11 +66,11 @@ _Static_assert(NET_TX_DATA_REGION_SIZE_CLI1 >= NET_TX_QUEUE_CAPACITY_CLI1 *NET_B
 #define NET_RX_DATA_REGION_SIZE_CLI0            NET_DATA_REGION_SIZE
 #define NET_RX_DATA_REGION_SIZE_CLI1            NET_DATA_REGION_SIZE
 
-_Static_assert(NET_RX_DATA_REGION_SIZE_DRIV >= NET_RX_QUEUE_CAPACITY_DRIV *NET_BUFFER_SIZE,
+_Static_assert(NET_RX_DATA_REGION_SIZE_DRIV >= NET_RX_QUEUE_CAPACITY_DRIV * NET_BUFFER_SIZE,
                "Driver RX data region size must fit Driver RX buffers");
-_Static_assert(NET_RX_DATA_REGION_SIZE_CLI0 >= NET_RX_QUEUE_CAPACITY_CLI0 *NET_BUFFER_SIZE,
+_Static_assert(NET_RX_DATA_REGION_SIZE_CLI0 >= NET_RX_QUEUE_CAPACITY_CLI0 * NET_BUFFER_SIZE,
                "Client0 RX data region size must fit Client0 RX buffers");
-_Static_assert(NET_RX_DATA_REGION_SIZE_CLI1 >= NET_RX_QUEUE_CAPACITY_CLI1 *NET_BUFFER_SIZE,
+_Static_assert(NET_RX_DATA_REGION_SIZE_CLI1 >= NET_RX_QUEUE_CAPACITY_CLI1 * NET_BUFFER_SIZE,
                "Client1 RX data region size must fit Client1 RX buffers");
 
 #define NET_MAX_QUEUE_CAPACITY MAX(NET_TX_QUEUE_CAPACITY_DRIV, MAX(NET_RX_QUEUE_CAPACITY_DRIV, MAX(NET_RX_QUEUE_CAPACITY_CLI0, NET_RX_QUEUE_CAPACITY_CLI1)))
@@ -80,7 +80,7 @@ _Static_assert(NET_RX_QUEUE_CAPACITY_COPY0 >= NET_RX_QUEUE_CAPACITY_DRIV,
                "Copy0 queues must have capacity to fit all RX buffers.");
 _Static_assert(NET_RX_QUEUE_CAPACITY_COPY1 >= NET_RX_QUEUE_CAPACITY_DRIV,
                "Copy1 queues must have capacity to fit all RX buffers.");
-_Static_assert(sizeof(net_queue_t) + NET_MAX_QUEUE_CAPACITY *sizeof(net_buff_desc_t) <= NET_DATA_REGION_SIZE,
+_Static_assert(sizeof(net_queue_t) + NET_MAX_QUEUE_CAPACITY * sizeof(net_buff_desc_t) <= NET_DATA_REGION_SIZE,
                "net_queue_t must fit into a single data region.");
 
 static inline uint64_t net_cli_mac_addr(char *pd_name)
@@ -134,23 +134,17 @@ static inline void net_virt_queue_info(char *pd_name, net_queue_t *cli0_free, ne
                                        net_queue_info_t ret[NUM_NETWORK_CLIENTS])
 {
     if (!sddf_strcmp(pd_name, NET_VIRT_RX_NAME)) {
-        ret[0] = (net_queue_info_t) {
-            .free = cli0_free, .active = cli0_active, .capacity = NET_RX_QUEUE_CAPACITY_COPY0
-        };
-        ret[1] = (net_queue_info_t) {
-            .free = (net_queue_t *)((uintptr_t)cli0_free + 2 * NET_DATA_REGION_SIZE),
-            .active = (net_queue_t *)((uintptr_t)cli0_active + 2 * NET_DATA_REGION_SIZE),
-            .capacity = NET_RX_QUEUE_CAPACITY_COPY1
-        };
+        ret[0] =
+            (net_queue_info_t) { .free = cli0_free, .active = cli0_active, .capacity = NET_RX_QUEUE_CAPACITY_COPY0 };
+        ret[1] = (net_queue_info_t) { .free = (net_queue_t *)((uintptr_t)cli0_free + 2 * NET_DATA_REGION_SIZE),
+                                      .active = (net_queue_t *)((uintptr_t)cli0_active + 2 * NET_DATA_REGION_SIZE),
+                                      .capacity = NET_RX_QUEUE_CAPACITY_COPY1 };
     } else if (!sddf_strcmp(pd_name, NET_VIRT_TX_NAME)) {
-        ret[0] = (net_queue_info_t) {
-            .free = cli0_free, .active = cli0_active, .capacity = NET_TX_QUEUE_CAPACITY_CLI0
-        };
-        ret[1] = (net_queue_info_t) {
-            .free = (net_queue_t *)((uintptr_t)cli0_free + 2 * NET_DATA_REGION_SIZE),
-            .active = (net_queue_t *)((uintptr_t)cli0_active + 2 * NET_DATA_REGION_SIZE),
-            .capacity = NET_TX_QUEUE_CAPACITY_CLI1
-        };
+        ret[0] =
+            (net_queue_info_t) { .free = cli0_free, .active = cli0_active, .capacity = NET_TX_QUEUE_CAPACITY_CLI0 };
+        ret[1] = (net_queue_info_t) { .free = (net_queue_t *)((uintptr_t)cli0_free + 2 * NET_DATA_REGION_SIZE),
+                                      .active = (net_queue_t *)((uintptr_t)cli0_active + 2 * NET_DATA_REGION_SIZE),
+                                      .capacity = NET_TX_QUEUE_CAPACITY_CLI1 };
     }
 }
 

--- a/examples/echo_server/include/serial_config/serial_config.h
+++ b/examples/echo_server/include/serial_config/serial_config.h
@@ -33,22 +33,22 @@
 #define SERIAL_CLI2_NAME "bench"
 #define SERIAL_VIRT_TX_NAME "serial_virt_tx"
 
-#define SERIAL_QUEUE_SIZE                          0x1000
-#define SERIAL_DATA_REGION_SIZE                    0x2000
+#define SERIAL_QUEUE_SIZE                              0x1000
+#define SERIAL_DATA_REGION_CAPACITY                    0x2000
 
-#define SERIAL_TX_DATA_REGION_SIZE_DRIV            (2 * SERIAL_DATA_REGION_SIZE)
-#define SERIAL_TX_DATA_REGION_SIZE_CLI0            SERIAL_DATA_REGION_SIZE
-#define SERIAL_TX_DATA_REGION_SIZE_CLI1            SERIAL_DATA_REGION_SIZE
-#define SERIAL_TX_DATA_REGION_SIZE_CLI2            SERIAL_DATA_REGION_SIZE
+#define SERIAL_TX_DATA_REGION_CAPACITY_DRIV            (2 * SERIAL_DATA_REGION_CAPACITY)
+#define SERIAL_TX_DATA_REGION_CAPACITY_CLI0            SERIAL_DATA_REGION_CAPACITY
+#define SERIAL_TX_DATA_REGION_CAPACITY_CLI1            SERIAL_DATA_REGION_CAPACITY
+#define SERIAL_TX_DATA_REGION_CAPACITY_CLI2            SERIAL_DATA_REGION_CAPACITY
 
-#define SERIAL_MAX_CLIENT_TX_DATA_SIZE MAX(SERIAL_TX_DATA_REGION_SIZE_CLI2, MAX(SERIAL_TX_DATA_REGION_SIZE_CLI0, SERIAL_TX_DATA_REGION_SIZE_CLI1))
+#define SERIAL_MAX_CLIENT_TX_DATA_CAPACITY MAX(SERIAL_TX_DATA_REGION_CAPACITY_CLI2, MAX(SERIAL_TX_DATA_REGION_CAPACITY_CLI0, SERIAL_TX_DATA_REGION_CAPACITY_CLI1))
 #if SERIAL_WITH_COLOUR
-_Static_assert(SERIAL_TX_DATA_REGION_SIZE_DRIV > SERIAL_MAX_CLIENT_TX_DATA_SIZE,
+_Static_assert(SERIAL_TX_DATA_REGION_CAPACITY_DRIV > SERIAL_MAX_CLIENT_TX_DATA_CAPACITY,
                "Driver TX data region must be larger than all client data regions in SERIAL_WITH_COLOUR mode.");
 #endif
 
-#define SERIAL_MAX_DATA_SIZE MAX(SERIAL_TX_DATA_REGION_SIZE_DRIV, SERIAL_MAX_CLIENT_TX_DATA_SIZE)
-_Static_assert(SERIAL_MAX_DATA_SIZE < UINT32_MAX,
+#define SERIAL_MAX_DATA_CAPACITY MAX(SERIAL_TX_DATA_REGION_CAPACITY_DRIV, SERIAL_MAX_CLIENT_TX_DATA_CAPACITY)
+_Static_assert(SERIAL_MAX_DATA_CAPACITY < UINT32_MAX,
                "Data regions must be smaller than UINT32 max to correctly use queue data structure.");
 
 static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_t *rx_queue_handle,
@@ -56,11 +56,11 @@ static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_
                                              char *rx_data, serial_queue_handle_t *tx_queue_handle, serial_queue_t *tx_queue, char *tx_data)
 {
     if (!sddf_strcmp(pd_name, SERIAL_CLI0_NAME)) {
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, tx_data);
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI0, tx_data);
     } else if (!sddf_strcmp(pd_name, SERIAL_CLI1_NAME)) {
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_CLI1, tx_data);
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI1, tx_data);
     } else if (!sddf_strcmp(pd_name, SERIAL_CLI2_NAME)) {
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_CLI2, tx_data);
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI2, tx_data);
     }
 }
 
@@ -68,12 +68,12 @@ static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle
                                               serial_queue_t *cli_queue, char *cli_data)
 {
     if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
-        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, cli_data);
+        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI0, cli_data);
         serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)((uintptr_t)cli_queue + SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_SIZE_CLI1, cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0);
+                          SERIAL_TX_DATA_REGION_CAPACITY_CLI1, cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0);
         serial_queue_init(&cli_queue_handle[2], (serial_queue_t *)((uintptr_t)cli_queue + 2 * SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_SIZE_CLI2, cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0 +
-                          SERIAL_TX_DATA_REGION_SIZE_CLI1);
+                          SERIAL_TX_DATA_REGION_CAPACITY_CLI2, cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0 +
+                          SERIAL_TX_DATA_REGION_CAPACITY_CLI1);
     }
 }
 

--- a/examples/echo_server/include/serial_config/serial_config.h
+++ b/examples/echo_server/include/serial_config/serial_config.h
@@ -72,8 +72,8 @@ static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle
         serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)((uintptr_t)cli_queue + SERIAL_QUEUE_SIZE),
                           SERIAL_TX_DATA_REGION_CAPACITY_CLI1, cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0);
         serial_queue_init(&cli_queue_handle[2], (serial_queue_t *)((uintptr_t)cli_queue + 2 * SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_CAPACITY_CLI2, cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0 +
-                          SERIAL_TX_DATA_REGION_CAPACITY_CLI1);
+                          SERIAL_TX_DATA_REGION_CAPACITY_CLI2,
+                          cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0 + SERIAL_TX_DATA_REGION_CAPACITY_CLI1);
     }
 }
 

--- a/examples/echo_server/lwip.c
+++ b/examples/echo_server/lwip.c
@@ -38,7 +38,7 @@ serial_queue_t *serial_tx_queue;
 serial_queue_handle_t serial_tx_queue_handle;
 
 #define LWIP_TICK_MS 100
-#define NUM_PBUFFS NET_MAX_CLIENT_QUEUE_SIZE
+#define NUM_PBUFFS NET_MAX_CLIENT_QUEUE_CAPACITY
 
 net_queue_t *rx_free;
 net_queue_t *rx_active;
@@ -289,10 +289,10 @@ void init(void)
     serial_cli_queue_init_sys(microkit_name, NULL, NULL, NULL, &serial_tx_queue_handle, serial_tx_queue, serial_tx_data);
     serial_putchar_init(SERIAL_TX_CH, &serial_tx_queue_handle);
 
-    size_t rx_size, tx_size;
-    net_cli_queue_size(microkit_name, &rx_size, &tx_size);
-    net_queue_init(&state.rx_queue, rx_free, rx_active, rx_size);
-    net_queue_init(&state.tx_queue, tx_free, tx_active, tx_size);
+    size_t rx_capacity, tx_capacity;
+    net_cli_queue_capacity(microkit_name, &rx_capacity, &tx_capacity);
+    net_queue_init(&state.rx_queue, rx_free, rx_active, rx_capacity);
+    net_queue_init(&state.tx_queue, tx_free, tx_active, tx_capacity);
     net_buffers_init(&state.tx_queue, 0);
 
     lwip_init();

--- a/examples/serial/include/serial_config/serial_config.h
+++ b/examples/serial/include/serial_config/serial_config.h
@@ -36,27 +36,27 @@
 #define SERIAL_VIRT_RX_NAME "serial_virt_rx"
 #define SERIAL_VIRT_TX_NAME "serial_virt_tx"
 
-#define SERIAL_QUEUE_SIZE                          0x1000
-#define SERIAL_DATA_REGION_SIZE                    0x2000
+#define SERIAL_QUEUE_SIZE                              0x1000
+#define SERIAL_DATA_REGION_CAPACITY                    0x2000
 
-#define SERIAL_TX_DATA_REGION_SIZE_DRIV            (2 * SERIAL_DATA_REGION_SIZE)
-#define SERIAL_TX_DATA_REGION_SIZE_CLI0            SERIAL_DATA_REGION_SIZE
-#define SERIAL_TX_DATA_REGION_SIZE_CLI1            SERIAL_DATA_REGION_SIZE
+#define SERIAL_TX_DATA_REGION_CAPACITY_DRIV            (2 * SERIAL_DATA_REGION_CAPACITY)
+#define SERIAL_TX_DATA_REGION_CAPACITY_CLI0            SERIAL_DATA_REGION_CAPACITY
+#define SERIAL_TX_DATA_REGION_CAPACITY_CLI1            SERIAL_DATA_REGION_CAPACITY
 
-#define SERIAL_RX_DATA_REGION_SIZE_DRIV            SERIAL_DATA_REGION_SIZE
-#define SERIAL_RX_DATA_REGION_SIZE_CLI0            SERIAL_DATA_REGION_SIZE
-#define SERIAL_RX_DATA_REGION_SIZE_CLI1            SERIAL_DATA_REGION_SIZE
+#define SERIAL_RX_DATA_REGION_CAPACITY_DRIV            SERIAL_DATA_REGION_CAPACITY
+#define SERIAL_RX_DATA_REGION_CAPACITY_CLI0            SERIAL_DATA_REGION_CAPACITY
+#define SERIAL_RX_DATA_REGION_CAPACITY_CLI1            SERIAL_DATA_REGION_CAPACITY
 
-#define SERIAL_MAX_CLIENT_TX_DATA_SIZE MAX(SERIAL_TX_DATA_REGION_SIZE_CLI0, SERIAL_TX_DATA_REGION_SIZE_CLI1)
+#define SERIAL_MAX_CLIENT_TX_DATA_CAPACITY MAX(SERIAL_TX_DATA_REGION_CAPACITY_CLI0, SERIAL_TX_DATA_REGION_CAPACITY_CLI1)
 #if SERIAL_WITH_COLOUR
-_Static_assert(SERIAL_TX_DATA_REGION_SIZE_DRIV > SERIAL_MAX_CLIENT_TX_DATA_SIZE,
+_Static_assert(SERIAL_TX_DATA_REGION_CAPACITY_DRIV > SERIAL_MAX_CLIENT_TX_DATA_CAPACITY,
                "Driver TX data region must be larger than all client data regions in SERIAL_WITH_COLOUR mode.");
 #endif
 
-#define SERIAL_MAX_TX_DATA_SIZE MAX(SERIAL_TX_DATA_REGION_SIZE_DRIV, SERIAL_MAX_CLIENT_TX_DATA_SIZE)
-#define SERIAL_MAX_RX_DATA_SIZE MAX(SERIAL_RX_DATA_REGION_SIZE_DRIV, MAX(SERIAL_RX_DATA_REGION_SIZE_CLI0, SERIAL_RX_DATA_REGION_SIZE_CLI1))
-#define SERIAL_MAX_DATA_SIZE MAX(SERIAL_MAX_TX_DATA_SIZE, SERIAL_MAX_RX_DATA_SIZE)
-_Static_assert(SERIAL_MAX_DATA_SIZE < UINT32_MAX,
+#define SERIAL_MAX_TX_DATA_CAPACITY MAX(SERIAL_TX_DATA_REGION_CAPACITY_DRIV, SERIAL_MAX_CLIENT_TX_DATA_CAPACITY)
+#define SERIAL_MAX_RX_DATA_CAPACITY MAX(SERIAL_RX_DATA_REGION_CAPACITY_DRIV, MAX(SERIAL_RX_DATA_REGION_CAPACITY_CLI0, SERIAL_RX_DATA_REGION_CAPACITY_CLI1))
+#define SERIAL_MAX_DATA_CAPACITY MAX(SERIAL_MAX_TX_DATA_CAPACITY, SERIAL_MAX_RX_DATA_CAPACITY)
+_Static_assert(SERIAL_MAX_DATA_CAPACITY < UINT32_MAX,
                "Data regions must be smaller than UINT32 max to correctly use queue data structure.");
 
 static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_t *rx_queue_handle,
@@ -64,11 +64,11 @@ static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_
                                              char *rx_data, serial_queue_handle_t *tx_queue_handle, serial_queue_t *tx_queue, char *tx_data)
 {
     if (!sddf_strcmp(pd_name, SERIAL_CLI0_NAME)) {
-        serial_queue_init(rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_CLI0, rx_data);
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, tx_data);
+        serial_queue_init(rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_CAPACITY_CLI0, rx_data);
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI0, tx_data);
     } else if (!sddf_strcmp(pd_name, SERIAL_CLI1_NAME)) {
-        serial_queue_init(rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_SIZE_CLI1, rx_data);
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_SIZE_CLI1, tx_data);
+        serial_queue_init(rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_CAPACITY_CLI1, rx_data);
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI1, tx_data);
     }
 }
 
@@ -76,13 +76,13 @@ static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle
                                               serial_queue_t *cli_queue, char *cli_data)
 {
     if (!sddf_strcmp(pd_name, SERIAL_VIRT_RX_NAME)) {
-        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_RX_DATA_REGION_SIZE_CLI0, cli_data);
+        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_RX_DATA_REGION_CAPACITY_CLI0, cli_data);
         serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)((uintptr_t)cli_queue + SERIAL_QUEUE_SIZE),
-                          SERIAL_RX_DATA_REGION_SIZE_CLI1, cli_data + SERIAL_RX_DATA_REGION_SIZE_CLI0);
+                          SERIAL_RX_DATA_REGION_CAPACITY_CLI1, cli_data + SERIAL_RX_DATA_REGION_CAPACITY_CLI0);
     } else if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
-        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_TX_DATA_REGION_SIZE_CLI0, cli_data);
+        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI0, cli_data);
         serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)((uintptr_t)cli_queue + SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_SIZE_CLI1, cli_data + SERIAL_TX_DATA_REGION_SIZE_CLI0);
+                          SERIAL_TX_DATA_REGION_CAPACITY_CLI1, cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0);
     }
 }
 

--- a/include/sddf/serial/queue.h
+++ b/include/sddf/serial/queue.h
@@ -26,7 +26,7 @@ typedef struct serial_queue {
 
 typedef struct serial_queue_handle {
     serial_queue_t *queue;
-    uint32_t size;
+    uint32_t capacity;
     char *data_region;
 } serial_queue_handle_t;
 
@@ -53,7 +53,7 @@ static inline int serial_queue_empty(serial_queue_handle_t *queue_handle, uint32
  */
 static inline int serial_queue_full(serial_queue_handle_t *queue_handle, uint32_t local_tail)
 {
-    return local_tail - queue_handle->queue->head == queue_handle->size;
+    return local_tail - queue_handle->queue->head == queue_handle->capacity;
 }
 
 /**
@@ -73,7 +73,7 @@ static inline int serial_enqueue(serial_queue_handle_t *queue_handle, uint32_t *
         return -1;
     }
 
-    queue_handle->data_region[*local_tail % queue_handle->size] = character;
+    queue_handle->data_region[*local_tail % queue_handle->capacity] = character;
     (*local_tail)++;
 
     return 0;
@@ -96,7 +96,7 @@ static inline int serial_dequeue(serial_queue_handle_t *queue_handle, uint32_t *
         return -1;
     }
 
-    *character = queue_handle->data_region[*local_head % queue_handle->size];
+    *character = queue_handle->data_region[*local_head % queue_handle->capacity];
     (*local_head)++;
 
     return 0;
@@ -114,7 +114,7 @@ static inline void serial_update_visible_tail(serial_queue_handle_t *queue_handl
 {
     uint32_t head = queue_handle->queue->head;
     uint32_t tail = queue_handle->queue->tail;
-    uint32_t max_tail = head + queue_handle->size;
+    uint32_t max_tail = head + queue_handle->capacity;
 
     /* Ensure updates to tail don't overwrite existing data */
     if (head <= tail) {
@@ -124,7 +124,7 @@ static inline void serial_update_visible_tail(serial_queue_handle_t *queue_handl
         assert(local_tail >= tail && local_tail < head);
     }
 
-    /* Ensure updates to tail don't exceed size restraints */
+    /* Ensure updates to tail don't exceed capacity restraints */
     if (head <= max_tail) {
         assert(local_tail <= max_tail);
     } else {
@@ -152,7 +152,7 @@ static inline void serial_update_visible_head(serial_queue_handle_t *queue_handl
     uint32_t head = queue_handle->queue->head;
     uint32_t tail = queue_handle->queue->tail;
 
-    /* Ensure updates to head don't corrupt queue size constraints */
+    /* Ensure updates to head don't corrupt queue capacity constraints */
     if (head <= tail) {
         assert(local_head >= head && local_head <= tail);
     } else {
@@ -189,7 +189,7 @@ static inline uint32_t serial_queue_length(serial_queue_handle_t *queue_handle)
  */
 static inline uint32_t serial_queue_contiguous_length(serial_queue_handle_t *queue_handle)
 {
-    return MIN(queue_handle->size - (queue_handle->queue->head % queue_handle->size), serial_queue_length(queue_handle));
+    return MIN(queue_handle->capacity - (queue_handle->queue->head % queue_handle->capacity), serial_queue_length(queue_handle));
 }
 
 /**
@@ -202,7 +202,7 @@ static inline uint32_t serial_queue_contiguous_length(serial_queue_handle_t *que
  */
 static inline uint32_t serial_queue_free(serial_queue_handle_t *queue_handle)
 {
-    return queue_handle->size - serial_queue_length(queue_handle);
+    return queue_handle->capacity - serial_queue_length(queue_handle);
 }
 
 /**
@@ -215,7 +215,7 @@ static inline uint32_t serial_queue_free(serial_queue_handle_t *queue_handle)
  */
 static inline uint32_t serial_queue_contiguous_free(serial_queue_handle_t *queue_handle)
 {
-    return MIN(queue_handle->size - (queue_handle->queue->tail % queue_handle->size), serial_queue_free(queue_handle));
+    return MIN(queue_handle->capacity - (queue_handle->queue->tail % queue_handle->capacity), serial_queue_free(queue_handle));
 }
 
 /**
@@ -231,7 +231,7 @@ static inline uint32_t serial_enqueue_batch(serial_queue_handle_t *qh,
                                             uint32_t n,
                                             const char *src)
 {
-    char *p = qh->data_region + (qh->queue->tail % qh->size);
+    char *p = qh->data_region + (qh->queue->tail % qh->capacity);
     uint32_t avail = serial_queue_free(qh);
     uint32_t n_prewrap;
     uint32_t n_postwrap;
@@ -270,9 +270,9 @@ static inline void serial_transfer_all(serial_queue_handle_t *active_queue_handl
         uint32_t free = serial_queue_contiguous_free(free_queue_handle);
         uint32_t to_transfer = (active < free) ? active : free;
 
-        sddf_memcpy(free_queue_handle->data_region + (free_queue_handle->queue->tail % free_queue_handle->size),
+        sddf_memcpy(free_queue_handle->data_region + (free_queue_handle->queue->tail % free_queue_handle->capacity),
                     active_queue_handle->data_region + (active_queue_handle->queue->head %
-                                                        active_queue_handle->size), to_transfer);
+                                                        active_queue_handle->capacity), to_transfer);
 
         /* Make copy visible */
         serial_update_visible_tail(free_queue_handle, free_queue_handle->queue->tail + to_transfer);
@@ -308,7 +308,7 @@ static inline void serial_transfer_all_with_colour(serial_queue_handle_t *active
         uint32_t free = serial_queue_contiguous_free(free_queue_handle);
         uint32_t to_transfer = (remaining < free) ? remaining : free;
 
-        sddf_memcpy(free_queue_handle->data_region + (free_queue_handle->queue->tail % free_queue_handle->size),
+        sddf_memcpy(free_queue_handle->data_region + (free_queue_handle->queue->tail % free_queue_handle->capacity),
                     colour_start + colour_transferred, to_transfer);
 
         serial_update_visible_tail(free_queue_handle, free_queue_handle->queue->tail + to_transfer);
@@ -321,9 +321,9 @@ static inline void serial_transfer_all_with_colour(serial_queue_handle_t *active
         uint32_t free = serial_queue_contiguous_free(free_queue_handle);
         uint32_t to_transfer = (active < free) ? active : free;
 
-        sddf_memcpy(free_queue_handle->data_region + (free_queue_handle->queue->tail % free_queue_handle->size),
+        sddf_memcpy(free_queue_handle->data_region + (free_queue_handle->queue->tail % free_queue_handle->capacity),
                     active_queue_handle->data_region + (active_queue_handle->queue->head %
-                                                        active_queue_handle->size), to_transfer);
+                                                        active_queue_handle->capacity), to_transfer);
 
         /* Make copy visible */
         serial_update_visible_tail(free_queue_handle, free_queue_handle->queue->tail + to_transfer);
@@ -336,7 +336,7 @@ static inline void serial_transfer_all_with_colour(serial_queue_handle_t *active
         uint32_t free = serial_queue_contiguous_free(free_queue_handle);
         uint32_t to_transfer = (remaining < free) ? remaining : free;
 
-        sddf_memcpy(free_queue_handle->data_region + (free_queue_handle->queue->tail % free_queue_handle->size),
+        sddf_memcpy(free_queue_handle->data_region + (free_queue_handle->queue->tail % free_queue_handle->capacity),
                     colour_end + colour_transferred, to_transfer);
 
         serial_update_visible_tail(free_queue_handle, free_queue_handle->queue->tail + to_transfer);
@@ -349,14 +349,14 @@ static inline void serial_transfer_all_with_colour(serial_queue_handle_t *active
  *
  * @param queue_handle queue handle to use.
  * @param queue pointer to queue in shared memory.
- * @param size size of the queue.
+ * @param capacity capacity of the queue.
  * @param data_region address of the data region.
  */
 static inline void serial_queue_init(serial_queue_handle_t *queue_handle,
-                                     serial_queue_t *queue, uint32_t size, char *data_region)
+                                     serial_queue_t *queue, uint32_t capacity, char *data_region)
 {
     queue_handle->queue = queue;
-    queue_handle->size = size;
+    queue_handle->capacity = capacity;
     queue_handle->data_region = data_region;
 }
 

--- a/include/sddf/serial/queue.h
+++ b/include/sddf/serial/queue.h
@@ -189,7 +189,8 @@ static inline uint32_t serial_queue_length(serial_queue_handle_t *queue_handle)
  */
 static inline uint32_t serial_queue_contiguous_length(serial_queue_handle_t *queue_handle)
 {
-    return MIN(queue_handle->capacity - (queue_handle->queue->head % queue_handle->capacity), serial_queue_length(queue_handle));
+    return MIN(queue_handle->capacity - (queue_handle->queue->head % queue_handle->capacity),
+               serial_queue_length(queue_handle));
 }
 
 /**
@@ -215,7 +216,8 @@ static inline uint32_t serial_queue_free(serial_queue_handle_t *queue_handle)
  */
 static inline uint32_t serial_queue_contiguous_free(serial_queue_handle_t *queue_handle)
 {
-    return MIN(queue_handle->capacity - (queue_handle->queue->tail % queue_handle->capacity), serial_queue_free(queue_handle));
+    return MIN(queue_handle->capacity - (queue_handle->queue->tail % queue_handle->capacity),
+               serial_queue_free(queue_handle));
 }
 
 /**
@@ -271,8 +273,9 @@ static inline void serial_transfer_all(serial_queue_handle_t *active_queue_handl
         uint32_t to_transfer = (active < free) ? active : free;
 
         sddf_memcpy(free_queue_handle->data_region + (free_queue_handle->queue->tail % free_queue_handle->capacity),
-                    active_queue_handle->data_region + (active_queue_handle->queue->head %
-                                                        active_queue_handle->capacity), to_transfer);
+                    active_queue_handle->data_region
+                        + (active_queue_handle->queue->head % active_queue_handle->capacity),
+                    to_transfer);
 
         /* Make copy visible */
         serial_update_visible_tail(free_queue_handle, free_queue_handle->queue->tail + to_transfer);
@@ -322,8 +325,9 @@ static inline void serial_transfer_all_with_colour(serial_queue_handle_t *active
         uint32_t to_transfer = (active < free) ? active : free;
 
         sddf_memcpy(free_queue_handle->data_region + (free_queue_handle->queue->tail % free_queue_handle->capacity),
-                    active_queue_handle->data_region + (active_queue_handle->queue->head %
-                                                        active_queue_handle->capacity), to_transfer);
+                    active_queue_handle->data_region
+                        + (active_queue_handle->queue->head % active_queue_handle->capacity),
+                    to_transfer);
 
         /* Make copy visible */
         serial_update_visible_tail(free_queue_handle, free_queue_handle->queue->tail + to_transfer);
@@ -352,8 +356,8 @@ static inline void serial_transfer_all_with_colour(serial_queue_handle_t *active
  * @param capacity capacity of the queue.
  * @param data_region address of the data region.
  */
-static inline void serial_queue_init(serial_queue_handle_t *queue_handle,
-                                     serial_queue_t *queue, uint32_t capacity, char *data_region)
+static inline void serial_queue_init(serial_queue_handle_t *queue_handle, serial_queue_t *queue, uint32_t capacity,
+                                     char *data_region)
 {
     queue_handle->queue = queue;
     queue_handle->capacity = capacity;

--- a/network/components/copy.c
+++ b/network/components/copy.c
@@ -36,7 +36,7 @@ void rx_return(void)
             int err = net_dequeue_free(&rx_queue_cli, &cli_buffer);
             assert(!err);
 
-            if (cli_buffer.io_or_offset % NET_BUFFER_SIZE || cli_buffer.io_or_offset >= NET_BUFFER_SIZE * rx_queue_cli.size) {
+            if (cli_buffer.io_or_offset % NET_BUFFER_SIZE || cli_buffer.io_or_offset >= NET_BUFFER_SIZE * rx_queue_cli.capacity) {
                 sddf_dprintf("COPY|LOG: Client provided offset %lx which is not buffer aligned or outside of buffer region\n",
                              cli_buffer.io_or_offset);
                 continue;
@@ -97,12 +97,12 @@ void notified(microkit_channel ch)
 
 void init(void)
 {
-    size_t cli_queue_size, virt_queue_size = 0;
-    net_copy_queue_size(microkit_name, &cli_queue_size, &virt_queue_size);
+    size_t cli_queue_capacity, virt_queue_capacity = 0;
+    net_copy_queue_capacity(microkit_name, &cli_queue_capacity, &virt_queue_capacity);
 
     /* Set up the queues */
-    net_queue_init(&rx_queue_cli, rx_free_cli, rx_active_cli, cli_queue_size);
-    net_queue_init(&rx_queue_virt, rx_free_virt, rx_active_virt, virt_queue_size);
+    net_queue_init(&rx_queue_cli, rx_free_cli, rx_active_cli, cli_queue_capacity);
+    net_queue_init(&rx_queue_virt, rx_free_virt, rx_active_virt, virt_queue_capacity);
 
     net_buffers_init(&rx_queue_cli, 0);
 }

--- a/network/components/copy.c
+++ b/network/components/copy.c
@@ -36,7 +36,8 @@ void rx_return(void)
             int err = net_dequeue_free(&rx_queue_cli, &cli_buffer);
             assert(!err);
 
-            if (cli_buffer.io_or_offset % NET_BUFFER_SIZE || cli_buffer.io_or_offset >= NET_BUFFER_SIZE * rx_queue_cli.capacity) {
+            if (cli_buffer.io_or_offset % NET_BUFFER_SIZE
+                || cli_buffer.io_or_offset >= NET_BUFFER_SIZE * rx_queue_cli.capacity) {
                 sddf_dprintf("COPY|LOG: Client provided offset %lx which is not buffer aligned or outside of buffer region\n",
                              cli_buffer.io_or_offset);
                 continue;

--- a/network/components/virt_rx.c
+++ b/network/components/virt_rx.c
@@ -35,7 +35,7 @@ uintptr_t buffer_data_paddr;
 /* In order to handle broadcast packets where the same buffer is given to multiple clients
   * we keep track of a reference count of each buffer and only hand it back to the driver once
   * all clients have returned the buffer. */
-uint32_t buffer_refs[NET_RX_QUEUE_SIZE_DRIV] = {0};
+uint32_t buffer_refs[NET_RX_QUEUE_CAPACITY_DRIV] = {0};
 
 typedef struct state {
     net_queue_handle_t rx_queue_drv;
@@ -157,7 +157,7 @@ void rx_provide(void)
                 int err = net_dequeue_free(&state.rx_queue_clients[client], &buffer);
                 assert(!err);
                 assert(!(buffer.io_or_offset % NET_BUFFER_SIZE) &&
-                       (buffer.io_or_offset < NET_BUFFER_SIZE * state.rx_queue_clients[client].size));
+                       (buffer.io_or_offset < NET_BUFFER_SIZE * state.rx_queue_clients[client].capacity));
 
                 int ref_index = buffer.io_or_offset / NET_BUFFER_SIZE;
                 assert(buffer_refs[ref_index] != 0);
@@ -213,11 +213,11 @@ void init(void)
     for (int i = 0; i < NUM_NETWORK_CLIENTS; i++) {
         net_set_mac_addr((uint8_t *) &state.mac_addrs[i], macs[i]);
         net_queue_init(&state.rx_queue_clients[i], queue_info[i].free, queue_info[i].active,
-                       queue_info[i].size);
+                       queue_info[i].capacity);
     }
 
     /* Set up driver queues */
-    net_queue_init(&state.rx_queue_drv, rx_free_drv, rx_active_drv, NET_RX_QUEUE_SIZE_DRIV);
+    net_queue_init(&state.rx_queue_drv, rx_free_drv, rx_active_drv, NET_RX_QUEUE_CAPACITY_DRIV);
     net_buffers_init(&state.rx_queue_drv, buffer_data_paddr);
 
     if (net_require_signal_free(&state.rx_queue_drv)) {

--- a/network/components/virt_rx.c
+++ b/network/components/virt_rx.c
@@ -35,7 +35,7 @@ uintptr_t buffer_data_paddr;
 /* In order to handle broadcast packets where the same buffer is given to multiple clients
   * we keep track of a reference count of each buffer and only hand it back to the driver once
   * all clients have returned the buffer. */
-uint32_t buffer_refs[NET_RX_QUEUE_CAPACITY_DRIV] = {0};
+uint32_t buffer_refs[NET_RX_QUEUE_CAPACITY_DRIV] = { 0 };
 
 typedef struct state {
     net_queue_handle_t rx_queue_drv;
@@ -156,8 +156,8 @@ void rx_provide(void)
                 net_buff_desc_t buffer;
                 int err = net_dequeue_free(&state.rx_queue_clients[client], &buffer);
                 assert(!err);
-                assert(!(buffer.io_or_offset % NET_BUFFER_SIZE) &&
-                       (buffer.io_or_offset < NET_BUFFER_SIZE * state.rx_queue_clients[client].capacity));
+                assert(!(buffer.io_or_offset % NET_BUFFER_SIZE)
+                       && (buffer.io_or_offset < NET_BUFFER_SIZE * state.rx_queue_clients[client].capacity));
 
                 int ref_index = buffer.io_or_offset / NET_BUFFER_SIZE;
                 assert(buffer_refs[ref_index] != 0);
@@ -212,8 +212,7 @@ void init(void)
     /* Set up client queues */
     for (int i = 0; i < NUM_NETWORK_CLIENTS; i++) {
         net_set_mac_addr((uint8_t *) &state.mac_addrs[i], macs[i]);
-        net_queue_init(&state.rx_queue_clients[i], queue_info[i].free, queue_info[i].active,
-                       queue_info[i].capacity);
+        net_queue_init(&state.rx_queue_clients[i], queue_info[i].free, queue_info[i].active, queue_info[i].capacity);
     }
 
     /* Set up driver queues */

--- a/network/components/virt_tx.c
+++ b/network/components/virt_tx.c
@@ -34,8 +34,8 @@ state_t state;
 int extract_offset(uintptr_t *phys)
 {
     for (int client = 0; client < NUM_NETWORK_CLIENTS; client++) {
-        if (*phys >= state.buffer_region_paddrs[client] &&
-            *phys < state.buffer_region_paddrs[client] + state.tx_queue_clients[client].capacity * NET_BUFFER_SIZE) {
+        if (*phys >= state.buffer_region_paddrs[client]
+            && *phys < state.buffer_region_paddrs[client] + state.tx_queue_clients[client].capacity * NET_BUFFER_SIZE) {
             *phys = *phys - state.buffer_region_paddrs[client];
             return client;
         }
@@ -54,8 +54,8 @@ void tx_provide(void)
                 int err = net_dequeue_active(&state.tx_queue_clients[client], &buffer);
                 assert(!err);
 
-                if (buffer.io_or_offset % NET_BUFFER_SIZE ||
-                    buffer.io_or_offset >= NET_BUFFER_SIZE * state.tx_queue_clients[client].capacity) {
+                if (buffer.io_or_offset % NET_BUFFER_SIZE
+                    || buffer.io_or_offset >= NET_BUFFER_SIZE * state.tx_queue_clients[client].capacity) {
                     sddf_dprintf("VIRT_TX|LOG: Client provided offset %lx which is not buffer aligned or outside of buffer region\n",
                                  buffer.io_or_offset);
                     err = net_enqueue_free(&state.tx_queue_clients[client], buffer);
@@ -141,8 +141,7 @@ void init(void)
     net_mem_region_vaddr(microkit_name, client_vaddrs, buffer_data_region_cli0_vaddr);
 
     for (int i = 0; i < NUM_NETWORK_CLIENTS; i++) {
-        net_queue_init(&state.tx_queue_clients[i], queue_info[i].free, queue_info[i].active,
-                       queue_info[i].capacity);
+        net_queue_init(&state.tx_queue_clients[i], queue_info[i].free, queue_info[i].active, queue_info[i].capacity);
         state.buffer_region_vaddrs[i] = client_vaddrs[i];
     }
 

--- a/serial/components/virt_rx.c
+++ b/serial/components/virt_rx.c
@@ -128,7 +128,7 @@ void rx_return(void)
 
 void init(void)
 {
-    serial_queue_init(&rx_queue_handle_drv, rx_queue_drv, SERIAL_RX_DATA_REGION_SIZE_DRIV, rx_data_drv);
+    serial_queue_init(&rx_queue_handle_drv, rx_queue_drv, SERIAL_RX_DATA_REGION_CAPACITY_DRIV, rx_data_drv);
     serial_virt_queue_init_sys(microkit_name, rx_queue_handle_cli, rx_queue_cli0, rx_data_cli0);
 }
 

--- a/serial/components/virt_tx.c
+++ b/serial/components/virt_tx.c
@@ -203,7 +203,7 @@ void tx_provide(microkit_channel ch)
 
 void init(void)
 {
-    serial_queue_init(&tx_queue_handle_drv, tx_queue_drv, SERIAL_TX_DATA_REGION_SIZE_DRIV, tx_data_drv);
+    serial_queue_init(&tx_queue_handle_drv, tx_queue_drv, SERIAL_TX_DATA_REGION_CAPACITY_DRIV, tx_data_drv);
     serial_virt_queue_init_sys(microkit_name, tx_queue_handle_cli, tx_queue_cli0, tx_data_cli0);
 
 #if !SERIAL_TX_ONLY


### PR DESCRIPTION
This PR removes the use of "size" from describing how many entries a queue has. To describe the maximum number of entries that a queue can hold, the word "capacity" is now used. To describe the number of entries a queue currently has, the word "length" is used. Size is still used to describe how large a data region is. 

This PR makes this change for both the serial and networking subsystems. This fixes issue (https://github.com/au-ts/sddf/issues/140) for these subsystems. 