### PR TITLE
Fix serial queue flag functions and descriptions

### DIFF
--- a/include/sddf/serial/queue.h
+++ b/include/sddf/serial/queue.h
@@ -365,24 +365,11 @@ static inline void serial_queue_init(serial_queue_handle_t *queue_handle, serial
 }
 
 /**
- * Indicate to producer of the queue that consumer requires signalling.
- *
- * @param queue queue handle of queue that requires signalling upon enqueuing.
- */
-static inline void serial_request_consumer_signal(serial_queue_handle_t *queue_handle)
-{
-    queue_handle->queue->consumer_signalled = 0;
-#ifdef CONFIG_ENABLE_SMP_SUPPORT
-    THREAD_MEMORY_RELEASE();
-#endif
-}
-
-/**
  * Indicate to consumer of the queue that producer requires signalling.
  *
  * @param queue queue handle of queue that requires signalling upon enqueuing.
  */
-static inline void serial_request_producer_signal(serial_queue_handle_t *queue_handle)
+static inline void serial_request_consumer_signal(serial_queue_handle_t *queue_handle)
 {
     queue_handle->queue->producer_signalled = 0;
 #ifdef CONFIG_ENABLE_SMP_SUPPORT
@@ -391,24 +378,24 @@ static inline void serial_request_producer_signal(serial_queue_handle_t *queue_h
 }
 
 /**
- * Indicate to producer of the queue that consumer has been signalled.
+ * Indicate to producer of the queue that consumer requires signalling.
  *
- * @param queue queue handle of the queue that has been signalled.
+ * @param queue queue handle of queue that requires signalling upon enqueuing.
  */
-static inline void serial_cancel_consumer_signal(serial_queue_handle_t *queue_handle)
+static inline void serial_request_producer_signal(serial_queue_handle_t *queue_handle)
 {
-    queue_handle->queue->consumer_signalled = 1;
+    queue_handle->queue->consumer_signalled = 0;
 #ifdef CONFIG_ENABLE_SMP_SUPPORT
     THREAD_MEMORY_RELEASE();
 #endif
 }
 
 /**
- * Indicate to consumer of the queue that producer has been signalled.
+ * Indicate that producer has been signalled.
  *
  * @param queue queue handle of the queue that has been signalled.
  */
-static inline void serial_cancel_producer_signal(serial_queue_handle_t *queue_handle)
+static inline void serial_cancel_consumer_signal(serial_queue_handle_t *queue_handle)
 {
     queue_handle->queue->producer_signalled = 1;
 #ifdef CONFIG_ENABLE_SMP_SUPPORT
@@ -417,13 +404,16 @@ static inline void serial_cancel_producer_signal(serial_queue_handle_t *queue_ha
 }
 
 /**
- * Consumer of the queue requires signalling.
+ * Indicate that consumer has been signalled.
  *
- * @param queue queue handle of the queue to check.
+ * @param queue queue handle of the queue that has been signalled.
  */
-static inline bool serial_require_consumer_signal(serial_queue_handle_t *queue_handle)
+static inline void serial_cancel_producer_signal(serial_queue_handle_t *queue_handle)
 {
-    return !queue_handle->queue->consumer_signalled;
+    queue_handle->queue->consumer_signalled = 1;
+#ifdef CONFIG_ENABLE_SMP_SUPPORT
+    THREAD_MEMORY_RELEASE();
+#endif
 }
 
 /**
@@ -431,7 +421,17 @@ static inline bool serial_require_consumer_signal(serial_queue_handle_t *queue_h
  *
  * @param queue queue handle of the queue to check.
  */
-static inline bool serial_require_producer_signal(serial_queue_handle_t *queue_handle)
+static inline bool serial_require_consumer_signal(serial_queue_handle_t *queue_handle)
 {
     return !queue_handle->queue->producer_signalled;
+}
+
+/**
+ * Consumer of the queue requires signalling.
+ *
+ * @param queue queue handle of the queue to check.
+ */
+static inline bool serial_require_producer_signal(serial_queue_handle_t *queue_handle)
+{
+    return !queue_handle->queue->consumer_signalled;
 }


### PR DESCRIPTION
It was pointed out by @alwin-joshy that the descriptions of the serial queue flags and flag functions were incorrect. Since we already use that name `consumer_signalled` in the network queue to indicate whether the consumer of the queue has been signalled, I updated the serial queue library to be in line with this.

This came down to two changes:
- Fixing the function descriptions to accurately describe their usage.
- Swapping which flag corresponds to which side of the queue - prior to this PR, the consumer would set the `producer_signalled` flag to indicate whether it needed to be signalled, and vice versa for the producer. This does not align with the network queue (and the original intention), thus I updated the flag functions so that the consumer now sets the `consumer_signalled` flag to indicate whether or not it requires signalling. Likewise all other flag setting functions have been updated.

This PR is invisible to any components using the library, as flags are always accessed through these functions.