### PR TITLE
build.zig: Override MICROKIT_SDK environment variable

### DIFF
--- a/examples/blk/build.zig
+++ b/examples/blk/build.zig
@@ -134,6 +134,7 @@ pub fn build(b: *std.Build) void {
         "-r", b.getInstallPath(.prefix, "./report.txt")
     });
     microkit_tool_cmd.step.dependOn(b.getInstallStep());
+    microkit_tool_cmd.setEnvironmentVariable("MICROKIT_SDK", microkit_sdk);
 
     const microkit_step = b.step("microkit", "Compile and build the final bootable image");
     microkit_step.dependOn(&blk_driver_install.step);

--- a/examples/i2c/build.zig
+++ b/examples/i2c/build.zig
@@ -154,6 +154,7 @@ pub fn build(b: *std.Build) void {
     microkit_tool_cmd.step.dependOn(b.getInstallStep());
     microkit_tool_cmd.step.dependOn(&i2c_driver_install.step);
     microkit_tool_cmd.step.dependOn(&timer_driver_install.step);
+    microkit_tool_cmd.setEnvironmentVariable("MICROKIT_SDK", microkit_sdk);
     const microkit_step = b.step("microkit", "Compile and build the final bootable image");
     microkit_step.dependOn(&microkit_tool_cmd.step);
     b.default_step = microkit_step;

--- a/examples/serial/build.zig
+++ b/examples/serial/build.zig
@@ -154,6 +154,7 @@ pub fn build(b: *std.Build) void {
     });
     microkit_tool_cmd.step.dependOn(b.getInstallStep());
     microkit_tool_cmd.step.dependOn(&driver_install.step);
+    microkit_tool_cmd.setEnvironmentVariable("MICROKIT_SDK", microkit_sdk);
     // Add the "microkit" step, and make it the default step when we execute `zig build`>
     const microkit_step = b.step("microkit", "Compile and build the final bootable image");
     microkit_step.dependOn(&microkit_tool_cmd.step);

--- a/examples/timer/build.zig
+++ b/examples/timer/build.zig
@@ -138,6 +138,7 @@ pub fn build(b: *std.Build) void {
     });
     microkit_tool_cmd.step.dependOn(b.getInstallStep());
     microkit_tool_cmd.step.dependOn(&driver_install.step);
+    microkit_tool_cmd.setEnvironmentVariable("MICROKIT_SDK", microkit_sdk);
     const microkit_step = b.step("microkit", "Compile and build the final bootable image");
     microkit_step.dependOn(&microkit_tool_cmd.step);
     b.default_step = microkit_step;
@@ -163,4 +164,3 @@ pub fn build(b: *std.Build) void {
         simulate_step.dependOn(&qemu_cmd.step);
     }
 }
-


### PR DESCRIPTION
This prevents a footgun whereby an environment variable MICROKIT_SDK is set, but a different `-Dsdk=<sdk>` is set as an argument. This is because the Microkit tool uses the boards path from the environment variable preferentially to the path it is installed in.

This aligns the zig build files to the makefiles.