### PR TITLE
ci: update to GCC-12 and use macos-14

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -26,9 +26,9 @@ jobs:
         run: sudo apt update && sudo apt install -y make llvm lld xxd
       - name: Download and install AArch64 GCC toolchain
         run: |
-          wget -O aarch64-toolchain.tar.gz https://trustworthy.systems/Downloads/microkit/arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-elf.tar.xz%3Frev%3D73ff9780c12348b1b6772a1f54ab4bb3
-          tar xf aarch64-toolchain.tar.gz
-          echo "$(pwd)/arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+          wget -O aarch64-toolchain.tar.xz https://trustworthy.systems/Downloads/microkit/arm-gnu-toolchain-12.3.rel1-x86_64-aarch64-none-elf.tar.xz
+          tar xf aarch64-toolchain.tar.xz
+          echo "$(pwd)/arm-gnu-toolchain-12.3.rel1-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
       - name: Install Zig
         uses: mlugg/setup-zig@v1.2.0
         with:
@@ -36,29 +36,29 @@ jobs:
       - name: Build and run examples
         run: ./ci/examples.sh ${PWD}/microkit-sdk-1.4.1
         shell: bash
-  build_macos_x86_64:
-    name: macOS x86-64
-    runs-on: macos-12
+  build_macos_arm64:
+    name: macOS ARM64
+    runs-on: macos-14
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Download Microkit SDK
         run: |
-          wget https://github.com/seL4/microkit/releases/download/1.4.1/microkit-sdk-1.4.1-macos-x86-64.tar.gz
-          tar xf microkit-sdk-1.4.1-macos-x86-64.tar.gz
+          wget https://github.com/seL4/microkit/releases/download/1.4.1/microkit-sdk-1.4.1-macos-aarch64.tar.gz
+          tar xf microkit-sdk-1.4.1-macos-aarch64.tar.gz
       - name: Install dependencies (via Homebrew)
         run: |
-          brew install llvm make
-          echo "/usr/local/opt/llvm/bin:$PATH" >> $GITHUB_PATH
+          brew install llvm lld make
+          echo "/opt/homebrew/opt/llvm/bin:$PATH" >> $GITHUB_PATH
       - name: Install Zig
         uses: mlugg/setup-zig@v1.2.0
         with:
           version: 0.13.0
       - name: Download and install AArch64 GCC toolchain
         run: |
-          wget -O aarch64-toolchain.tar.gz https://trustworthy.systems/Downloads/microkit/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf.tar.xz%3Frev%3D51c39c753f8c4a54875b7c5dccfb84ef
-          tar xf aarch64-toolchain.tar.gz
-          echo "$(pwd)/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-aarch64-none-elf/bin" >> $GITHUB_PATH
+          wget -O aarch64-toolchain.tar.xz https://trustworthy.systems/Downloads/microkit/arm-gnu-toolchain-12.3.rel1-darwin-arm64-aarch64-none-elf.tar.xz
+          tar xf aarch64-toolchain.tar.xz
+          echo "$(pwd)/arm-gnu-toolchain-12.3.rel1-darwin-arm64-aarch64-none-elf/bin" >> $GITHUB_PATH
       - name: Build and run examples
         run: ./ci/examples.sh ${PWD}/microkit-sdk-1.4.1
         shell: bash


### PR DESCRIPTION
macos-12 is deprecated, we don't have aarch64-none-elf version 11 for macOS on Apple Silicon which is what macos-14's environment is. For this reason, we have to update GCC while also updating the macOS version.

Homebrew now packages LLD in a separate package, so we have to install that as well.