### PR TITLE
drivers/serial/virtio: do not define DEBUG_DRIVER by default

### DIFF
--- a/drivers/serial/virtio/include/console.h
+++ b/drivers/serial/virtio/include/console.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#define DEBUG_DRIVER
+// #define DEBUG_DRIVER
 
 #ifdef DEBUG_DRIVER
 #define LOG_DRIVER(...) do{ sddf_dprintf("CONSOLE DRIVER|INFO: "); sddf_dprintf(__VA_ARGS__); }while(0)


### PR DESCRIPTION
Forgot to not commit this