### PR TITLE
Update ethernet driver HW rings

### DIFF
--- a/drivers/network/imx/ethernet.c
+++ b/drivers/network/imx/ethernet.c
@@ -19,6 +19,7 @@ __attribute__((__section__(".device_resources"))) device_resources_t device_reso
 
 __attribute__((__section__(".net_driver_config"))) net_driver_config_t config;
 
+/* HW ring capacity must be a power of 2 */
 #define RX_COUNT 256
 #define TX_COUNT 256
 #define MAX_COUNT MAX(RX_COUNT, TX_COUNT)
@@ -32,10 +33,11 @@ struct descriptor {
 
 /* HW ring buffer data type */
 typedef struct {
-    unsigned int tail; /* index to insert at */
-    unsigned int head; /* index to remove from */
+    uint32_t tail; /* index to insert at */
+    uint32_t head; /* index to remove from */
+    uint32_t capacity; /* capacity of the ring */
+    volatile struct descriptor *descr; /* buffer descriptor array */
     net_buff_desc_t descr_mdata[MAX_COUNT]; /* associated meta data array */
-    volatile struct descriptor *descr; /* buffer descripter array */
 } hw_ring_t;
 
 hw_ring_t rx; /* Rx NIC ring */
@@ -48,14 +50,14 @@ net_queue_handle_t tx_queue;
 
 volatile struct enet_regs *eth;
 
-static inline bool hw_ring_full(hw_ring_t *ring, size_t ring_capacity)
+static inline bool hw_ring_full(hw_ring_t *ring)
 {
-    return !((ring->tail - ring->head + 1) % ring_capacity);
+    return ring->tail - ring->head == ring->capacity;
 }
 
-static inline bool hw_ring_empty(hw_ring_t *ring, size_t ring_capacity)
+static inline bool hw_ring_empty(hw_ring_t *ring)
 {
-    return !((ring->tail - ring->head) % ring_capacity);
+    return ring->tail - ring->head == 0;
 }
 
 static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys,
@@ -68,7 +70,7 @@ static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys,
     /* Ensure all writes to the descriptor complete, before we set the flags
      * that makes hardware aware of this slot.
      */
-    __sync_synchronize();
+    THREAD_MEMORY_RELEASE();
     d->stat = stat;
 }
 
@@ -76,30 +78,31 @@ static void rx_provide(void)
 {
     bool reprocess = true;
     while (reprocess) {
-        while (!hw_ring_full(&rx, RX_COUNT) && !net_queue_empty_free(&rx_queue)) {
+        while (!hw_ring_full(&rx) && !net_queue_empty_free(&rx_queue)) {
             net_buff_desc_t buffer;
             int err = net_dequeue_free(&rx_queue, &buffer);
             assert(!err);
 
+            uint32_t idx = rx.tail % rx.capacity;
             uint16_t stat = RXD_EMPTY;
-            if (rx.tail + 1 == RX_COUNT) {
+            if (idx + 1 == rx.capacity) {
                 stat |= WRAP;
             }
-            rx.descr_mdata[rx.tail] = buffer;
-            update_ring_slot(&rx, rx.tail, buffer.io_or_offset, 0, stat);
-            rx.tail = (rx.tail + 1) % RX_COUNT;
+            rx.descr_mdata[idx] = buffer;
+            update_ring_slot(&rx, idx, buffer.io_or_offset, 0, stat);
+            rx.tail++;
             eth->rdar = RDAR_RDAR;
         }
 
         /* Only request a notification from virtualiser if HW ring not full */
-        if (!hw_ring_full(&rx, RX_COUNT)) {
+        if (!hw_ring_full(&rx)) {
             net_request_signal_free(&rx_queue);
         } else {
             net_cancel_signal_free(&rx_queue);
         }
         reprocess = false;
 
-        if (!net_queue_empty_free(&rx_queue) && !hw_ring_full(&rx, RX_COUNT)) {
+        if (!net_queue_empty_free(&rx_queue) && !hw_ring_full(&rx)) {
             net_cancel_signal_free(&rx_queue);
             reprocess = true;
         }
@@ -109,20 +112,23 @@ static void rx_provide(void)
 static void rx_return(void)
 {
     bool packets_transferred = false;
-    while (!hw_ring_empty(&rx, RX_COUNT)) {
+    while (!hw_ring_empty(&rx)) {
         /* If buffer slot is still empty, we have processed all packets the device has filled */
-        volatile struct descriptor *d = &(rx.descr[rx.head]);
+        uint32_t idx = rx.head % rx.capacity;
+        volatile struct descriptor *d = &(rx.descr[idx]);
         if (d->stat & RXD_EMPTY) {
             break;
         }
 
-        net_buff_desc_t buffer = rx.descr_mdata[rx.head];
+        THREAD_MEMORY_ACQUIRE();
+
+        net_buff_desc_t buffer = rx.descr_mdata[idx];
         buffer.len = d->len;
         int err = net_enqueue_active(&rx_queue, buffer);
         assert(!err);
 
         packets_transferred = true;
-        rx.head = (rx.head + 1) % RX_COUNT;
+        rx.head++;
     }
 
     if (packets_transferred && net_require_signal_active(&rx_queue)) {
@@ -135,26 +141,26 @@ static void tx_provide(void)
 {
     bool reprocess = true;
     while (reprocess) {
-        while (!(hw_ring_full(&tx, TX_COUNT)) && !net_queue_empty_active(&tx_queue)) {
+        while (!(hw_ring_full(&tx)) && !net_queue_empty_active(&tx_queue)) {
             net_buff_desc_t buffer;
             int err = net_dequeue_active(&tx_queue, &buffer);
             assert(!err);
 
+            uint32_t idx = tx.tail % tx.capacity;
             uint16_t stat = TXD_READY | TXD_ADDCRC | TXD_LAST;
-            if (tx.tail + 1 == TX_COUNT) {
+            if (idx + 1 == tx.capacity) {
                 stat |= WRAP;
             }
-            tx.descr_mdata[tx.tail] = buffer;
-            update_ring_slot(&tx, tx.tail, buffer.io_or_offset, buffer.len, stat);
-
-            tx.tail = (tx.tail + 1) % TX_COUNT;
+            tx.descr_mdata[idx] = buffer;
+            update_ring_slot(&tx, idx, buffer.io_or_offset, buffer.len, stat);
+            tx.tail++;
             eth->tdar = TDAR_TDAR;
         }
 
         net_request_signal_active(&tx_queue);
         reprocess = false;
 
-        if (!hw_ring_full(&tx, TX_COUNT) && !net_queue_empty_active(&tx_queue)) {
+        if (!hw_ring_full(&tx) && !net_queue_empty_active(&tx_queue)) {
             net_cancel_signal_active(&tx_queue);
             reprocess = true;
         }
@@ -164,21 +170,23 @@ static void tx_provide(void)
 static void tx_return(void)
 {
     bool enqueued = false;
-    while (!hw_ring_empty(&tx, TX_COUNT)) {
+    while (!hw_ring_empty(&tx)) {
         /* Ensure that this buffer has been sent by the device */
-        volatile struct descriptor *d = &(tx.descr[tx.head]);
+        uint32_t idx = tx.head % tx.capacity;
+        volatile struct descriptor *d = &(tx.descr[idx]);
         if (d->stat & TXD_READY) {
             break;
         }
 
-        net_buff_desc_t buffer = tx.descr_mdata[tx.head];
+        THREAD_MEMORY_ACQUIRE();
+
+        net_buff_desc_t buffer = tx.descr_mdata[idx];
         buffer.len = 0;
-
-        tx.head = (tx.head + 1) % TX_COUNT;
-
         int err = net_enqueue_free(&tx_queue, buffer);
         assert(!err);
+
         enqueued = true;
+        tx.head++;
     }
 
     if (enqueued && net_require_signal_free(&tx_queue)) {
@@ -219,6 +227,8 @@ static void eth_setup(void)
     /* Set up HW rings */
     rx.descr = (volatile struct descriptor *)device_resources.regions[1].region.vaddr;
     tx.descr = (volatile struct descriptor *)device_resources.regions[2].region.vaddr;
+    rx.capacity = RX_COUNT;
+    tx.capacity = TX_COUNT;
 
     /* Perform reset */
     eth->ecr = ECR_RESET;
@@ -261,7 +271,7 @@ static void eth_setup(void)
     eth->tipg = TIPG;
     /* Transmit FIFO Watermark register - store and forward */
     eth->tfwr = STRFWD;
-    /* clear rx store and forward. This must be done for hardware csums*/
+    /* clear rx store and forward. This must be done for hardware csums */
     eth->rsfl = 0;
     /* Do not forward frames with errors + check the csum */
     eth->racc = RACC_LINEDIS | RACC_IPDIS | RACC_PRODIS;

--- a/drivers/network/meson/ethernet.c
+++ b/drivers/network/meson/ethernet.c
@@ -19,6 +19,7 @@ __attribute__((__section__(".device_resources"))) device_resources_t device_reso
 
 __attribute__((__section__(".net_driver_config"))) net_driver_config_t config;
 
+/* HW ring capacity must be a power of 2 */
 #define RX_COUNT 256
 #define TX_COUNT 256
 #define MAX_COUNT MAX(RX_COUNT, TX_COUNT)
@@ -34,10 +35,11 @@ struct descriptor {
 };
 
 typedef struct {
-    unsigned int tail; /* index to insert at */
-    unsigned int head; /* index to remove from */
+    uint32_t tail; /* index to insert at */
+    uint32_t head; /* index to remove from */
+    uint32_t capacity; /* capacity of the ring */
+    volatile struct descriptor *descr; /* buffer descriptor array */
     net_buff_desc_t descr_mdata[MAX_COUNT]; /* associated meta data array */
-    volatile struct descriptor *descr; /* buffer descripter array */
 } hw_ring_t;
 
 hw_ring_t rx;
@@ -49,14 +51,14 @@ net_queue_handle_t tx_queue;
 volatile struct eth_mac_regs *eth_mac;
 volatile struct eth_dma_regs *eth_dma;
 
-static inline bool hw_ring_full(hw_ring_t *ring, size_t ring_capacity)
+static inline bool hw_ring_full(hw_ring_t *ring)
 {
-    return !((ring->tail + 2 - ring->head) % ring_capacity);
+    return ring->tail - ring->head == ring->capacity;
 }
 
-static inline bool hw_ring_empty(hw_ring_t *ring, size_t ring_capacity)
+static inline bool hw_ring_empty(hw_ring_t *ring)
 {
-    return !((ring->tail - ring->head) % ring_capacity);
+    return ring->tail - ring->head == 0;
 }
 
 static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uint32_t status,
@@ -77,27 +79,28 @@ static void rx_provide()
 {
     bool reprocess = true;
     while (reprocess) {
-        while (!hw_ring_full(&rx, RX_COUNT) && !net_queue_empty_free(&rx_queue)) {
+        while (!hw_ring_full(&rx) && !net_queue_empty_free(&rx_queue)) {
             net_buff_desc_t buffer;
             int err = net_dequeue_free(&rx_queue, &buffer);
             assert(!err);
 
+            uint32_t idx = rx.tail % rx.capacity;
             uint32_t cntl = (MAX_RX_FRAME_SZ << DESC_RXCTRL_SIZE1SHFT) & DESC_RXCTRL_SIZE1MASK;
-            if (rx.tail + 1 == RX_COUNT) {
+            if (idx + 1 == rx.capacity) {
                 cntl |= DESC_RXCTRL_RXRINGEND;
             }
 
-            rx.descr_mdata[rx.tail] = buffer;
-            update_ring_slot(&rx, rx.tail, DESC_RXSTS_OWNBYDMA, cntl, buffer.io_or_offset, 0);
+            rx.descr_mdata[idx] = buffer;
+            update_ring_slot(&rx, idx, DESC_RXSTS_OWNBYDMA, cntl, buffer.io_or_offset, 0);
             eth_dma->rxpolldemand = POLL_DATA;
 
-            rx.tail = (rx.tail + 1) % RX_COUNT;
+            rx.tail++;
         }
 
         net_request_signal_free(&rx_queue);
         reprocess = false;
 
-        if (!net_queue_empty_free(&rx_queue) && !hw_ring_full(&rx, RX_COUNT)) {
+        if (!net_queue_empty_free(&rx_queue) && !hw_ring_full(&rx)) {
             net_cancel_signal_free(&rx_queue);
             reprocess = true;
         }
@@ -107,33 +110,36 @@ static void rx_provide()
 static void rx_return(void)
 {
     bool packets_transferred = false;
-    while (!hw_ring_empty(&rx, RX_COUNT)) {
+    while (!hw_ring_empty(&rx)) {
         /* If buffer slot is still empty, we have processed all packets the device has filled */
-        volatile struct descriptor *d = &(rx.descr[rx.head]);
+        uint32_t idx = rx.head % rx.capacity;
+        volatile struct descriptor *d = &(rx.descr[idx]);
         if (d->status & DESC_RXSTS_OWNBYDMA) {
             break;
         }
-        net_buff_desc_t buffer = rx.descr_mdata[rx.head];
+
         THREAD_MEMORY_ACQUIRE();
 
+        net_buff_desc_t buffer = rx.descr_mdata[idx];
         if (d->status & DESC_RXSTS_ERROR) {
             sddf_dprintf("ETH|ERROR: RX descriptor returned with error status %x\n", d->status);
+            idx = rx.tail % rx.capacity;
             uint32_t cntl = (MAX_RX_FRAME_SZ << DESC_RXCTRL_SIZE1SHFT) & DESC_RXCTRL_SIZE1MASK;
-            if (rx.tail + 1 == RX_COUNT) {
+            if (idx + 1 == rx.capacity) {
                 cntl |= DESC_RXCTRL_RXRINGEND;
             }
 
-            rx.descr_mdata[rx.tail] = buffer;
-            update_ring_slot(&rx, rx.tail, DESC_RXSTS_OWNBYDMA, cntl, buffer.io_or_offset, 0);
+            rx.descr_mdata[idx] = buffer;
+            update_ring_slot(&rx, idx, DESC_RXSTS_OWNBYDMA, cntl, buffer.io_or_offset, 0);
             eth_dma->rxpolldemand = POLL_DATA;
-            rx.tail = (rx.tail + 1) % RX_COUNT;
+            rx.tail++;
         } else {
             buffer.len = (d->status & DESC_RXSTS_LENMSK) >> DESC_RXSTS_LENSHFT;
             int err = net_enqueue_active(&rx_queue, buffer);
             assert(!err);
             packets_transferred = true;
         }
-        rx.head = (rx.head + 1) % RX_COUNT;
+        rx.head++;
     }
 
     if (packets_transferred && net_require_signal_active(&rx_queue)) {
@@ -146,26 +152,27 @@ static void tx_provide(void)
 {
     bool reprocess = true;
     while (reprocess) {
-        while (!(hw_ring_full(&tx, TX_COUNT)) && !net_queue_empty_active(&tx_queue)) {
+        while (!(hw_ring_full(&tx)) && !net_queue_empty_active(&tx_queue)) {
             net_buff_desc_t buffer;
             int err = net_dequeue_active(&tx_queue, &buffer);
             assert(!err);
 
+            uint32_t idx = tx.tail % tx.capacity;
             uint32_t cntl = (((uint32_t) buffer.len) << DESC_TXCTRL_SIZE1SHFT) & DESC_TXCTRL_SIZE1MASK;
             cntl |= DESC_TXCTRL_TXLAST | DESC_TXCTRL_TXFIRST | DESC_TXCTRL_TXINT;
-            if (tx.tail + 1 == TX_COUNT) {
+            if (idx + 1 == tx.capacity) {
                 cntl |= DESC_TXCTRL_TXRINGEND;
             }
-            tx.descr_mdata[tx.tail] = buffer;
-            update_ring_slot(&tx, tx.tail, DESC_TXSTS_OWNBYDMA, cntl, buffer.io_or_offset, 0);
+            tx.descr_mdata[idx] = buffer;
+            update_ring_slot(&tx, idx, DESC_TXSTS_OWNBYDMA, cntl, buffer.io_or_offset, 0);
 
-            tx.tail = (tx.tail + 1) % TX_COUNT;
+            tx.tail++;
         }
 
         net_request_signal_active(&tx_queue);
         reprocess = false;
 
-        if (!hw_ring_full(&tx, TX_COUNT) && !net_queue_empty_active(&tx_queue)) {
+        if (!hw_ring_full(&tx) && !net_queue_empty_active(&tx_queue)) {
             net_cancel_signal_active(&tx_queue);
             reprocess = true;
         }
@@ -176,19 +183,21 @@ static void tx_provide(void)
 static void tx_return(void)
 {
     bool enqueued = false;
-    while (!hw_ring_empty(&tx, TX_COUNT)) {
+    while (!hw_ring_empty(&tx)) {
         /* Ensure that this buffer has been sent by the device */
-        volatile struct descriptor *d = &(tx.descr[tx.head]);
+        uint32_t idx = tx.head % tx.capacity;
+        volatile struct descriptor *d = &(tx.descr[idx]);
         if (d->status & DESC_TXSTS_OWNBYDMA) {
             break;
         }
-        net_buff_desc_t buffer = tx.descr_mdata[tx.head];
+
         THREAD_MEMORY_ACQUIRE();
 
+        net_buff_desc_t buffer = tx.descr_mdata[idx];
         int err = net_enqueue_free(&tx_queue, buffer);
         assert(!err);
         enqueued = true;
-        tx.head = (tx.head + 1) % TX_COUNT;
+        tx.head++;
     }
 
     if (enqueued && net_require_signal_free(&tx_queue)) {
@@ -232,6 +241,8 @@ static void eth_setup(void)
 
     rx.descr = (volatile struct descriptor *)device_resources.regions[1].region.vaddr;
     tx.descr = (volatile struct descriptor *)device_resources.regions[2].region.vaddr;
+    rx.capacity = RX_COUNT;
+    tx.capacity = TX_COUNT;
 
     /* Perform reset */
     eth_dma->busmode |= DMAMAC_SWRST;


### PR DESCRIPTION
This PR updates the ethernet driver HW rings to comply with sDDF queue conventions. Changes are:

1. Use overflowing unsigneds for head and tail indices (rather than keeping indices modulo ring capacity).
2. Use the entire capacity of the HW rings (rather than keeping 1-2 entries as guard entries which was previously required before changing 1).
3. Keep ring capacity as an element in the HW ring struct. Prior to this PR, it was used as a macro throughout the code, and required as a function parameter to queue functions which already took the queue data structure as a parameter.
4. Correct the memory barriers when reading from and writing to the ring DMA region. This involved the addition of two acquire fences to prevent re-orderings before reading, and the relaxing of a full memory barrier to a release barrier when adding an entry to the ring (writing).

Note that this PR is based off https://github.com/au-ts/sddf/pull/253, and should be merged secondary to that.