### PR TITLE
drivers/blk/virtio: make setvars consistent with other block drivers

### DIFF
--- a/drivers/blk/virtio/block.c
+++ b/drivers/blk/virtio/block.c
@@ -49,8 +49,8 @@
 uintptr_t blk_regs;
 
 blk_storage_info_t *blk_storage_info;
-uintptr_t blk_request;
-uintptr_t blk_response;
+blk_req_queue_t *blk_req_queue;
+blk_resp_queue_t *blk_resp_queue;
 
 uintptr_t requests_paddr;
 uintptr_t requests_vaddr;
@@ -395,7 +395,7 @@ void init(void)
     regs = (volatile virtio_mmio_regs_t *)(blk_regs + VIRTIO_MMIO_BLK_OFFSET);
     virtio_blk_init();
 
-    blk_queue_init(&blk_queue, (blk_req_queue_t *)blk_request, (blk_resp_queue_t *)blk_response, QUEUE_SIZE);
+    blk_queue_init(&blk_queue, blk_req_queue, blk_resp_queue, QUEUE_SIZE);
 }
 
 void notified(microkit_channel ch)

--- a/examples/blk/board/qemu_virt_aarch64/blk.system
+++ b/examples/blk/board/qemu_virt_aarch64/blk.system
@@ -29,8 +29,8 @@
         <setvar symbol="requests_paddr" region_paddr="blk_driver_metadata" />
 
         <map mr="blk_driver_storage_info" vaddr="0x40_000_000" perms="rw" cached="true" setvar_vaddr="blk_storage_info" />
-        <map mr="blk_driver_request" vaddr="0x40_200_000" perms="rw" cached="true" setvar_vaddr="blk_request" />
-        <map mr="blk_driver_response" vaddr="0x40_400_000" perms="rw" cached="true" setvar_vaddr="blk_response" />
+        <map mr="blk_driver_request" vaddr="0x40_200_000" perms="rw" cached="true" setvar_vaddr="blk_req_queue" />
+        <map mr="blk_driver_response" vaddr="0x40_400_000" perms="rw" cached="true" setvar_vaddr="blk_resp_queue" />
 
         <map mr="blk_virtio_headers" vaddr="0x50_000_000" perms="rw" cached="false" setvar_vaddr="virtio_headers_vaddr" />
         <map mr="blk_driver_metadata" vaddr="0x60_000_000" perms="rw" cached="false" setvar_vaddr="requests_vaddr" />


### PR DESCRIPTION
The i.MX8 uSDHC driver uses `blk_req_queue` and `blk_resp_queue` which makes more sense. So we make the virtIO driver conssitent with it.