### PR TITLE
Add missing comma to colours list is serial tx virt

### DIFF
--- a/serial/components/virt_tx.c
+++ b/serial/components/virt_tx.c
@@ -32,7 +32,7 @@ const char *colours[] = {
     /* foreground blue */
     "\x1b[34m",
     /* foreground magenta */
-    "\x1b[35m"
+    "\x1b[35m",
     /* foreground cyan */
     "\x1b[36m"
 };


### PR DESCRIPTION
This fixes an accidental typo in the list of colours for the serial tx virt that was unfortunately not caught during testing as we didn't use enough clients.