### PR TITLE
Use the entire capacity of the net queue

### DIFF
--- a/include/sddf/network/queue.h
+++ b/include/sddf/network/queue.h
@@ -85,7 +85,7 @@ static inline bool net_queue_empty_active(net_queue_handle_t *queue)
  */
 static inline bool net_queue_full_free(net_queue_handle_t *queue)
 {
-    return queue->free->tail + 1 - queue->free->head == queue->capacity;
+    return queue->free->tail - queue->free->head == queue->capacity;
 }
 
 /**
@@ -97,7 +97,7 @@ static inline bool net_queue_full_free(net_queue_handle_t *queue)
  */
 static inline bool net_queue_full_active(net_queue_handle_t *queue)
 {
-    return queue->active->tail + 1 - queue->active->head == queue->capacity;
+    return queue->active->tail - queue->active->head == queue->capacity;
 }
 
 /**
@@ -215,7 +215,7 @@ static inline void net_queue_init(net_queue_handle_t *queue, net_queue_t *free, 
  */
 static inline void net_buffers_init(net_queue_handle_t *queue, uintptr_t base_addr)
 {
-    for (uint32_t i = 0; i < queue->capacity - 1; i++) {
+    for (uint32_t i = 0; i < queue->capacity; i++) {
         net_buff_desc_t buffer = {(NET_BUFFER_SIZE * i) + base_addr, 0};
         int err = net_enqueue_free(queue, buffer);
         assert(!err);


### PR DESCRIPTION
This PR modifies the network queue library to use the entire capacity of the queue, rather than keeping one entry empty. 

Originally, the `head` and `tail` indices where kept modulo the `capacity` of the queue, so we could not use all entries of the queue as if `head == tail` then we could not distinguish between empty and full.

The indices are no longer kept modulo the capacity, therefore we can now use the entire capacity of the queue as empty and full can be distinguished by `tail - head` (0 meaning empty, capacity meaning full).