### PR TITLE
Move `blk` and `mmc` example to default to Clang

### DIFF
--- a/examples/blk/blk.mk
+++ b/examples/blk/blk.mk
@@ -16,7 +16,7 @@ $(error SDDF must be specified)
 endif
 
 ifeq ($(strip $(TOOLCHAIN)),)
-	TOOLCHAIN := aarch64-none-elf
+	TOOLCHAIN := clang
 endif
 
 ifeq ($(strip $(TOOLCHAIN)), clang)

--- a/examples/mmc/mmc.mk
+++ b/examples/mmc/mmc.mk
@@ -13,7 +13,7 @@ $(error SDDF must be specified)
 endif
 
 ifeq ($(strip $(TOOLCHAIN)),)
-	TOOLCHAIN := aarch64-none-elf
+	TOOLCHAIN := clang
 endif
 
 ifeq ($(strip $(TOOLCHAIN)), clang)


### PR DESCRIPTION
To be consistent with all other examples, with the exception of the echo server since it has a dependency on libc.