### PR TITLE
Rework serial config files

### DIFF
--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -93,7 +93,8 @@ static void benchmark_print_IPC_data(uint64_t *buffer, uint32_t id)
         number_schedules = buffer[BENCHMARK_TCB_NUMBER_SCHEDULES];
         kernel = buffer[BENCHMARK_TCB_KERNEL_UTILISATION];
         entries = buffer[BENCHMARK_TCB_NUMBER_KERNEL_ENTRIES];
-        sddf_printf("Utilisation details for PD: %s (%x)\n", pd_id_to_name(id), id);
+        sddf_printf("Utilisation details for PD: %s (%x)\n", 
+                    pd_id_to_name(id), id);
     }
     sddf_printf("{\nKernelUtilisation: %lx\nKernelEntries: "
                 "%lx\nNumberSchedules: %lx\nTotalUtilisation: %lx\n}\n",
@@ -105,7 +106,6 @@ static void benchmark_stop_core()
     seL4_BenchmarkFinalizeLog();
     seL4_BenchmarkGetThreadUtilisation(TCB_CAP);
     benchmark_print_IPC_data((uint64_t *)&seL4_GetIPCBuffer()->msg[0], TOTAL_ID);
-
     for (uint32_t id = 1; id < core_config.max_core_id + 1; id++) {
         if (core_config.core_bitmap & (1 << id)) {
             seL4_BenchmarkGetThreadUtilisation(BASE_TCB_CAP + id);
@@ -219,7 +219,8 @@ void notified(microkit_channel ch)
 
 void init(void)
 {
-    serial_cli_queue_init_sys(microkit_name, NULL, NULL, NULL, &serial_tx_queue_handle, serial_tx_queue,
+    serial_cli_queue_init_sys(microkit_name, NULL, NULL, NULL,
+                              &serial_tx_queue_handle, serial_tx_queue,
                               serial_tx_data);
     serial_putchar_init(SERIAL_TX_CH, &serial_tx_queue_handle);
 
@@ -262,18 +263,20 @@ seL4_Bool fault(microkit_child id, microkit_msginfo msginfo, microkit_msginfo *r
     sddf_printf("BENCH|LOG: Faulting PD %s (%x)\n", pd_id_to_name(id), id);
 
     seL4_UserContext regs;
-    seL4_TCB_ReadRegisters(BASE_TCB_CAP + id, false, 0, sizeof(seL4_UserContext) / sizeof(seL4_Word), &regs);
+    seL4_TCB_ReadRegisters(BASE_TCB_CAP + id, false, 0,
+                           sizeof(seL4_UserContext) / sizeof(seL4_Word), &regs);
     sddf_printf("Registers: \npc : %lx\nspsr : %lx\nx0 : %lx\nx1 : %lx\n"
                 "x2 : %lx\nx3 : %lx\nx4 : %lx\nx5 : %lx\nx6 : %lx\nx7 : %lx\n",
-                regs.pc, regs.spsr, regs.x0, regs.x1, regs.x2, regs.x3, regs.x4, regs.x5, regs.x6, regs.x7);
+                regs.pc, regs.spsr, regs.x0, regs.x1, regs.x2, regs.x3,
+                regs.x4, regs.x5, regs.x6, regs.x7);
 
     switch (microkit_msginfo_get_label(msginfo)) {
     case seL4_Fault_CapFault: {
         uint64_t ip = seL4_GetMR(seL4_CapFault_IP);
         uint64_t fault_addr = seL4_GetMR(seL4_CapFault_Addr);
         uint64_t in_recv_phase = seL4_GetMR(seL4_CapFault_InRecvPhase);
-        sddf_printf("CapFault: ip=%lx  fault_addr=%lx  in_recv_phase=%s\n", ip, fault_addr,
-                    (in_recv_phase == 0 ? "false" : "true"));
+        sddf_printf("CapFault: ip=%lx  fault_addr=%lx  in_recv_phase=%s\n",
+                    ip, fault_addr, (in_recv_phase == 0 ? "false" : "true"));
         break;
     }
     case seL4_Fault_UserException: {
@@ -285,7 +288,8 @@ seL4_Bool fault(microkit_child id, microkit_msginfo msginfo, microkit_msginfo *r
         uint64_t fault_addr = seL4_GetMR(seL4_VMFault_Addr);
         uint64_t is_instruction = seL4_GetMR(seL4_VMFault_PrefetchFault);
         uint64_t fsr = seL4_GetMR(seL4_VMFault_FSR);
-        sddf_printf("VMFault: ip=%lx  fault_addr=%lx  fsr=%lx %s\n", ip, fault_addr, fsr,
+        sddf_printf("VMFault: ip=%lx  fault_addr=%lx  fsr=%lx %s\n",
+                    ip, fault_addr, fsr,
                     (is_instruction ? "(instruction fault)" : "(data fault)"));
         break;
     }

--- a/benchmark/idle.c
+++ b/benchmark/idle.c
@@ -13,7 +13,6 @@
 #define INIT 3
 #define MAGIC_CYCLES 150
 
-uintptr_t cyclecounters_vaddr;
 struct bench *b;
 
 void count_idle(void)
@@ -48,6 +47,5 @@ void notified(microkit_channel ch)
 
 void init(void)
 {
-    b = (void *)cyclecounters_vaddr;
     return;
 }

--- a/drivers/network/imx/ethernet.c
+++ b/drivers/network/imx/ethernet.c
@@ -42,10 +42,11 @@ struct descriptor {
 
 /* HW ring buffer data type */
 typedef struct {
-    unsigned int tail; /* index to insert at */
-    unsigned int head; /* index to remove from */
+    uint32_t tail; /* index to insert at */
+    uint32_t head; /* index to remove from */
+    uint32_t capacity; /* capacity of the ring */
+    volatile struct descriptor *descr; /* buffer descriptor array */
     net_buff_desc_t descr_mdata[MAX_COUNT]; /* associated meta data array */
-    volatile struct descriptor *descr; /* buffer descripter array */
 } hw_ring_t;
 
 hw_ring_t rx; /* Rx NIC ring */
@@ -58,14 +59,14 @@ net_queue_handle_t tx_queue;
 
 volatile struct enet_regs *eth;
 
-static inline bool hw_ring_full(hw_ring_t *ring, size_t ring_capacity)
+static inline bool hw_ring_full(hw_ring_t *ring)
 {
-    return !((ring->tail - ring->head + 1) % ring_capacity);
+    return ring->tail - ring->head == ring->capacity;
 }
 
-static inline bool hw_ring_empty(hw_ring_t *ring, size_t ring_capacity)
+static inline bool hw_ring_empty(hw_ring_t *ring)
 {
-    return !((ring->tail - ring->head) % ring_capacity);
+    return ring->tail - ring->head == 0;
 }
 
 static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys,
@@ -78,7 +79,7 @@ static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys,
     /* Ensure all writes to the descriptor complete, before we set the flags
      * that makes hardware aware of this slot.
      */
-    __sync_synchronize();
+    THREAD_MEMORY_RELEASE();
     d->stat = stat;
 }
 
@@ -86,30 +87,31 @@ static void rx_provide(void)
 {
     bool reprocess = true;
     while (reprocess) {
-        while (!hw_ring_full(&rx, RX_COUNT) && !net_queue_empty_free(&rx_queue)) {
+        while (!hw_ring_full(&rx) && !net_queue_empty_free(&rx_queue)) {
             net_buff_desc_t buffer;
             int err = net_dequeue_free(&rx_queue, &buffer);
             assert(!err);
 
+            uint32_t idx = rx.tail % rx.capacity;
             uint16_t stat = RXD_EMPTY;
-            if (rx.tail + 1 == RX_COUNT) {
+            if (idx + 1 == rx.capacity) {
                 stat |= WRAP;
             }
-            rx.descr_mdata[rx.tail] = buffer;
-            update_ring_slot(&rx, rx.tail, buffer.io_or_offset, 0, stat);
-            rx.tail = (rx.tail + 1) % RX_COUNT;
+            rx.descr_mdata[idx] = buffer;
+            update_ring_slot(&rx, idx, buffer.io_or_offset, 0, stat);
+            rx.tail++;
             eth->rdar = RDAR_RDAR;
         }
 
         /* Only request a notification from virtualiser if HW ring not full */
-        if (!hw_ring_full(&rx, RX_COUNT)) {
+        if (!hw_ring_full(&rx)) {
             net_request_signal_free(&rx_queue);
         } else {
             net_cancel_signal_free(&rx_queue);
         }
         reprocess = false;
 
-        if (!net_queue_empty_free(&rx_queue) && !hw_ring_full(&rx, RX_COUNT)) {
+        if (!net_queue_empty_free(&rx_queue) && !hw_ring_full(&rx)) {
             net_cancel_signal_free(&rx_queue);
             reprocess = true;
         }
@@ -119,20 +121,23 @@ static void rx_provide(void)
 static void rx_return(void)
 {
     bool packets_transferred = false;
-    while (!hw_ring_empty(&rx, RX_COUNT)) {
+    while (!hw_ring_empty(&rx)) {
         /* If buffer slot is still empty, we have processed all packets the device has filled */
-        volatile struct descriptor *d = &(rx.descr[rx.head]);
+        uint32_t idx = rx.head % rx.capacity;
+        volatile struct descriptor *d = &(rx.descr[idx]);
         if (d->stat & RXD_EMPTY) {
             break;
         }
 
-        net_buff_desc_t buffer = rx.descr_mdata[rx.head];
+        THREAD_MEMORY_ACQUIRE();
+
+        net_buff_desc_t buffer = rx.descr_mdata[idx];
         buffer.len = d->len;
         int err = net_enqueue_active(&rx_queue, buffer);
         assert(!err);
 
         packets_transferred = true;
-        rx.head = (rx.head + 1) % RX_COUNT;
+        rx.head++;
     }
 
     if (packets_transferred && net_require_signal_active(&rx_queue)) {
@@ -145,26 +150,26 @@ static void tx_provide(void)
 {
     bool reprocess = true;
     while (reprocess) {
-        while (!(hw_ring_full(&tx, TX_COUNT)) && !net_queue_empty_active(&tx_queue)) {
+        while (!(hw_ring_full(&tx)) && !net_queue_empty_active(&tx_queue)) {
             net_buff_desc_t buffer;
             int err = net_dequeue_active(&tx_queue, &buffer);
             assert(!err);
 
+            uint32_t idx = tx.tail % tx.capacity;
             uint16_t stat = TXD_READY | TXD_ADDCRC | TXD_LAST;
-            if (tx.tail + 1 == TX_COUNT) {
+            if (idx + 1 == tx.capacity) {
                 stat |= WRAP;
             }
-            tx.descr_mdata[tx.tail] = buffer;
-            update_ring_slot(&tx, tx.tail, buffer.io_or_offset, buffer.len, stat);
-
-            tx.tail = (tx.tail + 1) % TX_COUNT;
+            tx.descr_mdata[idx] = buffer;
+            update_ring_slot(&tx, idx, buffer.io_or_offset, buffer.len, stat);
+            tx.tail++;
             eth->tdar = TDAR_TDAR;
         }
 
         net_request_signal_active(&tx_queue);
         reprocess = false;
 
-        if (!hw_ring_full(&tx, TX_COUNT) && !net_queue_empty_active(&tx_queue)) {
+        if (!hw_ring_full(&tx) && !net_queue_empty_active(&tx_queue)) {
             net_cancel_signal_active(&tx_queue);
             reprocess = true;
         }
@@ -174,21 +179,23 @@ static void tx_provide(void)
 static void tx_return(void)
 {
     bool enqueued = false;
-    while (!hw_ring_empty(&tx, TX_COUNT)) {
+    while (!hw_ring_empty(&tx)) {
         /* Ensure that this buffer has been sent by the device */
-        volatile struct descriptor *d = &(tx.descr[tx.head]);
+        uint32_t idx = tx.head % tx.capacity;
+        volatile struct descriptor *d = &(tx.descr[idx]);
         if (d->stat & TXD_READY) {
             break;
         }
 
-        net_buff_desc_t buffer = tx.descr_mdata[tx.head];
+        THREAD_MEMORY_ACQUIRE();
+
+        net_buff_desc_t buffer = tx.descr_mdata[idx];
         buffer.len = 0;
-
-        tx.head = (tx.head + 1) % TX_COUNT;
-
         int err = net_enqueue_free(&tx_queue, buffer);
         assert(!err);
+
         enqueued = true;
+        tx.head++;
     }
 
     if (enqueued && net_require_signal_free(&tx_queue)) {
@@ -225,7 +232,9 @@ static void eth_setup(void)
     uint32_t h = eth->paur;
 
     /* Set up HW rings */
+    rx.capacity = RX_COUNT;
     rx.descr = (volatile struct descriptor *)hw_ring_buffer_vaddr;
+    tx.capacity = TX_COUNT;
     tx.descr = (volatile struct descriptor *)(hw_ring_buffer_vaddr + (sizeof(struct descriptor) * RX_COUNT));
 
     /* Perform reset */
@@ -269,14 +278,13 @@ static void eth_setup(void)
     eth->tipg = TIPG;
     /* Transmit FIFO Watermark register - store and forward */
     eth->tfwr = STRFWD;
-    /* clear rx store and forward. This must be done for hardware csums*/
+    /* clear rx store and forward. This must be done for hardware csums */
     eth->rsfl = 0;
     /* Do not forward frames with errors + check the csum */
     eth->racc = RACC_LINEDIS | RACC_IPDIS | RACC_PRODIS;
     /* Add the checksum for known IP protocols */
     eth->tacc = TACC_PROCHK | TACC_IPCHK;
 
-    /* Set RDSR */
     eth->rdsr = hw_ring_buffer_paddr;
     eth->tdsr = hw_ring_buffer_paddr + (sizeof(struct descriptor) * RX_COUNT);
 

--- a/drivers/network/meson/ethernet.c
+++ b/drivers/network/meson/ethernet.c
@@ -44,10 +44,11 @@ _Static_assert((RX_COUNT + TX_COUNT) * sizeof(struct descriptor) <= NET_HW_REGIO
                "Expect rx+tx buffers to fit in single 2MB page");
 
 typedef struct {
-    unsigned int tail; /* index to insert at */
-    unsigned int head; /* index to remove from */
+    uint32_t tail; /* index to insert at */
+    uint32_t head; /* index to remove from */
+    uint32_t capacity; /* capacity of the ring */
+    volatile struct descriptor *descr; /* buffer descriptor array */
     net_buff_desc_t descr_mdata[MAX_COUNT]; /* associated meta data array */
-    volatile struct descriptor *descr; /* buffer descripter array */
 } hw_ring_t;
 
 hw_ring_t rx;
@@ -59,14 +60,14 @@ net_queue_handle_t tx_queue;
 volatile struct eth_mac_regs *eth_mac;
 volatile struct eth_dma_regs *eth_dma;
 
-static inline bool hw_ring_full(hw_ring_t *ring, size_t ring_capacity)
+static inline bool hw_ring_full(hw_ring_t *ring)
 {
-    return !((ring->tail + 2 - ring->head) % ring_capacity);
+    return ring->tail - ring->head == ring->capacity;
 }
 
-static inline bool hw_ring_empty(hw_ring_t *ring, size_t ring_capacity)
+static inline bool hw_ring_empty(hw_ring_t *ring)
 {
-    return !((ring->tail - ring->head) % ring_capacity);
+    return ring->tail - ring->head == 0;
 }
 
 static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uint32_t status,
@@ -87,27 +88,28 @@ static void rx_provide()
 {
     bool reprocess = true;
     while (reprocess) {
-        while (!hw_ring_full(&rx, RX_COUNT) && !net_queue_empty_free(&rx_queue)) {
+        while (!hw_ring_full(&rx) && !net_queue_empty_free(&rx_queue)) {
             net_buff_desc_t buffer;
             int err = net_dequeue_free(&rx_queue, &buffer);
             assert(!err);
 
+            uint32_t idx = rx.tail % rx.capacity;
             uint32_t cntl = (MAX_RX_FRAME_SZ << DESC_RXCTRL_SIZE1SHFT) & DESC_RXCTRL_SIZE1MASK;
-            if (rx.tail + 1 == RX_COUNT) {
+            if (idx + 1 == rx.capacity) {
                 cntl |= DESC_RXCTRL_RXRINGEND;
             }
 
-            rx.descr_mdata[rx.tail] = buffer;
-            update_ring_slot(&rx, rx.tail, DESC_RXSTS_OWNBYDMA, cntl, buffer.io_or_offset, 0);
+            rx.descr_mdata[idx] = buffer;
+            update_ring_slot(&rx, idx, DESC_RXSTS_OWNBYDMA, cntl, buffer.io_or_offset, 0);
             eth_dma->rxpolldemand = POLL_DATA;
 
-            rx.tail = (rx.tail + 1) % RX_COUNT;
+            rx.tail++;
         }
 
         net_request_signal_free(&rx_queue);
         reprocess = false;
 
-        if (!net_queue_empty_free(&rx_queue) && !hw_ring_full(&rx, RX_COUNT)) {
+        if (!net_queue_empty_free(&rx_queue) && !hw_ring_full(&rx)) {
             net_cancel_signal_free(&rx_queue);
             reprocess = true;
         }
@@ -117,33 +119,36 @@ static void rx_provide()
 static void rx_return(void)
 {
     bool packets_transferred = false;
-    while (!hw_ring_empty(&rx, RX_COUNT)) {
+    while (!hw_ring_empty(&rx)) {
         /* If buffer slot is still empty, we have processed all packets the device has filled */
-        volatile struct descriptor *d = &(rx.descr[rx.head]);
+        uint32_t idx = rx.head % rx.capacity;
+        volatile struct descriptor *d = &(rx.descr[idx]);
         if (d->status & DESC_RXSTS_OWNBYDMA) {
             break;
         }
-        net_buff_desc_t buffer = rx.descr_mdata[rx.head];
+
         THREAD_MEMORY_ACQUIRE();
 
+        net_buff_desc_t buffer = rx.descr_mdata[idx];
         if (d->status & DESC_RXSTS_ERROR) {
             sddf_dprintf("ETH|ERROR: RX descriptor returned with error status %x\n", d->status);
+            idx = rx.tail % rx.capacity;
             uint32_t cntl = (MAX_RX_FRAME_SZ << DESC_RXCTRL_SIZE1SHFT) & DESC_RXCTRL_SIZE1MASK;
-            if (rx.tail + 1 == RX_COUNT) {
+            if (idx + 1 == rx.capacity) {
                 cntl |= DESC_RXCTRL_RXRINGEND;
             }
 
-            rx.descr_mdata[rx.tail] = buffer;
-            update_ring_slot(&rx, rx.tail, DESC_RXSTS_OWNBYDMA, cntl, buffer.io_or_offset, 0);
+            rx.descr_mdata[idx] = buffer;
+            update_ring_slot(&rx, idx, DESC_RXSTS_OWNBYDMA, cntl, buffer.io_or_offset, 0);
             eth_dma->rxpolldemand = POLL_DATA;
-            rx.tail = (rx.tail + 1) % RX_COUNT;
+            rx.tail++;
         } else {
             buffer.len = (d->status & DESC_RXSTS_LENMSK) >> DESC_RXSTS_LENSHFT;
             int err = net_enqueue_active(&rx_queue, buffer);
             assert(!err);
             packets_transferred = true;
         }
-        rx.head = (rx.head + 1) % RX_COUNT;
+        rx.head++;
     }
 
     if (packets_transferred && net_require_signal_active(&rx_queue)) {
@@ -156,26 +161,27 @@ static void tx_provide(void)
 {
     bool reprocess = true;
     while (reprocess) {
-        while (!(hw_ring_full(&tx, TX_COUNT)) && !net_queue_empty_active(&tx_queue)) {
+        while (!(hw_ring_full(&tx)) && !net_queue_empty_active(&tx_queue)) {
             net_buff_desc_t buffer;
             int err = net_dequeue_active(&tx_queue, &buffer);
             assert(!err);
 
+            uint32_t idx = tx.tail % tx.capacity;
             uint32_t cntl = (((uint32_t) buffer.len) << DESC_TXCTRL_SIZE1SHFT) & DESC_TXCTRL_SIZE1MASK;
             cntl |= DESC_TXCTRL_TXLAST | DESC_TXCTRL_TXFIRST | DESC_TXCTRL_TXINT;
-            if (tx.tail + 1 == TX_COUNT) {
+            if (idx + 1 == tx.capacity) {
                 cntl |= DESC_TXCTRL_TXRINGEND;
             }
-            tx.descr_mdata[tx.tail] = buffer;
-            update_ring_slot(&tx, tx.tail, DESC_TXSTS_OWNBYDMA, cntl, buffer.io_or_offset, 0);
+            tx.descr_mdata[idx] = buffer;
+            update_ring_slot(&tx, idx, DESC_TXSTS_OWNBYDMA, cntl, buffer.io_or_offset, 0);
 
-            tx.tail = (tx.tail + 1) % TX_COUNT;
+            tx.tail++;
         }
 
         net_request_signal_active(&tx_queue);
         reprocess = false;
 
-        if (!hw_ring_full(&tx, TX_COUNT) && !net_queue_empty_active(&tx_queue)) {
+        if (!hw_ring_full(&tx) && !net_queue_empty_active(&tx_queue)) {
             net_cancel_signal_active(&tx_queue);
             reprocess = true;
         }
@@ -186,19 +192,21 @@ static void tx_provide(void)
 static void tx_return(void)
 {
     bool enqueued = false;
-    while (!hw_ring_empty(&tx, TX_COUNT)) {
+    while (!hw_ring_empty(&tx)) {
         /* Ensure that this buffer has been sent by the device */
-        volatile struct descriptor *d = &(tx.descr[tx.head]);
+        uint32_t idx = tx.head % tx.capacity;
+        volatile struct descriptor *d = &(tx.descr[idx]);
         if (d->status & DESC_TXSTS_OWNBYDMA) {
             break;
         }
-        net_buff_desc_t buffer = tx.descr_mdata[tx.head];
+
         THREAD_MEMORY_ACQUIRE();
 
+        net_buff_desc_t buffer = tx.descr_mdata[idx];
         int err = net_enqueue_free(&tx_queue, buffer);
         assert(!err);
         enqueued = true;
-        tx.head = (tx.head + 1) % TX_COUNT;
+        tx.head++;
     }
 
     if (enqueued && net_require_signal_free(&tx_queue)) {
@@ -238,7 +246,9 @@ static void eth_setup(void)
 
     assert((hw_ring_buffer_paddr & 0xFFFFFFFF) == hw_ring_buffer_paddr);
 
+    rx.capacity = RX_COUNT;
     rx.descr = (volatile struct descriptor *)hw_ring_buffer_vaddr;
+    tx.capacity = TX_COUNT;
     tx.descr = (volatile struct descriptor *)(hw_ring_buffer_vaddr + (sizeof(struct descriptor) * RX_COUNT));
 
     /* Perform reset */

--- a/examples/echo_server/Makefile
+++ b/examples/echo_server/Makefile
@@ -24,11 +24,23 @@ ifeq ($(strip $(MICROKIT_BOARD)), odroidc4)
 	export UART_DRIV_DIR := meson
 	export TIMER_DRV_DIR := meson
 	export CPU := cortex-a55
+else ifeq ($(strip $(MICROKIT_BOARD)), odroidc4_4_cores)
+	export DRIV_DIR := meson
+	export UART_DRIV_DIR := meson
+	export TIMER_DRV_DIR := meson
+	export CPU := cortex-a55
+	export CONFIG_INCLUDE_SMP := _smp
 else ifneq ($(filter $(strip $(MICROKIT_BOARD)),imx8mm_evk imx8mp_evk maaxboard),)
 	export DRIV_DIR := imx
 	export UART_DRIV_DIR := imx
 	export TIMER_DRV_DIR := imx
 	export CPU := cortex-a53
+else ifeq ($(strip $(MICROKIT_BOARD)), imx8mm_evk_4_cores)
+	export DRIV_DIR := imx
+	export UART_DRIV_DIR := imx
+	export TIMER_DRV_DIR := imx
+	export CPU := cortex-a53
+	export CONFIG_INCLUDE_SMP := _smp
 else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_aarch64)
 	export DRIV_DIR := virtio
 	export UART_DRIV_DIR := arm

--- a/examples/echo_server/board/imx8mm_evk_4_cores/echo_server.system
+++ b/examples/echo_server/board/imx8mm_evk_4_cores/echo_server.system
@@ -43,33 +43,56 @@
     <memory_region name="net_tx_free_cli1" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="net_tx_active_cli1" size="0x200_000" page_size="0x200_000"/>
 
-    <memory_region name="cyclecounters" size="0x1000"/>
+    <memory_region name="cyclecounters0" size="0x1000"/>
+    <memory_region name="cyclecounters1" size="0x1000"/>
+    <memory_region name="cyclecounters2" size="0x1000"/>
+    <memory_region name="cyclecounters3" size="0x1000"/>
 
     <!-- shared memory for serial data regions -->
     <memory_region name="serial_tx_data_driver" size="0x4_000" />
     <memory_region name="serial_tx_data_client0" size="0x2_000" />
     <memory_region name="serial_tx_data_client1" size="0x2_000" />
     <memory_region name="serial_tx_data_client2" size="0x2_000" />
+    <memory_region name="serial_tx_data_client3" size="0x2_000" />
+    <memory_region name="serial_tx_data_client4" size="0x2_000" />
+    <memory_region name="serial_tx_data_client5" size="0x2_000" />
 
     <!-- shared memory for serial queue regions -->
     <memory_region name="serial_tx_queue_driver" size="0x1_000" />
     <memory_region name="serial_tx_queue_client0" size="0x1_000" />
     <memory_region name="serial_tx_queue_client1" size="0x1_000" />
     <memory_region name="serial_tx_queue_client2" size="0x1_000" />
+    <memory_region name="serial_tx_queue_client3" size="0x1_000" />
+    <memory_region name="serial_tx_queue_client4" size="0x1_000" />
+    <memory_region name="serial_tx_queue_client5" size="0x1_000" />
 
-    <protection_domain name="benchIdle" priority="1" >
+    <protection_domain name="benchIdle0" priority="1" cpu="0">
         <program_image path="idle.elf" />
-        <!-- benchmark.c puts PMU data in here for lwip to collect -->
-        <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
+        <map mr="cyclecounters0" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
     </protection_domain>
 
-    <protection_domain name="bench0" priority="102" >
+    <protection_domain name="benchIdle1" priority="1" cpu="1">
+        <program_image path="idle.elf" />
+        <map mr="cyclecounters1" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
+    </protection_domain>
+
+    <protection_domain name="benchIdle2" priority="1" cpu="2">
+        <program_image path="idle.elf" />
+        <map mr="cyclecounters2" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
+    </protection_domain>
+
+    <protection_domain name="benchIdle3" priority="1" cpu="3">
+        <program_image path="idle.elf" />
+        <map mr="cyclecounters3" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
+    </protection_domain>
+
+    <protection_domain name="bench0" priority="102" cpu="0">
         <program_image path="benchmark.elf" />
 
         <map mr="serial_tx_queue_client2" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
         <map mr="serial_tx_data_client2" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
 
-        <protection_domain name="eth" priority="101" id="1" budget="100" period="400">
+        <protection_domain name="eth" priority="101" id="1" budget="100" period="400" cpu="0">
             <program_image path="eth_driver.elf" />
             <map mr="eth0" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="eth"/>
 
@@ -84,6 +107,115 @@
 
             <setvar symbol="hw_ring_buffer_paddr" region_paddr="hw_ring_buffer" />
         </protection_domain>
+
+        <protection_domain name="net_virt_tx" priority="100" budget="20000" id="3" cpu="0">
+            <program_image path="network_virt_tx.elf" />
+            <map mr="net_tx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="tx_free_drv" />
+            <map mr="net_tx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_active_drv" />
+
+            <map mr="net_tx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli0" />
+            <map mr="net_tx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli0" />
+            <map mr="net_tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" />
+            <map mr="net_tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" />
+
+            <map mr="net_tx_buffer_data_region_cli0" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli0_vaddr" />
+            <map mr="net_tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" />
+            <setvar symbol="buffer_data_region_cli0_paddr" region_paddr="net_tx_buffer_data_region_cli0" />
+            <setvar symbol="buffer_data_region_cli1_paddr" region_paddr="net_tx_buffer_data_region_cli1" />
+        </protection_domain>
+    </protection_domain>
+
+    <protection_domain name="bench1" priority="102" cpu="1">
+        <program_image path="benchmark.elf" />
+
+        <map mr="serial_tx_queue_client3" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="serial_tx_data_client3" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+
+        <protection_domain name="net_virt_rx" priority="99" id="2" cpu="1">
+            <program_image path="network_virt_rx.elf" />
+            <map mr="net_rx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_drv" />
+            <map mr="net_rx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_drv" />
+
+            <map mr="net_rx_free_copy0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
+            <map mr="net_rx_active_copy0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
+            <map mr="net_rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" />
+            <map mr="net_rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" />
+
+            <map mr="net_rx_buffer_data_region" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
+            <setvar symbol="buffer_data_paddr" region_paddr="net_rx_buffer_data_region" />
+        </protection_domain>
+
+        <protection_domain name="copy0" priority="98" budget="20000" id="4" cpu="1">
+            <program_image path="copy.elf" />
+            <map mr="net_rx_free_copy0" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_virt" />
+            <map mr="net_rx_active_copy0" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_virt" />
+
+            <map mr="net_rx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli" />
+            <map mr="net_rx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli" />
+
+            <map mr="net_rx_buffer_data_region" vaddr="0x2_800_000" perms="r" cached="true" setvar_vaddr="virt_buffer_data_region" />
+            <map mr="net_rx_buffer_data_region_cli0" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="cli_buffer_data_region" />
+        </protection_domain>
+
+        <protection_domain name="copy1" priority="96" budget="20000" id="5" cpu="1">
+            <program_image path="copy.elf" />
+            <map mr="net_rx_free_copy1" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_virt" />
+            <map mr="net_rx_active_copy1" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_virt" />
+
+            <map mr="net_rx_free_cli1" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli" />
+            <map mr="net_rx_active_cli1" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli" />
+
+            <map mr="net_rx_buffer_data_region" vaddr="0x2_800_000" perms="r" cached="true" setvar_vaddr="virt_buffer_data_region" />
+            <map mr="net_rx_buffer_data_region_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="cli_buffer_data_region" />
+        </protection_domain>
+
+        <protection_domain name="client0" priority="97" budget="20000" id="6" cpu="1">
+            <program_image path="lwip.elf" />
+
+            <map mr="net_rx_free_cli0" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
+            <map mr="net_rx_active_cli0" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
+            <map mr="net_tx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
+            <map mr="net_tx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
+
+            <map mr="net_rx_buffer_data_region_cli0" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_buffer_data_region" />
+            <map mr="net_tx_buffer_data_region_cli0" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
+
+            <map mr="serial_tx_queue_client0" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+            <map mr="serial_tx_data_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+
+            <map mr="cyclecounters0" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="idle_ccounts_vaddr" />
+            <map mr="cyclecounters1" vaddr="0x5_011_000" perms="rw" cached="true" />
+            <map mr="cyclecounters2" vaddr="0x5_012_000" perms="rw" cached="true" />
+            <map mr="cyclecounters3" vaddr="0x5_013_000" perms="rw" cached="true" />
+        </protection_domain>
+
+        <protection_domain name="client1" priority="95" budget="20000" id="7" cpu="1">
+            <program_image path="lwip.elf" />
+
+            <map mr="net_rx_free_cli1" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
+            <map mr="net_rx_active_cli1" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
+            <map mr="net_tx_free_cli1" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
+            <map mr="net_tx_active_cli1" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
+
+            <map mr="net_rx_buffer_data_region_cli1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_buffer_data_region" />
+            <map mr="net_tx_buffer_data_region_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
+
+            <map mr="serial_tx_queue_client1" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+            <map mr="serial_tx_data_client1" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+        </protection_domain>
+
+        <protection_domain name="timer" priority="101" pp="true" id="8" passive="true" cpu="1">
+            <program_image path="timer_driver.elf" />
+            <map mr="timer" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
+            <irq irq="87" id="0" /> <!-- timer interrupt -->
+        </protection_domain>
+    </protection_domain>
+
+    <protection_domain name="bench2" priority="102" cpu="2">
+        <program_image path="benchmark.elf" />
+
+        <map mr="serial_tx_queue_client4" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="serial_tx_data_client4" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
 
         <protection_domain name="uart" priority="100" id="9">
             <program_image path="uart_driver.elf" />
@@ -102,104 +234,25 @@
             <map mr="serial_tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
             <map mr="serial_tx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>
             <map mr="serial_tx_queue_client2" vaddr="0x4_003_000" perms="rw" cached="true"/>
+            <map mr="serial_tx_queue_client3" vaddr="0x4_004_000" perms="rw" cached="true"/>
+            <map mr="serial_tx_queue_client4" vaddr="0x4_005_000" perms="rw" cached="true"/>
+            <map mr="serial_tx_queue_client5" vaddr="0x4_006_000" perms="rw" cached="true"/>
 
-            <map mr="serial_tx_data_driver" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data_drv" />
-            <map mr="serial_tx_data_client0" vaddr="0x4_008_000" perms="r" cached="true" setvar_vaddr="tx_data_cli0" />
-            <map mr="serial_tx_data_client1" vaddr="0x4_00a_000" perms="r" cached="true"/>
-            <map mr="serial_tx_data_client2" vaddr="0x4_00c_000" perms="r" cached="true"/>
+            <map mr="serial_tx_data_driver" vaddr="0x4_008_000" perms="rw" cached="true" setvar_vaddr="tx_data_drv" />
+            <map mr="serial_tx_data_client0" vaddr="0x4_00c_000" perms="r" cached="true" setvar_vaddr="tx_data_cli0" />
+            <map mr="serial_tx_data_client1" vaddr="0x4_00e_000" perms="r" cached="true"/>
+            <map mr="serial_tx_data_client2" vaddr="0x4_010_000" perms="r" cached="true"/>
+            <map mr="serial_tx_data_client3" vaddr="0x4_012_000" perms="r" cached="true"/>
+            <map mr="serial_tx_data_client4" vaddr="0x4_014_000" perms="r" cached="true"/>
+            <map mr="serial_tx_data_client5" vaddr="0x4_016_000" perms="r" cached="true"/>
         </protection_domain>
+    </protection_domain>
 
-        <protection_domain name="net_virt_rx" priority="99" id="2">
-            <program_image path="network_virt_rx.elf" />
-            <map mr="net_rx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_drv" />
-            <map mr="net_rx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_drv" />
+    <protection_domain name="bench3" priority="102" cpu="3">
+        <program_image path="benchmark.elf" />
 
-            <map mr="net_rx_free_copy0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
-            <map mr="net_rx_active_copy0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
-            <map mr="net_rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" />
-            <map mr="net_rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" />
-
-            <map mr="net_rx_buffer_data_region" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
-            <setvar symbol="buffer_data_paddr" region_paddr="net_rx_buffer_data_region" />
-        </protection_domain>
-
-        <protection_domain name="copy0" priority="98" budget="20000" id="4">
-            <program_image path="copy.elf" />
-            <map mr="net_rx_free_copy0" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_virt" />
-            <map mr="net_rx_active_copy0" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_virt" />
-
-            <map mr="net_rx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli" />
-            <map mr="net_rx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli" />
-
-            <map mr="net_rx_buffer_data_region" vaddr="0x2_800_000" perms="r" cached="true" setvar_vaddr="virt_buffer_data_region" />
-            <map mr="net_rx_buffer_data_region_cli0" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="cli_buffer_data_region" />
-        </protection_domain>
-
-        <protection_domain name="copy1" priority="96" budget="20000" id="5">
-            <program_image path="copy.elf" />
-            <map mr="net_rx_free_copy1" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_virt" />
-            <map mr="net_rx_active_copy1" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_virt" />
-
-            <map mr="net_rx_free_cli1" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli" />
-            <map mr="net_rx_active_cli1" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli" />
-
-            <map mr="net_rx_buffer_data_region" vaddr="0x2_800_000" perms="r" cached="true" setvar_vaddr="virt_buffer_data_region" />
-            <map mr="net_rx_buffer_data_region_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="cli_buffer_data_region" />
-        </protection_domain>
-
-        <protection_domain name="net_virt_tx" priority="100" budget="20000" id="3">
-            <program_image path="network_virt_tx.elf" />
-            <map mr="net_tx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="tx_free_drv" />
-            <map mr="net_tx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_active_drv" />
-
-            <map mr="net_tx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free_cli0" />
-            <map mr="net_tx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active_cli0" />
-            <map mr="net_tx_free_cli1" vaddr="0x2_800_000" perms="rw" cached="true" />
-            <map mr="net_tx_active_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" />
-
-            <map mr="net_tx_buffer_data_region_cli0" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_region_cli0_vaddr" />
-            <map mr="net_tx_buffer_data_region_cli1" vaddr="0x2_e00_000" perms="r" cached="true" />
-            <setvar symbol="buffer_data_region_cli0_paddr" region_paddr="net_tx_buffer_data_region_cli0" />
-            <setvar symbol="buffer_data_region_cli1_paddr" region_paddr="net_tx_buffer_data_region_cli1" />
-        </protection_domain>
-
-        <protection_domain name="client0" priority="97" budget="20000" id="6">
-            <program_image path="lwip.elf" />
-
-            <map mr="net_rx_free_cli0" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-            <map mr="net_rx_active_cli0" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
-            <map mr="net_tx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-            <map mr="net_tx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
-
-            <map mr="net_rx_buffer_data_region_cli0" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_buffer_data_region" />
-            <map mr="net_tx_buffer_data_region_cli0" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
-
-            <map mr="serial_tx_queue_client0" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
-            <map mr="serial_tx_data_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-
-            <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="idle_ccounts_vaddr" />
-        </protection_domain>
-
-        <protection_domain name="client1" priority="95" budget="20000" id="7">
-            <program_image path="lwip.elf" />
-
-            <map mr="net_rx_free_cli1" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
-            <map mr="net_rx_active_cli1" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />
-            <map mr="net_tx_free_cli1" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
-            <map mr="net_tx_active_cli1" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
-
-            <map mr="net_rx_buffer_data_region_cli1" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="rx_buffer_data_region" />
-            <map mr="net_tx_buffer_data_region_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_buffer_data_region" />
-
-            <map mr="serial_tx_queue_client1" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
-            <map mr="serial_tx_data_client1" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
-        </protection_domain>
-
-        <protection_domain name="timer" priority="101" pp="true" id="8" passive="true">
-            <program_image path="timer_driver.elf" />
-            <map mr="timer" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
-            <irq irq="87" id="0" /> <!-- timer interrupt -->
-        </protection_domain>
+        <map mr="serial_tx_queue_client5" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="serial_tx_data_client5" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
     </protection_domain>
 
     <channel>
@@ -220,6 +273,21 @@
    <channel>
         <end pd="serial_virt_tx" id="3"/>
         <end pd="bench0" id="0"/>
+    </channel>
+
+   <channel>
+        <end pd="serial_virt_tx" id="4"/>
+        <end pd="bench1" id="0"/>
+    </channel>
+
+   <channel>
+        <end pd="serial_virt_tx" id="5"/>
+        <end pd="bench2" id="0"/>
+    </channel>
+
+   <channel>
+        <end pd="serial_virt_tx" id="6"/>
+        <end pd="bench3" id="0"/>
     </channel>
 
     <channel>
@@ -263,18 +331,63 @@
     </channel>
 
     <channel>
-        <end pd="client0" id="4" /> <!-- start channel -->
+        <end pd="client0" id="4" /> <!-- core 0 start channel -->
         <end pd="bench0" id="1" />
     </channel>
 
     <channel>
-        <end pd="client0" id="5" /> <!-- stop channel -->
+        <end pd="client0" id="5" /> <!-- core 0 stop channel -->
         <end pd="bench0" id="2" />
     </channel>
 
     <channel>
-        <end pd="benchIdle" id="3" /> <!-- bench init channel -->
+        <end pd="bench0" id="3" /> <!-- core 1 start channel -->
+        <end pd="bench1" id="1" />
+    </channel>
+
+    <channel>
+        <end pd="bench0" id="4" /> <!-- core 1 stop channel -->
+        <end pd="bench1" id="2" />
+    </channel>
+
+    <channel>
+        <end pd="bench1" id="3" /> <!-- core 2 start channel -->
+        <end pd="bench2" id="1" />
+    </channel>
+
+    <channel>
+        <end pd="bench1" id="4" /> <!-- core 2 stop channel -->
+        <end pd="bench2" id="2" />
+    </channel>
+
+    <channel>
+        <end pd="bench2" id="3" /> <!-- core 3 start channel -->
+        <end pd="bench3" id="1" />
+    </channel>
+
+    <channel>
+        <end pd="bench2" id="4" /> <!-- core 3 stop channel -->
+        <end pd="bench3" id="2" />
+    </channel>
+
+    <channel>
+        <end pd="benchIdle0" id="3" /> <!-- core 0 bench init channel -->
         <end pd="bench0" id="5" />
+    </channel>
+
+    <channel>
+        <end pd="benchIdle1" id="3" /> <!-- core 1 bench init channel -->
+        <end pd="bench1" id="5" />
+    </channel>
+
+    <channel>
+        <end pd="benchIdle2" id="3" /> <!-- core 2 bench init channel -->
+        <end pd="bench2" id="5" />
+    </channel>
+
+    <channel>
+        <end pd="benchIdle3" id="3" /> <!-- core 3 bench init channel -->
+        <end pd="bench3" id="5" />
     </channel>
 
     <channel>

--- a/examples/echo_server/board/imx8mp_evk/echo_server.system
+++ b/examples/echo_server/board/imx8mp_evk/echo_server.system
@@ -60,10 +60,10 @@
     <protection_domain name="benchIdle" priority="1" >
         <program_image path="idle.elf" />
         <!-- benchmark.c puts PMU data in here for lwip to collect -->
-        <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="cyclecounters_vaddr" />
+        <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
     </protection_domain>
 
-    <protection_domain name="bench" priority="102" >
+    <protection_domain name="bench0" priority="102" >
         <program_image path="benchmark.elf" />
 
         <map mr="serial_tx_queue_client2" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
@@ -177,7 +177,7 @@
             <map mr="serial_tx_queue_client0" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
             <map mr="serial_tx_data_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
 
-            <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="cyclecounters_vaddr" />
+            <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="idle_ccounts_vaddr" />
         </protection_domain>
 
         <protection_domain name="client1" priority="95" budget="20000" id="7">
@@ -219,7 +219,7 @@
 
    <channel>
         <end pd="serial_virt_tx" id="3"/>
-        <end pd="bench" id="0"/>
+        <end pd="bench0" id="0"/>
     </channel>
 
     <channel>
@@ -264,17 +264,17 @@
 
     <channel>
         <end pd="client0" id="4" /> <!-- start channel -->
-        <end pd="bench" id="1" />
+        <end pd="bench0" id="1" />
     </channel>
 
     <channel>
         <end pd="client0" id="5" /> <!-- stop channel -->
-        <end pd="bench" id="2" />
+        <end pd="bench0" id="2" />
     </channel>
 
     <channel>
         <end pd="benchIdle" id="3" /> <!-- bench init channel -->
-        <end pd="bench" id="3" />
+        <end pd="bench0" id="5" />
     </channel>
 
     <channel>

--- a/examples/echo_server/board/maaxboard/echo_server.system
+++ b/examples/echo_server/board/maaxboard/echo_server.system
@@ -60,10 +60,10 @@
     <protection_domain name="benchIdle" priority="1" >
         <program_image path="idle.elf" />
         <!-- benchmark.c puts PMU data in here for lwip to collect -->
-        <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="cyclecounters_vaddr" />
+        <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
     </protection_domain>
 
-    <protection_domain name="bench" priority="102" >
+    <protection_domain name="bench0" priority="102" >
         <program_image path="benchmark.elf" />
 
         <map mr="serial_tx_queue_client2" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
@@ -177,7 +177,7 @@
             <map mr="serial_tx_queue_client0" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
             <map mr="serial_tx_data_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
 
-            <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="cyclecounters_vaddr" />
+            <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="idle_ccounts_vaddr" />
         </protection_domain>
 
         <protection_domain name="client1" priority="95" budget="20000" id="7">
@@ -219,7 +219,7 @@
 
    <channel>
         <end pd="serial_virt_tx" id="3"/>
-        <end pd="bench" id="0"/>
+        <end pd="bench0" id="0"/>
     </channel>
 
     <channel>
@@ -264,17 +264,17 @@
 
     <channel>
         <end pd="client0" id="4" /> <!-- start channel -->
-        <end pd="bench" id="1" />
+        <end pd="bench0" id="1" />
     </channel>
 
     <channel>
         <end pd="client0" id="5" /> <!-- stop channel -->
-        <end pd="bench" id="2" />
+        <end pd="bench0" id="2" />
     </channel>
 
     <channel>
         <end pd="benchIdle" id="3" /> <!-- bench init channel -->
-        <end pd="bench" id="3" />
+        <end pd="bench0" id="5" />
     </channel>
 
     <channel>

--- a/examples/echo_server/board/odroidc4/echo_server.system
+++ b/examples/echo_server/board/odroidc4/echo_server.system
@@ -60,10 +60,10 @@
     <protection_domain name="benchIdle" priority="1" >
         <program_image path="idle.elf" />
         <!-- benchmark.c puts PMU data in here for lwip to collect -->
-        <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="cyclecounters_vaddr" />
+        <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
     </protection_domain>
 
-    <protection_domain name="bench" priority="102" >
+    <protection_domain name="bench0" priority="102" >
         <program_image path="benchmark.elf" />
 
         <map mr="serial_tx_queue_client2" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
@@ -177,7 +177,7 @@
             <map mr="serial_tx_queue_client0" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
             <map mr="serial_tx_data_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
 
-            <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="cyclecounters_vaddr" />
+            <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="idle_ccounts_vaddr" />
         </protection_domain>
 
         <protection_domain name="client1" priority="95" budget="20000" id="7">
@@ -219,7 +219,7 @@
 
    <channel>
         <end pd="serial_virt_tx" id="3"/>
-        <end pd="bench" id="0"/>
+        <end pd="bench0" id="0"/>
     </channel>
 
     <channel>
@@ -264,17 +264,17 @@
 
     <channel>
         <end pd="client0" id="4" /> <!-- start channel -->
-        <end pd="bench" id="1" />
+        <end pd="bench0" id="1" />
     </channel>
 
     <channel>
         <end pd="client0" id="5" /> <!-- stop channel -->
-        <end pd="bench" id="2" />
+        <end pd="bench0" id="2" />
     </channel>
 
     <channel>
         <end pd="benchIdle" id="3" /> <!-- bench init channel -->
-        <end pd="bench" id="3" />
+        <end pd="bench0" id="5" />
     </channel>
 
     <channel>

--- a/examples/echo_server/board/odroidc4_4_cores/echo_server.system
+++ b/examples/echo_server/board/odroidc4_4_cores/echo_server.system
@@ -5,9 +5,9 @@
     SPDX-License-Identifier: BSD-2-Clause
 -->
 <system>
-    <memory_region name="uart" size="0x10_000" phys_addr="0x30890000" />
-    <memory_region name="eth0" size="0x10_000" phys_addr="0x30be0000" />
-    <memory_region name="timer" size="0x10_000" phys_addr="0x302d0000" />
+    <memory_region name="uart" size="0x1_000" phys_addr="0xff803000" />
+    <memory_region name="eth0" size="0x10_000" phys_addr="0xff3f0000" />
+    <memory_region name="timer" size="0x1_000" phys_addr="0xffd0f000" />
 
     <!-- driver/device queue mechanism -->
     <memory_region name="hw_ring_buffer" size="0x10_000" />
@@ -43,35 +43,58 @@
     <memory_region name="net_tx_free_cli1" size="0x200_000" page_size="0x200_000"/>
     <memory_region name="net_tx_active_cli1" size="0x200_000" page_size="0x200_000"/>
 
-    <memory_region name="cyclecounters" size="0x1000"/>
+    <memory_region name="cyclecounters0" size="0x1000"/>
+    <memory_region name="cyclecounters1" size="0x1000"/>
+    <memory_region name="cyclecounters2" size="0x1000"/>
+    <memory_region name="cyclecounters3" size="0x1000"/>
 
     <!-- shared memory for serial data regions -->
     <memory_region name="serial_tx_data_driver" size="0x4_000" />
     <memory_region name="serial_tx_data_client0" size="0x2_000" />
     <memory_region name="serial_tx_data_client1" size="0x2_000" />
     <memory_region name="serial_tx_data_client2" size="0x2_000" />
+    <memory_region name="serial_tx_data_client3" size="0x2_000" />
+    <memory_region name="serial_tx_data_client4" size="0x2_000" />
+    <memory_region name="serial_tx_data_client5" size="0x2_000" />
 
     <!-- shared memory for serial queue regions -->
     <memory_region name="serial_tx_queue_driver" size="0x1_000" />
     <memory_region name="serial_tx_queue_client0" size="0x1_000" />
     <memory_region name="serial_tx_queue_client1" size="0x1_000" />
     <memory_region name="serial_tx_queue_client2" size="0x1_000" />
+    <memory_region name="serial_tx_queue_client3" size="0x1_000" />
+    <memory_region name="serial_tx_queue_client4" size="0x1_000" />
+    <memory_region name="serial_tx_queue_client5" size="0x1_000" />
 
-    <protection_domain name="benchIdle" priority="1" >
+    <protection_domain name="benchIdle0" priority="1" cpu="0">
         <program_image path="idle.elf" />
-        <!-- benchmark.c puts PMU data in here for lwip to collect -->
-        <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
+        <map mr="cyclecounters0" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
     </protection_domain>
 
-    <protection_domain name="bench0" priority="102" >
+    <protection_domain name="benchIdle1" priority="1" cpu="1">
+        <program_image path="idle.elf" />
+        <map mr="cyclecounters1" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
+    </protection_domain>
+
+    <protection_domain name="benchIdle2" priority="1" cpu="2">
+        <program_image path="idle.elf" />
+        <map mr="cyclecounters2" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
+    </protection_domain>
+
+    <protection_domain name="benchIdle3" priority="1" cpu="3">
+        <program_image path="idle.elf" />
+        <map mr="cyclecounters3" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
+    </protection_domain>
+
+    <protection_domain name="bench0" priority="102" cpu="0">
         <program_image path="benchmark.elf" />
 
         <map mr="serial_tx_queue_client2" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
         <map mr="serial_tx_data_client2" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
 
-        <protection_domain name="eth" priority="101" id="1" budget="100" period="400">
+        <protection_domain name="eth" priority="101" id="1" budget="100" period="400" cpu="0">
             <program_image path="eth_driver.elf" />
-            <map mr="eth0" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="eth"/>
+            <map mr="eth0" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="eth_mac"/>
 
             <map mr="hw_ring_buffer" vaddr="0x2_200_000" perms="rw" cached="false" setvar_vaddr="hw_ring_buffer_vaddr" />
 
@@ -80,74 +103,12 @@
             <map mr="net_tx_free_drv" vaddr="0x2_800_000" perms="rw" cached="true" setvar_vaddr="tx_free" />
             <map mr="net_tx_active_drv" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="tx_active" />
 
-            <irq irq="152" id="0" /> <!--> ethernet interrupt -->
+            <irq irq="40" id="0" /> <!--> ethernet interrupt -->
 
             <setvar symbol="hw_ring_buffer_paddr" region_paddr="hw_ring_buffer" />
         </protection_domain>
 
-        <protection_domain name="uart" priority="100" id="9">
-            <program_image path="uart_driver.elf" />
-
-            <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
-
-            <map mr="serial_tx_queue_driver" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue" />
-            <map mr="serial_tx_data_driver" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
-
-            <irq irq="59" id="0" /> <!-- UART interrupt -->
-        </protection_domain>
-
-        <protection_domain name="serial_virt_tx" priority="99" id="10">
-            <program_image path="serial_virt_tx.elf" />
-            <map mr="serial_tx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
-            <map mr="serial_tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
-            <map mr="serial_tx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>
-            <map mr="serial_tx_queue_client2" vaddr="0x4_003_000" perms="rw" cached="true"/>
-
-            <map mr="serial_tx_data_driver" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="tx_data_drv" />
-            <map mr="serial_tx_data_client0" vaddr="0x4_008_000" perms="r" cached="true" setvar_vaddr="tx_data_cli0" />
-            <map mr="serial_tx_data_client1" vaddr="0x4_00a_000" perms="r" cached="true"/>
-            <map mr="serial_tx_data_client2" vaddr="0x4_00c_000" perms="r" cached="true"/>
-        </protection_domain>
-
-        <protection_domain name="net_virt_rx" priority="99" id="2">
-            <program_image path="network_virt_rx.elf" />
-            <map mr="net_rx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_drv" />
-            <map mr="net_rx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_drv" />
-
-            <map mr="net_rx_free_copy0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
-            <map mr="net_rx_active_copy0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
-            <map mr="net_rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" />
-            <map mr="net_rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" />
-
-            <map mr="net_rx_buffer_data_region" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
-            <setvar symbol="buffer_data_paddr" region_paddr="net_rx_buffer_data_region" />
-        </protection_domain>
-
-        <protection_domain name="copy0" priority="98" budget="20000" id="4">
-            <program_image path="copy.elf" />
-            <map mr="net_rx_free_copy0" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_virt" />
-            <map mr="net_rx_active_copy0" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_virt" />
-
-            <map mr="net_rx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli" />
-            <map mr="net_rx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli" />
-
-            <map mr="net_rx_buffer_data_region" vaddr="0x2_800_000" perms="r" cached="true" setvar_vaddr="virt_buffer_data_region" />
-            <map mr="net_rx_buffer_data_region_cli0" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="cli_buffer_data_region" />
-        </protection_domain>
-
-        <protection_domain name="copy1" priority="96" budget="20000" id="5">
-            <program_image path="copy.elf" />
-            <map mr="net_rx_free_copy1" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_virt" />
-            <map mr="net_rx_active_copy1" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_virt" />
-
-            <map mr="net_rx_free_cli1" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli" />
-            <map mr="net_rx_active_cli1" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli" />
-
-            <map mr="net_rx_buffer_data_region" vaddr="0x2_800_000" perms="r" cached="true" setvar_vaddr="virt_buffer_data_region" />
-            <map mr="net_rx_buffer_data_region_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="cli_buffer_data_region" />
-        </protection_domain>
-
-        <protection_domain name="net_virt_tx" priority="100" budget="20000" id="3">
+        <protection_domain name="net_virt_tx" priority="100" budget="20000" id="3" cpu="0">
             <program_image path="network_virt_tx.elf" />
             <map mr="net_tx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="tx_free_drv" />
             <map mr="net_tx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="tx_active_drv" />
@@ -162,8 +123,53 @@
             <setvar symbol="buffer_data_region_cli0_paddr" region_paddr="net_tx_buffer_data_region_cli0" />
             <setvar symbol="buffer_data_region_cli1_paddr" region_paddr="net_tx_buffer_data_region_cli1" />
         </protection_domain>
+    </protection_domain>
 
-        <protection_domain name="client0" priority="97" budget="20000" id="6">
+    <protection_domain name="bench1" priority="102" cpu="1">
+        <program_image path="benchmark.elf" />
+
+        <map mr="serial_tx_queue_client3" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="serial_tx_data_client3" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+
+        <protection_domain name="net_virt_rx" priority="99" id="2" cpu="1">
+            <program_image path="network_virt_rx.elf" />
+            <map mr="net_rx_free_drv" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_drv" />
+            <map mr="net_rx_active_drv" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_drv" />
+
+            <map mr="net_rx_free_copy0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli0" />
+            <map mr="net_rx_active_copy0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli0" />
+            <map mr="net_rx_free_copy1" vaddr="0x2_800_000" perms="rw" cached="true" />
+            <map mr="net_rx_active_copy1" vaddr="0x2_a00_000" perms="rw" cached="true" />
+
+            <map mr="net_rx_buffer_data_region" vaddr="0x2_c00_000" perms="r" cached="true" setvar_vaddr="buffer_data_vaddr" />
+            <setvar symbol="buffer_data_paddr" region_paddr="net_rx_buffer_data_region" />
+        </protection_domain>
+
+        <protection_domain name="copy0" priority="98" budget="20000" id="4" cpu="1">
+            <program_image path="copy.elf" />
+            <map mr="net_rx_free_copy0" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_virt" />
+            <map mr="net_rx_active_copy0" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_virt" />
+
+            <map mr="net_rx_free_cli0" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli" />
+            <map mr="net_rx_active_cli0" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli" />
+
+            <map mr="net_rx_buffer_data_region" vaddr="0x2_800_000" perms="r" cached="true" setvar_vaddr="virt_buffer_data_region" />
+            <map mr="net_rx_buffer_data_region_cli0" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="cli_buffer_data_region" />
+        </protection_domain>
+
+        <protection_domain name="copy1" priority="96" budget="20000" id="5" cpu="1">
+            <program_image path="copy.elf" />
+            <map mr="net_rx_free_copy1" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free_virt" />
+            <map mr="net_rx_active_copy1" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active_virt" />
+
+            <map mr="net_rx_free_cli1" vaddr="0x2_400_000" perms="rw" cached="true" setvar_vaddr="rx_free_cli" />
+            <map mr="net_rx_active_cli1" vaddr="0x2_600_000" perms="rw" cached="true" setvar_vaddr="rx_active_cli" />
+
+            <map mr="net_rx_buffer_data_region" vaddr="0x2_800_000" perms="r" cached="true" setvar_vaddr="virt_buffer_data_region" />
+            <map mr="net_rx_buffer_data_region_cli1" vaddr="0x2_a00_000" perms="rw" cached="true" setvar_vaddr="cli_buffer_data_region" />
+        </protection_domain>
+
+        <protection_domain name="client0" priority="97" budget="20000" id="6" cpu="1">
             <program_image path="lwip.elf" />
 
             <map mr="net_rx_free_cli0" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
@@ -177,10 +183,13 @@
             <map mr="serial_tx_queue_client0" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
             <map mr="serial_tx_data_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
 
-            <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="idle_ccounts_vaddr" />
+            <map mr="cyclecounters0" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="idle_ccounts_vaddr" />
+            <map mr="cyclecounters1" vaddr="0x5_011_000" perms="rw" cached="true" />
+            <map mr="cyclecounters2" vaddr="0x5_012_000" perms="rw" cached="true" />
+            <map mr="cyclecounters3" vaddr="0x5_013_000" perms="rw" cached="true" />
         </protection_domain>
 
-        <protection_domain name="client1" priority="95" budget="20000" id="7">
+        <protection_domain name="client1" priority="95" budget="20000" id="7" cpu="1">
             <program_image path="lwip.elf" />
 
             <map mr="net_rx_free_cli1" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
@@ -198,8 +207,52 @@
         <protection_domain name="timer" priority="101" pp="true" id="8" passive="true">
             <program_image path="timer_driver.elf" />
             <map mr="timer" vaddr="0x2_000_000" perms="rw" cached="false" setvar_vaddr="gpt_regs" />
-            <irq irq="87" id="0" /> <!-- timer interrupt -->
+            <irq irq="42" id="0" trigger="edge" /> <!-- timer interrupt -->
         </protection_domain>
+    </protection_domain>
+
+    <protection_domain name="bench2" priority="102" cpu="2">
+        <program_image path="benchmark.elf" />
+
+        <map mr="serial_tx_queue_client4" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="serial_tx_data_client4" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
+
+        <protection_domain name="uart" priority="100" id="9">
+            <program_image path="uart_driver.elf" />
+
+            <map mr="uart" vaddr="0x5_000_000" perms="rw" cached="false" setvar_vaddr="uart_base" />
+
+            <map mr="serial_tx_queue_driver" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue" />
+            <map mr="serial_tx_data_driver" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="tx_data" />
+
+            <irq irq="225" id="0" trigger="edge" /> <!-- UART interrupt -->
+        </protection_domain>
+
+        <protection_domain name="serial_virt_tx" priority="99" id="10">
+            <program_image path="serial_virt_tx.elf" />
+            <map mr="serial_tx_queue_driver" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="tx_queue_drv" />
+            <map mr="serial_tx_queue_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="tx_queue_cli0" />
+            <map mr="serial_tx_queue_client1" vaddr="0x4_002_000" perms="rw" cached="true"/>
+            <map mr="serial_tx_queue_client2" vaddr="0x4_003_000" perms="rw" cached="true"/>
+            <map mr="serial_tx_queue_client3" vaddr="0x4_004_000" perms="rw" cached="true"/>
+            <map mr="serial_tx_queue_client4" vaddr="0x4_005_000" perms="rw" cached="true"/>
+            <map mr="serial_tx_queue_client5" vaddr="0x4_006_000" perms="rw" cached="true"/>
+
+            <map mr="serial_tx_data_driver" vaddr="0x4_008_000" perms="rw" cached="true" setvar_vaddr="tx_data_drv" />
+            <map mr="serial_tx_data_client0" vaddr="0x4_00c_000" perms="r" cached="true" setvar_vaddr="tx_data_cli0" />
+            <map mr="serial_tx_data_client1" vaddr="0x4_00e_000" perms="r" cached="true"/>
+            <map mr="serial_tx_data_client2" vaddr="0x4_010_000" perms="r" cached="true"/>
+            <map mr="serial_tx_data_client3" vaddr="0x4_012_000" perms="r" cached="true"/>
+            <map mr="serial_tx_data_client4" vaddr="0x4_014_000" perms="r" cached="true"/>
+            <map mr="serial_tx_data_client5" vaddr="0x4_016_000" perms="r" cached="true"/>
+        </protection_domain>
+    </protection_domain>
+
+    <protection_domain name="bench3" priority="102" cpu="3">
+        <program_image path="benchmark.elf" />
+
+        <map mr="serial_tx_queue_client5" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
+        <map mr="serial_tx_data_client5" vaddr="0x4_002_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
     </protection_domain>
 
     <channel>
@@ -220,6 +273,21 @@
    <channel>
         <end pd="serial_virt_tx" id="3"/>
         <end pd="bench0" id="0"/>
+    </channel>
+
+   <channel>
+        <end pd="serial_virt_tx" id="4"/>
+        <end pd="bench1" id="0"/>
+    </channel>
+
+   <channel>
+        <end pd="serial_virt_tx" id="5"/>
+        <end pd="bench2" id="0"/>
+    </channel>
+
+   <channel>
+        <end pd="serial_virt_tx" id="6"/>
+        <end pd="bench3" id="0"/>
     </channel>
 
     <channel>
@@ -263,18 +331,63 @@
     </channel>
 
     <channel>
-        <end pd="client0" id="4" /> <!-- start channel -->
+        <end pd="client0" id="4" /> <!-- core 0 start channel -->
         <end pd="bench0" id="1" />
     </channel>
 
     <channel>
-        <end pd="client0" id="5" /> <!-- stop channel -->
+        <end pd="client0" id="5" /> <!-- core 0 stop channel -->
         <end pd="bench0" id="2" />
     </channel>
 
     <channel>
-        <end pd="benchIdle" id="3" /> <!-- bench init channel -->
+        <end pd="bench0" id="3" /> <!-- core 1 start channel -->
+        <end pd="bench1" id="1" />
+    </channel>
+
+    <channel>
+        <end pd="bench0" id="4" /> <!-- core 1 stop channel -->
+        <end pd="bench1" id="2" />
+    </channel>
+
+    <channel>
+        <end pd="bench1" id="3" /> <!-- core 2 start channel -->
+        <end pd="bench2" id="1" />
+    </channel>
+
+    <channel>
+        <end pd="bench1" id="4" /> <!-- core 2 stop channel -->
+        <end pd="bench2" id="2" />
+    </channel>
+
+    <channel>
+        <end pd="bench2" id="3" /> <!-- core 3 start channel -->
+        <end pd="bench3" id="1" />
+    </channel>
+
+    <channel>
+        <end pd="bench2" id="4" /> <!-- core 3 stop channel -->
+        <end pd="bench3" id="2" />
+    </channel>
+
+    <channel>
+        <end pd="benchIdle0" id="3" /> <!-- core 0 bench init channel -->
         <end pd="bench0" id="5" />
+    </channel>
+
+    <channel>
+        <end pd="benchIdle1" id="3" /> <!-- core 1 bench init channel -->
+        <end pd="bench1" id="5" />
+    </channel>
+
+    <channel>
+        <end pd="benchIdle2" id="3" /> <!-- core 2 bench init channel -->
+        <end pd="bench2" id="5" />
+    </channel>
+
+    <channel>
+        <end pd="benchIdle3" id="3" /> <!-- core 3 bench init channel -->
+        <end pd="bench3" id="5" />
     </channel>
 
     <channel>

--- a/examples/echo_server/board/qemu_virt_aarch64/echo_server.system
+++ b/examples/echo_server/board/qemu_virt_aarch64/echo_server.system
@@ -59,10 +59,10 @@
     <protection_domain name="benchIdle" priority="1" >
         <program_image path="idle.elf" />
         <!-- benchmark.c puts PMU data in here for lwip to collect -->
-        <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="cyclecounters_vaddr" />
+        <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="b" />
     </protection_domain>
 
-    <protection_domain name="bench" priority="102" >
+    <protection_domain name="bench0" priority="102" >
         <program_image path="benchmark.elf" />
 
         <map mr="serial_tx_queue_client2" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
@@ -176,7 +176,7 @@
             <map mr="serial_tx_queue_client0" vaddr="0x4_000_000" perms="rw" cached="true" setvar_vaddr="serial_tx_queue" />
             <map mr="serial_tx_data_client0" vaddr="0x4_001_000" perms="rw" cached="true" setvar_vaddr="serial_tx_data" />
 
-            <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="cyclecounters_vaddr" />
+            <map mr="cyclecounters" vaddr="0x5_010_000" perms="rw" cached="true" setvar_vaddr="idle_ccounts_vaddr" />
         </protection_domain>
 
         <protection_domain name="client1" priority="95" budget="20000" id="7">
@@ -217,7 +217,7 @@
 
    <channel>
         <end pd="serial_virt_tx" id="3"/>
-        <end pd="bench" id="0"/>
+        <end pd="bench0" id="0"/>
     </channel>
 
     <channel>
@@ -262,17 +262,17 @@
 
     <channel>
         <end pd="client0" id="4" /> <!-- start channel -->
-        <end pd="bench" id="1" />
+        <end pd="bench0" id="1" />
     </channel>
 
     <channel>
         <end pd="client0" id="5" /> <!-- stop channel -->
-        <end pd="bench" id="2" />
+        <end pd="bench0" id="2" />
     </channel>
 
     <channel>
         <end pd="benchIdle" id="3" /> <!-- bench init channel -->
-        <end pd="bench" id="3" />
+        <end pd="bench0" id="5" />
     </channel>
 
     <channel>

--- a/examples/echo_server/echo.mk
+++ b/examples/echo_server/echo.mk
@@ -7,19 +7,24 @@
 QEMU := qemu-system-aarch64
 
 MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
-ECHO_SERVER:=${SDDF}/examples/echo_server
-LWIPDIR:=network/ipstacks/lwip/src
+BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+ECHO_SERVER:=$(SDDF)/examples/echo_server
+
 BENCHMARK:=$(SDDF)/benchmark
-UTIL:=$(SDDF)/util
+CORE_CONFIG_INCLUDE:=$(ECHO_SERVER)/include/core_config$(CONFIG_INCLUDE_SMP)
+
+LWIPDIR:=network/ipstacks/lwip/src
+NETWORK_COMPONENTS:=$(SDDF)/network/components
 ETHERNET_DRIVER:=$(SDDF)/drivers/network/$(DRIV_DIR)
-ETHERNET_CONFIG_INCLUDE:=${ECHO_SERVER}/include/ethernet_config
+ETHERNET_CONFIG_INCLUDE:=$(ECHO_SERVER)/include/ethernet_config
+
 SERIAL_COMPONENTS := $(SDDF)/serial/components
 UART_DRIVER := $(SDDF)/drivers/serial/$(UART_DRIV_DIR)
-SERIAL_CONFIG_INCLUDE:=${ECHO_SERVER}/include/serial_config
-TIMER_DRIVER:=$(SDDF)/drivers/timer/$(TIMER_DRV_DIR)
-NETWORK_COMPONENTS:=$(SDDF)/network/components
+SERIAL_CONFIG_INCLUDE:=$(ECHO_SERVER)/include/serial_config$(CONFIG_INCLUDE_SMP)
 
-BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+TIMER_DRIVER:=$(SDDF)/drivers/timer/$(TIMER_DRV_DIR)
+UTIL:=$(SDDF)/util
+
 SYSTEM_FILE := ${ECHO_SERVER}/board/$(MICROKIT_BOARD)/echo_server.system
 IMAGE_FILE := loader.img
 REPORT_FILE := report.txt
@@ -37,11 +42,12 @@ CFLAGS := -mcpu=$(CPU) \
 	  -DMICROKIT_CONFIG_$(MICROKIT_CONFIG) \
 	  -I$(BOARD_DIR)/include \
 	  -I$(SDDF)/include \
-	  -I${ECHO_INCLUDE}/lwip \
-	  -I${ETHERNET_CONFIG_INCLUDE} \
+	  -I$(ECHO_INCLUDE)/lwip \
+	  -I$(CORE_CONFIG_INCLUDE) \
+	  -I$(ETHERNET_CONFIG_INCLUDE) \
 	  -I$(SERIAL_CONFIG_INCLUDE) \
-	  -I${SDDF}/$(LWIPDIR)/include \
-	  -I${SDDF}/$(LWIPDIR)/include/ipv4 \
+	  -I$(SDDF)/$(LWIPDIR)/include \
+	  -I$(SDDF)/$(LWIPDIR)/include/ipv4 \
 	  -MD \
 	  -MP
 

--- a/examples/echo_server/include/core_config/core_config.h
+++ b/examples/echo_server/include/core_config/core_config.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sddf/util/string.h>
+#include <ethernet_config.h>
+#include <stdint.h>
+
+/* Total number of cores on the board. */
+#define MAX_CORES 4
+
+/* Total number of PDs being tracked during the benchmark. */
+#define NUM_PDS_TO_TRACK 8
+
+/* The core of the benchmark PD which is last in the notification chain.
+   The benchmark PD on this core receives START and STOP notifications,
+   but does not send them. */
+#define LAST_CORE 0
+
+typedef struct {
+    uint16_t pd_id; /* ID of the PD. */
+    uint16_t pd_core; /* Core of the PD. */
+    char *pd_name; /* Name of the PD. */
+} pd_core_info_t;
+
+pd_core_info_t pd_core_info[NUM_PDS_TO_TRACK] = {
+    { 1, 0, NET_DRIVER_NAME }, /* Ethernet driver. */
+    { 2, 0, NET_VIRT_RX_NAME }, /* Rx virtualiser. */
+    { 3, 0, NET_VIRT_TX_NAME }, /* Tx virtualiser. */
+    { 4, 0, NET_COPY0_NAME }, /* Copy component 0. */
+    { 5, 0, NET_COPY1_NAME }, /* Copy component 1. */
+    { 6, 0, NET_CLI0_NAME }, /* LWIP client 0. */
+    { 7, 0, NET_CLI1_NAME }, /* LWIP client 1. */
+    { 8, 0, NET_TIMER_NAME } /* Timer driver. */
+};
+
+typedef struct {
+    uint64_t core_bitmap; /* Bitmap of client IDs on this core. */
+    uint32_t core_value; /* Core of this benchmark process. */
+    uint32_t max_core_id; /* Maximum ID of client on this core. */
+    bool last_core; /* Whether this bench process is the last in the notification chain. */
+} core_config_t;
+
+static void bench_core_config_info(char *pd_name, core_config_t *core_config)
+{
+    core_config->max_core_id = 0;
+    core_config->last_core = false;
+
+    if (!sddf_strcmp(pd_name, "bench0")) {
+        core_config->core_value = 0;
+    } else if (!sddf_strcmp(pd_name, "bench1")) {
+        core_config->core_value = 1;
+    } else if (!sddf_strcmp(pd_name, "bench2")) {
+        core_config->core_value = 2;
+    } else if (!sddf_strcmp(pd_name, "bench3")) {
+        core_config->core_value = 3;
+    } else {
+        return;
+    }
+
+    if (core_config->core_value == LAST_CORE) {
+        core_config->last_core = true;
+    }
+
+    for (uint16_t i = 0; i < NUM_PDS_TO_TRACK; i++) {
+        if (pd_core_info[i].pd_core == core_config->core_value) {
+            core_config->core_bitmap |= (1 << pd_core_info[i].pd_id);
+            if (pd_core_info[i].pd_id > core_config->max_core_id) {
+                core_config->max_core_id = pd_core_info[i].pd_id;
+            }
+        }
+    }
+}
+
+static uint16_t bench_active_cores()
+{
+    uint16_t active_cores = 0;
+    for (uint16_t i = 0; i < NUM_PDS_TO_TRACK; i++) {
+        active_cores |= (1 << pd_core_info[i].pd_core);
+    }
+
+    return active_cores;
+}
+
+static char *pd_id_to_name(uint16_t pd_id)
+{
+    for (uint16_t i = 0; i < NUM_PDS_TO_TRACK; i++) {
+        if (pd_core_info[i].pd_id == pd_id) {
+            return pd_core_info[i].pd_name;
+        }
+    }
+
+    return NULL;
+}

--- a/examples/echo_server/include/core_config_smp/core_config.h
+++ b/examples/echo_server/include/core_config_smp/core_config.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sddf/util/string.h>
+#include <ethernet_config.h>
+#include <stdint.h>
+
+/* Total number of cores on the board. */
+#define MAX_CORES 4
+
+/* Total number of PDs being tracked during the benchmark. */
+#define NUM_PDS_TO_TRACK 8
+
+/* The core of the benchmark PD which is last in the notification chain.
+   The benchmark PD on this core receives START and STOP notifications,
+   but does not send them. */
+#define LAST_CORE 1
+
+typedef struct {
+    uint16_t pd_id; /* ID of the PD. */
+    uint16_t pd_core; /* Core of the PD. */
+    char *pd_name; /* Name of the PD. */
+} pd_core_info_t;
+
+pd_core_info_t pd_core_info[NUM_PDS_TO_TRACK] = {
+    { 1, 0, NET_DRIVER_NAME }, /* Ethernet driver. */
+    { 2, 1, NET_VIRT_RX_NAME }, /* Rx virtualiser. */
+    { 3, 0, NET_VIRT_TX_NAME }, /* Tx virtualiser. */
+    { 4, 1, NET_COPY0_NAME }, /* Copy component 0. */
+    { 5, 1, NET_COPY1_NAME }, /* Copy component 1. */
+    { 6, 1, NET_CLI0_NAME }, /* LWIP client 0. */
+    { 7, 1, NET_CLI1_NAME }, /* LWIP client 1. */
+    { 8, 1, NET_TIMER_NAME } /* Timer driver. */
+};
+
+typedef struct {
+    uint64_t core_bitmap; /* Bitmap of client IDs on this core. */
+    uint32_t core_value; /* Core of this benchmark process. */
+    uint32_t max_core_id; /* Maximum ID of client on this core. */
+    bool last_core; /* Whether this bench process is the last in the notification chain. */
+} core_config_t;
+
+static void bench_core_config_info(char *pd_name, core_config_t *core_config)
+{
+    core_config->max_core_id = 0;
+    core_config->last_core = false;
+
+    if (!sddf_strcmp(pd_name, "bench0")) {
+        core_config->core_value = 0;
+    } else if (!sddf_strcmp(pd_name, "bench1")) {
+        core_config->core_value = 1;
+    } else if (!sddf_strcmp(pd_name, "bench2")) {
+        core_config->core_value = 2;
+    } else if (!sddf_strcmp(pd_name, "bench3")) {
+        core_config->core_value = 3;
+    } else {
+        return;
+    }
+
+    if (core_config->core_value == LAST_CORE) {
+        core_config->last_core = true;
+    }
+
+    for (uint16_t i = 0; i < NUM_PDS_TO_TRACK; i++) {
+        if (pd_core_info[i].pd_core == core_config->core_value) {
+            core_config->core_bitmap |= (1 << pd_core_info[i].pd_id);
+            if (pd_core_info[i].pd_id > core_config->max_core_id) {
+                core_config->max_core_id = pd_core_info[i].pd_id;
+            }
+        }
+    }
+}
+
+static uint16_t bench_active_cores()
+{
+    uint16_t active_cores = 0;
+    for (uint16_t i = 0; i < NUM_PDS_TO_TRACK; i++) {
+        active_cores |= (1 << pd_core_info[i].pd_core);
+    }
+
+    return active_cores;
+}
+
+static char *pd_id_to_name(uint16_t pd_id)
+{
+    for (uint16_t i = 0; i < NUM_PDS_TO_TRACK; i++) {
+        if (pd_core_info[i].pd_id == pd_id) {
+            return pd_core_info[i].pd_name;
+        }
+    }
+
+    return NULL;
+}

--- a/examples/echo_server/include/serial_config/serial_config.h
+++ b/examples/echo_server/include/serial_config/serial_config.h
@@ -11,7 +11,7 @@
 #include <stdint.h>
 
 /* Number of clients that can be connected to the serial server. */
-#define SERIAL_NUM_CLIENTS 3
+#define NUM_SERIAL_CLIENTS 3
 
 /* Only support transmission and not receive. */
 #define SERIAL_TX_ONLY 1
@@ -41,47 +41,63 @@
 #define SERIAL_TX_DATA_REGION_CAPACITY_CLI1            SERIAL_DATA_REGION_CAPACITY
 #define SERIAL_TX_DATA_REGION_CAPACITY_CLI2            SERIAL_DATA_REGION_CAPACITY
 
+/* To avoid deadlocks caused when the virtualiser adds colour codes to the
+   start and end of strings, driver data region must be larger than any
+   client data region. */
 #define SERIAL_MAX_CLIENT_TX_DATA_CAPACITY MAX(SERIAL_TX_DATA_REGION_CAPACITY_CLI2, MAX(SERIAL_TX_DATA_REGION_CAPACITY_CLI0, SERIAL_TX_DATA_REGION_CAPACITY_CLI1))
 #if SERIAL_WITH_COLOUR
 _Static_assert(SERIAL_TX_DATA_REGION_CAPACITY_DRIV > SERIAL_MAX_CLIENT_TX_DATA_CAPACITY,
                "Driver TX data region must be larger than all client data regions in SERIAL_WITH_COLOUR mode.");
 #endif
 
+/* Ensure the entire data region can be assigned a unique index by a 32 bit
+   unsigned. */
 #define SERIAL_MAX_DATA_CAPACITY MAX(SERIAL_TX_DATA_REGION_CAPACITY_DRIV, SERIAL_MAX_CLIENT_TX_DATA_CAPACITY)
 _Static_assert(SERIAL_MAX_DATA_CAPACITY < UINT32_MAX,
                "Data regions must be smaller than UINT32 max to correctly use queue data structure.");
 
-static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_t *rx_queue_handle,
-                                             serial_queue_t *rx_queue,
-                                             char *rx_data, serial_queue_handle_t *tx_queue_handle, serial_queue_t *tx_queue, char *tx_data)
+static inline void serial_cli_data_capacity(char *pd_name, uint32_t *rx_data_capacity, uint32_t *tx_data_capacity)
 {
     if (!sddf_strcmp(pd_name, SERIAL_CLI0_NAME)) {
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI0, tx_data);
+        *tx_data_capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI0;
     } else if (!sddf_strcmp(pd_name, SERIAL_CLI1_NAME)) {
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI1, tx_data);
+        *tx_data_capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI1;
     } else if (!sddf_strcmp(pd_name, SERIAL_CLI2_NAME)) {
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI2, tx_data);
+        *tx_data_capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI2;
     }
 }
 
-static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle_t *cli_queue_handle,
-                                              serial_queue_t *cli_queue, char *cli_data)
+typedef struct serial_queue_info {
+    serial_queue_t *cli_queue;
+    char *cli_data;
+    uint32_t capacity;
+} serial_queue_info_t;
+
+static inline void serial_virt_queue_info(char *pd_name, serial_queue_t *cli_queue, char *cli_data,
+                                          serial_queue_info_t ret[NUM_SERIAL_CLIENTS])
 {
     if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
-        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI0, cli_data);
-        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)((uintptr_t)cli_queue + SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_CAPACITY_CLI1, cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0);
-        serial_queue_init(&cli_queue_handle[2], (serial_queue_t *)((uintptr_t)cli_queue + 2 * SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_CAPACITY_CLI2,
-                          cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0 + SERIAL_TX_DATA_REGION_CAPACITY_CLI1);
+        ret[0] = (serial_queue_info_t) { .cli_queue = cli_queue,
+                                         .cli_data = cli_data,
+                                         .capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI0 };
+        ret[1] =
+            (serial_queue_info_t) { .cli_queue = (serial_queue_t *)((uintptr_t)ret[0].cli_queue + SERIAL_QUEUE_SIZE),
+                                    .cli_data = ret[0].cli_data + ret[0].capacity,
+                                    .capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI1 };
+        ret[2] =
+            (serial_queue_info_t) { .cli_queue = (serial_queue_t *)((uintptr_t)ret[1].cli_queue + SERIAL_QUEUE_SIZE),
+                                    .cli_data = ret[1].cli_data + ret[1].capacity,
+                                    .capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI2 };
     }
 }
 
 #if SERIAL_WITH_COLOUR
-static inline void serial_channel_names_init(char **client_names)
+static inline void serial_channel_names_init(char *pd_name, char *client_names[NUM_SERIAL_CLIENTS])
 {
-    client_names[0] = SERIAL_CLI0_NAME;
-    client_names[1] = SERIAL_CLI1_NAME;
-    client_names[2] = SERIAL_CLI2_NAME;
+    if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
+        client_names[0] = SERIAL_CLI0_NAME;
+        client_names[1] = SERIAL_CLI1_NAME;
+        client_names[2] = SERIAL_CLI2_NAME;
+    }
 }
 #endif

--- a/examples/echo_server/include/serial_config_smp/serial_config.h
+++ b/examples/echo_server/include/serial_config_smp/serial_config.h
@@ -11,7 +11,7 @@
 #include <stdint.h>
 
 /* Number of clients that can be connected to the serial server. */
-#define SERIAL_NUM_CLIENTS 6
+#define NUM_SERIAL_CLIENTS 6
 
 /* Only support transmission and not receive. */
 #define SERIAL_TX_ONLY 1
@@ -62,60 +62,69 @@ _Static_assert(SERIAL_TX_DATA_REGION_CAPACITY_DRIV > SERIAL_MAX_CLIENT_TX_DATA_C
 _Static_assert(SERIAL_MAX_DATA_CAPACITY < UINT32_MAX,
                "Data regions must be smaller than UINT32 max to correctly use queue data structure.");
 
-static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_t *rx_queue_handle,
-                                             serial_queue_t *rx_queue, char *rx_data,
-                                             serial_queue_handle_t *tx_queue_handle, serial_queue_t *tx_queue,
-                                             char *tx_data)
+static inline void serial_cli_data_capacity(char *pd_name, uint32_t *rx_data_capacity, uint32_t *tx_data_capacity)
 {
     if (!sddf_strcmp(pd_name, SERIAL_CLI0_NAME)) {
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI0, tx_data);
+        *tx_data_capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI0;
     } else if (!sddf_strcmp(pd_name, SERIAL_CLI1_NAME)) {
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI1, tx_data);
+        *tx_data_capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI1;
     } else if (!sddf_strcmp(pd_name, SERIAL_CLI2_NAME)) {
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI2, tx_data);
+        *tx_data_capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI2;
     } else if (!sddf_strcmp(pd_name, SERIAL_CLI3_NAME)) {
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI3, tx_data);
+        *tx_data_capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI3;
     } else if (!sddf_strcmp(pd_name, SERIAL_CLI4_NAME)) {
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI4, tx_data);
+        *tx_data_capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI4;
     } else if (!sddf_strcmp(pd_name, SERIAL_CLI5_NAME)) {
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI5, tx_data);
+        *tx_data_capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI5;
     }
 }
 
-static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle_t *cli_queue_handle,
-                                              serial_queue_t *cli_queue, char *cli_data)
+typedef struct serial_queue_info {
+    serial_queue_t *cli_queue;
+    char *cli_data;
+    uint32_t capacity;
+} serial_queue_info_t;
+
+static inline void serial_virt_queue_info(char *pd_name, serial_queue_t *cli_queue, char *cli_data,
+                                          serial_queue_info_t ret[NUM_SERIAL_CLIENTS])
 {
     if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
-        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI0, cli_data);
-        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)((uintptr_t)cli_queue + SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_CAPACITY_CLI1, cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0);
-        serial_queue_init(&cli_queue_handle[2], (serial_queue_t *)((uintptr_t)cli_queue + 2 * SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_CAPACITY_CLI2,
-                          cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0 + SERIAL_TX_DATA_REGION_CAPACITY_CLI1);
-        serial_queue_init(&cli_queue_handle[3], (serial_queue_t *)((uintptr_t)cli_queue + 3 * SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_CAPACITY_CLI3,
-                          cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0 + SERIAL_TX_DATA_REGION_CAPACITY_CLI1
-                              + SERIAL_TX_DATA_REGION_CAPACITY_CLI2);
-        serial_queue_init(&cli_queue_handle[4], (serial_queue_t *)((uintptr_t)cli_queue + 4 * SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_CAPACITY_CLI4,
-                          cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0 + SERIAL_TX_DATA_REGION_CAPACITY_CLI1
-                              + SERIAL_TX_DATA_REGION_CAPACITY_CLI2 + SERIAL_TX_DATA_REGION_CAPACITY_CLI3);
-        serial_queue_init(&cli_queue_handle[5], (serial_queue_t *)((uintptr_t)cli_queue + 5 * SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_CAPACITY_CLI5,
-                          cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0 + SERIAL_TX_DATA_REGION_CAPACITY_CLI1
-                              + SERIAL_TX_DATA_REGION_CAPACITY_CLI2 + SERIAL_TX_DATA_REGION_CAPACITY_CLI3
-                              + SERIAL_TX_DATA_REGION_CAPACITY_CLI4);
+        ret[0] = (serial_queue_info_t) { .cli_queue = cli_queue,
+                                         .cli_data = cli_data,
+                                         .capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI0 };
+        ret[1] =
+            (serial_queue_info_t) { .cli_queue = (serial_queue_t *)((uintptr_t)ret[0].cli_queue + SERIAL_QUEUE_SIZE),
+                                    .cli_data = ret[0].cli_data + ret[0].capacity,
+                                    .capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI1 };
+        ret[2] =
+            (serial_queue_info_t) { .cli_queue = (serial_queue_t *)((uintptr_t)ret[1].cli_queue + SERIAL_QUEUE_SIZE),
+                                    .cli_data = ret[1].cli_data + ret[1].capacity,
+                                    .capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI2 };
+        ret[3] =
+            (serial_queue_info_t) { .cli_queue = (serial_queue_t *)((uintptr_t)ret[2].cli_queue + SERIAL_QUEUE_SIZE),
+                                    .cli_data = ret[2].cli_data + ret[2].capacity,
+                                    .capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI3 };
+        ret[4] =
+            (serial_queue_info_t) { .cli_queue = (serial_queue_t *)((uintptr_t)ret[3].cli_queue + SERIAL_QUEUE_SIZE),
+                                    .cli_data = ret[3].cli_data + ret[3].capacity,
+                                    .capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI4 };
+        ret[5] =
+            (serial_queue_info_t) { .cli_queue = (serial_queue_t *)((uintptr_t)ret[4].cli_queue + SERIAL_QUEUE_SIZE),
+                                    .cli_data = ret[4].cli_data + ret[4].capacity,
+                                    .capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI5 };
     }
 }
 
 #if SERIAL_WITH_COLOUR
-static inline void serial_channel_names_init(char **client_names)
+static inline void serial_channel_names_init(char *pd_name, char *client_names[NUM_SERIAL_CLIENTS])
 {
-    client_names[0] = SERIAL_CLI0_NAME;
-    client_names[1] = SERIAL_CLI1_NAME;
-    client_names[2] = SERIAL_CLI2_NAME;
-    client_names[3] = SERIAL_CLI3_NAME;
-    client_names[4] = SERIAL_CLI4_NAME;
-    client_names[5] = SERIAL_CLI5_NAME;
+    if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
+        client_names[0] = SERIAL_CLI0_NAME;
+        client_names[1] = SERIAL_CLI1_NAME;
+        client_names[2] = SERIAL_CLI2_NAME;
+        client_names[3] = SERIAL_CLI3_NAME;
+        client_names[4] = SERIAL_CLI4_NAME;
+        client_names[5] = SERIAL_CLI5_NAME;
+    }
 }
 #endif

--- a/examples/echo_server/include/serial_config_smp/serial_config.h
+++ b/examples/echo_server/include/serial_config_smp/serial_config.h
@@ -11,7 +11,7 @@
 #include <stdint.h>
 
 /* Number of clients that can be connected to the serial server. */
-#define SERIAL_NUM_CLIENTS 3
+#define SERIAL_NUM_CLIENTS 6
 
 /* Only support transmission and not receive. */
 #define SERIAL_TX_ONLY 1
@@ -31,6 +31,9 @@
 #define SERIAL_CLI0_NAME "client0"
 #define SERIAL_CLI1_NAME "client1"
 #define SERIAL_CLI2_NAME "bench0"
+#define SERIAL_CLI3_NAME "bench1"
+#define SERIAL_CLI4_NAME "bench2"
+#define SERIAL_CLI5_NAME "bench3"
 #define SERIAL_VIRT_TX_NAME "serial_virt_tx"
 
 #define SERIAL_QUEUE_SIZE                              0x1000
@@ -40,20 +43,29 @@
 #define SERIAL_TX_DATA_REGION_CAPACITY_CLI0            SERIAL_DATA_REGION_CAPACITY
 #define SERIAL_TX_DATA_REGION_CAPACITY_CLI1            SERIAL_DATA_REGION_CAPACITY
 #define SERIAL_TX_DATA_REGION_CAPACITY_CLI2            SERIAL_DATA_REGION_CAPACITY
+#define SERIAL_TX_DATA_REGION_CAPACITY_CLI3            SERIAL_DATA_REGION_CAPACITY
+#define SERIAL_TX_DATA_REGION_CAPACITY_CLI4            SERIAL_DATA_REGION_CAPACITY
+#define SERIAL_TX_DATA_REGION_CAPACITY_CLI5            SERIAL_DATA_REGION_CAPACITY
 
-#define SERIAL_MAX_CLIENT_TX_DATA_CAPACITY MAX(SERIAL_TX_DATA_REGION_CAPACITY_CLI2, MAX(SERIAL_TX_DATA_REGION_CAPACITY_CLI0, SERIAL_TX_DATA_REGION_CAPACITY_CLI1))
+/* To avoid deadlocks caused when the virtualiser adds colour codes to the
+   start and end of strings, driver data region must be larger than any
+   client data region. */
+#define SERIAL_MAX_CLIENT_TX_DATA_CAPACITY SERIAL_DATA_REGION_CAPACITY
 #if SERIAL_WITH_COLOUR
 _Static_assert(SERIAL_TX_DATA_REGION_CAPACITY_DRIV > SERIAL_MAX_CLIENT_TX_DATA_CAPACITY,
                "Driver TX data region must be larger than all client data regions in SERIAL_WITH_COLOUR mode.");
 #endif
 
+/* Ensure the entire data region can be assigned a unique index by a 32 bit
+   unsigned. */
 #define SERIAL_MAX_DATA_CAPACITY MAX(SERIAL_TX_DATA_REGION_CAPACITY_DRIV, SERIAL_MAX_CLIENT_TX_DATA_CAPACITY)
 _Static_assert(SERIAL_MAX_DATA_CAPACITY < UINT32_MAX,
                "Data regions must be smaller than UINT32 max to correctly use queue data structure.");
 
 static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_t *rx_queue_handle,
-                                             serial_queue_t *rx_queue,
-                                             char *rx_data, serial_queue_handle_t *tx_queue_handle, serial_queue_t *tx_queue, char *tx_data)
+                                             serial_queue_t *rx_queue, char *rx_data,
+                                             serial_queue_handle_t *tx_queue_handle, serial_queue_t *tx_queue,
+                                             char *tx_data)
 {
     if (!sddf_strcmp(pd_name, SERIAL_CLI0_NAME)) {
         serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI0, tx_data);
@@ -61,6 +73,12 @@ static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_
         serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI1, tx_data);
     } else if (!sddf_strcmp(pd_name, SERIAL_CLI2_NAME)) {
         serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI2, tx_data);
+    } else if (!sddf_strcmp(pd_name, SERIAL_CLI3_NAME)) {
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI3, tx_data);
+    } else if (!sddf_strcmp(pd_name, SERIAL_CLI4_NAME)) {
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI4, tx_data);
+    } else if (!sddf_strcmp(pd_name, SERIAL_CLI5_NAME)) {
+        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI5, tx_data);
     }
 }
 
@@ -74,6 +92,19 @@ static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle
         serial_queue_init(&cli_queue_handle[2], (serial_queue_t *)((uintptr_t)cli_queue + 2 * SERIAL_QUEUE_SIZE),
                           SERIAL_TX_DATA_REGION_CAPACITY_CLI2,
                           cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0 + SERIAL_TX_DATA_REGION_CAPACITY_CLI1);
+        serial_queue_init(&cli_queue_handle[3], (serial_queue_t *)((uintptr_t)cli_queue + 3 * SERIAL_QUEUE_SIZE),
+                          SERIAL_TX_DATA_REGION_CAPACITY_CLI3,
+                          cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0 + SERIAL_TX_DATA_REGION_CAPACITY_CLI1
+                              + SERIAL_TX_DATA_REGION_CAPACITY_CLI2);
+        serial_queue_init(&cli_queue_handle[4], (serial_queue_t *)((uintptr_t)cli_queue + 4 * SERIAL_QUEUE_SIZE),
+                          SERIAL_TX_DATA_REGION_CAPACITY_CLI4,
+                          cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0 + SERIAL_TX_DATA_REGION_CAPACITY_CLI1
+                              + SERIAL_TX_DATA_REGION_CAPACITY_CLI2 + SERIAL_TX_DATA_REGION_CAPACITY_CLI3);
+        serial_queue_init(&cli_queue_handle[5], (serial_queue_t *)((uintptr_t)cli_queue + 5 * SERIAL_QUEUE_SIZE),
+                          SERIAL_TX_DATA_REGION_CAPACITY_CLI5,
+                          cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0 + SERIAL_TX_DATA_REGION_CAPACITY_CLI1
+                              + SERIAL_TX_DATA_REGION_CAPACITY_CLI2 + SERIAL_TX_DATA_REGION_CAPACITY_CLI3
+                              + SERIAL_TX_DATA_REGION_CAPACITY_CLI4);
     }
 }
 
@@ -83,5 +114,8 @@ static inline void serial_channel_names_init(char **client_names)
     client_names[0] = SERIAL_CLI0_NAME;
     client_names[1] = SERIAL_CLI1_NAME;
     client_names[2] = SERIAL_CLI2_NAME;
+    client_names[3] = SERIAL_CLI3_NAME;
+    client_names[4] = SERIAL_CLI4_NAME;
+    client_names[5] = SERIAL_CLI5_NAME;
 }
 #endif

--- a/examples/echo_server/lwip.c
+++ b/examples/echo_server/lwip.c
@@ -286,13 +286,15 @@ static void netif_status_callback(struct netif *netif)
 
 void init(void)
 {
-    serial_cli_queue_init_sys(microkit_name, NULL, NULL, NULL, &serial_tx_queue_handle, serial_tx_queue, serial_tx_data);
+    uint32_t serial_tx_data_capacity;
+    serial_cli_data_capacity(microkit_name, NULL, &serial_tx_data_capacity);
+    serial_queue_init(&serial_tx_queue_handle, serial_tx_queue, serial_tx_data_capacity, serial_tx_data);
     serial_putchar_init(SERIAL_TX_CH, &serial_tx_queue_handle);
 
-    size_t rx_capacity, tx_capacity;
-    net_cli_queue_capacity(microkit_name, &rx_capacity, &tx_capacity);
-    net_queue_init(&state.rx_queue, rx_free, rx_active, rx_capacity);
-    net_queue_init(&state.tx_queue, tx_free, tx_active, tx_capacity);
+    size_t net_rx_capacity, net_tx_capacity;
+    net_cli_queue_capacity(microkit_name, &net_rx_capacity, &net_tx_capacity);
+    net_queue_init(&state.rx_queue, rx_free, rx_active, net_rx_capacity);
+    net_queue_init(&state.tx_queue, tx_free, tx_active, net_tx_capacity);
     net_buffers_init(&state.tx_queue, 0);
 
     lwip_init();

--- a/examples/serial/README.md
+++ b/examples/serial/README.md
@@ -86,7 +86,7 @@ system file including client names and queue sizes, as well as updated initialis
 for clients and virtualisers.
 * **Makefile**
 You must include directories for **SERIAL_COMPONENTS**, the **UART_DRIVER** and your
-**SERIAL_CONFIG_INCLUDE**. You must also supply **SERIAL_NUM_CLIENTS**. You must add the uart
+**SERIAL_CONFIG_INCLUDE**. You must also supply **NUM_SERIAL_CLIENTS**. You must add the uart
 driver, transmit virtualiser and optionally the receive virtualiser to your image list. You must
 add your serial include directory to your cflags, and finally you must include the uart driver
 and serial_components make files. For each component you wish to have access to the serial

--- a/examples/serial/include/serial_config/serial_config.h
+++ b/examples/serial/include/serial_config/serial_config.h
@@ -10,7 +10,8 @@
 #include <sddf/serial/queue.h>
 #include <stdint.h>
 
-#define SERIAL_NUM_CLIENTS 2
+/* Number of clients that can be connected to the serial server. */
+#define NUM_SERIAL_CLIENTS 2
 
 /* Only support transmission and not receive. */
 #define SERIAL_TX_ONLY 0
@@ -47,49 +48,68 @@
 #define SERIAL_RX_DATA_REGION_CAPACITY_CLI0            SERIAL_DATA_REGION_CAPACITY
 #define SERIAL_RX_DATA_REGION_CAPACITY_CLI1            SERIAL_DATA_REGION_CAPACITY
 
+/* To avoid deadlocks caused when the virtualiser adds colour codes to the
+   start and end of strings, driver data region must be larger than any
+   client data region. */
 #define SERIAL_MAX_CLIENT_TX_DATA_CAPACITY MAX(SERIAL_TX_DATA_REGION_CAPACITY_CLI0, SERIAL_TX_DATA_REGION_CAPACITY_CLI1)
 #if SERIAL_WITH_COLOUR
 _Static_assert(SERIAL_TX_DATA_REGION_CAPACITY_DRIV > SERIAL_MAX_CLIENT_TX_DATA_CAPACITY,
                "Driver TX data region must be larger than all client data regions in SERIAL_WITH_COLOUR mode.");
 #endif
 
+/* Ensure the entire data region can be assigned a unique index by a 32 bit
+   unsigned. */
 #define SERIAL_MAX_TX_DATA_CAPACITY MAX(SERIAL_TX_DATA_REGION_CAPACITY_DRIV, SERIAL_MAX_CLIENT_TX_DATA_CAPACITY)
 #define SERIAL_MAX_RX_DATA_CAPACITY MAX(SERIAL_RX_DATA_REGION_CAPACITY_DRIV, MAX(SERIAL_RX_DATA_REGION_CAPACITY_CLI0, SERIAL_RX_DATA_REGION_CAPACITY_CLI1))
 #define SERIAL_MAX_DATA_CAPACITY MAX(SERIAL_MAX_TX_DATA_CAPACITY, SERIAL_MAX_RX_DATA_CAPACITY)
 _Static_assert(SERIAL_MAX_DATA_CAPACITY < UINT32_MAX,
                "Data regions must be smaller than UINT32 max to correctly use queue data structure.");
 
-static inline void serial_cli_queue_init_sys(char *pd_name, serial_queue_handle_t *rx_queue_handle,
-                                             serial_queue_t *rx_queue,
-                                             char *rx_data, serial_queue_handle_t *tx_queue_handle, serial_queue_t *tx_queue, char *tx_data)
+static inline void serial_cli_data_capacity(char *pd_name, uint32_t *rx_data_capacity, uint32_t *tx_data_capacity)
 {
     if (!sddf_strcmp(pd_name, SERIAL_CLI0_NAME)) {
-        serial_queue_init(rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_CAPACITY_CLI0, rx_data);
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI0, tx_data);
+        *tx_data_capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI0;
+        *rx_data_capacity = SERIAL_RX_DATA_REGION_CAPACITY_CLI0;
     } else if (!sddf_strcmp(pd_name, SERIAL_CLI1_NAME)) {
-        serial_queue_init(rx_queue_handle, rx_queue, SERIAL_RX_DATA_REGION_CAPACITY_CLI1, rx_data);
-        serial_queue_init(tx_queue_handle, tx_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI1, tx_data);
+        *tx_data_capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI1;
+        *rx_data_capacity = SERIAL_RX_DATA_REGION_CAPACITY_CLI1;
     }
 }
 
-static inline void serial_virt_queue_init_sys(char *pd_name, serial_queue_handle_t *cli_queue_handle,
-                                              serial_queue_t *cli_queue, char *cli_data)
+typedef struct serial_queue_info {
+    serial_queue_t *cli_queue;
+    char *cli_data;
+    uint32_t capacity;
+} serial_queue_info_t;
+
+static inline void serial_virt_queue_info(char *pd_name, serial_queue_t *cli_queue, char *cli_data,
+                                          serial_queue_info_t ret[NUM_SERIAL_CLIENTS])
 {
-    if (!sddf_strcmp(pd_name, SERIAL_VIRT_RX_NAME)) {
-        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_RX_DATA_REGION_CAPACITY_CLI0, cli_data);
-        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)((uintptr_t)cli_queue + SERIAL_QUEUE_SIZE),
-                          SERIAL_RX_DATA_REGION_CAPACITY_CLI1, cli_data + SERIAL_RX_DATA_REGION_CAPACITY_CLI0);
-    } else if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
-        serial_queue_init(cli_queue_handle, cli_queue, SERIAL_TX_DATA_REGION_CAPACITY_CLI0, cli_data);
-        serial_queue_init(&cli_queue_handle[1], (serial_queue_t *)((uintptr_t)cli_queue + SERIAL_QUEUE_SIZE),
-                          SERIAL_TX_DATA_REGION_CAPACITY_CLI1, cli_data + SERIAL_TX_DATA_REGION_CAPACITY_CLI0);
+    if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
+        ret[0] = (serial_queue_info_t) { .cli_queue = cli_queue,
+                                         .cli_data = cli_data,
+                                         .capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI0 };
+        ret[1] =
+            (serial_queue_info_t) { .cli_queue = (serial_queue_t *)((uintptr_t)ret[0].cli_queue + SERIAL_QUEUE_SIZE),
+                                    .cli_data = ret[0].cli_data + ret[0].capacity,
+                                    .capacity = SERIAL_TX_DATA_REGION_CAPACITY_CLI1 };
+    } else if (!sddf_strcmp(pd_name, SERIAL_VIRT_RX_NAME)) {
+        ret[0] = (serial_queue_info_t) { .cli_queue = cli_queue,
+                                         .cli_data = cli_data,
+                                         .capacity = SERIAL_RX_DATA_REGION_CAPACITY_CLI0 };
+        ret[1] =
+            (serial_queue_info_t) { .cli_queue = (serial_queue_t *)((uintptr_t)ret[0].cli_queue + SERIAL_QUEUE_SIZE),
+                                    .cli_data = ret[0].cli_data + ret[0].capacity,
+                                    .capacity = SERIAL_RX_DATA_REGION_CAPACITY_CLI1 };
     }
 }
 
 #if SERIAL_WITH_COLOUR
-static inline void serial_channel_names_init(char **client_names)
+static inline void serial_channel_names_init(char *pd_name, char *client_names[NUM_SERIAL_CLIENTS])
 {
-    client_names[0] = SERIAL_CLI0_NAME;
-    client_names[1] = SERIAL_CLI1_NAME;
+    if (!sddf_strcmp(pd_name, SERIAL_VIRT_TX_NAME)) {
+        client_names[0] = SERIAL_CLI0_NAME;
+        client_names[1] = SERIAL_CLI1_NAME;
+    }
 }
 #endif

--- a/examples/serial/serial_server.c
+++ b/examples/serial/serial_server.c
@@ -24,7 +24,10 @@ uint32_t local_head;
 
 void init(void)
 {
-    serial_cli_queue_init_sys(microkit_name, &rx_queue_handle, rx_queue, rx_data, &tx_queue_handle, tx_queue, tx_data);
+    uint32_t rx_data_capacity, tx_data_capacity;
+    serial_cli_data_capacity(microkit_name, &rx_data_capacity, &tx_data_capacity);
+    serial_queue_init(&rx_queue_handle, rx_queue, rx_data_capacity, rx_data);
+    serial_queue_init(&tx_queue_handle, tx_queue, tx_data_capacity, tx_data);
     serial_putchar_init(TX_CH, &tx_queue_handle);
     sddf_printf("Hello world! I am %s.\nPlease give me character!\n", microkit_name);
 }


### PR DESCRIPTION
This PR redesigns the serial config files in line with the ethernet config files updated here https://github.com/au-ts/sddf/pull/203. 

Rather than initialising the serial queues on behalf of the components, the config functions now initialise the variables required by the components to initialise the queues, allowing the components to initialise their own queues.

In the case of the serial clients, this is just the capacity of the serial queues. For the virtualisers, this PR introduces a `serial_queue_info` struct (like the `net_queue_info` struct), which contains client queue addresses, capacity and data region addresses. A struct is initialised for each client, allowing the virtualisers to initialise client queues with the struct. 

Note that this PR is based off https://github.com/au-ts/sddf/pull/255, and should be merged secondary to that.