### PR TITLE
fix: clang compiler in devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,8 @@
               llvm = pkgs.llvmPackages_18;
               zig = zig-overlay.packages.${system}."0.13.0";
             in
-            pkgs.mkShell rec {
+            # mkShellNoCC, because we do not want the cc from stdenv to leak into this shell
+            pkgs.mkShellNoCC rec {
               name = "sddf-dev";
 
               microkit-platform = microkit-platforms.${system} or (throw "Unsupported system: ${system}");
@@ -59,19 +60,34 @@
                 dosfstools
                 imagemagick
 
+                (symlinkJoin {
+                  name = "clang-complete";
+                  paths = llvm.clang-unwrapped.all;
+
+                  # Clang searches up from the directory where it sits to find its built-in
+                  # headers. The `symlinkJoin` creates a symlink to the clang binary, and that
+                  # symlink is what ends up in your PATH from this shell. However, that symlink's
+                  # destination, the clang binary file, still resides in its own nix store
+                  # entry (`llvm.clang-unwrapped`), isolated from the header files (found in
+                  # `llvm.clang-unwrapped.lib` under `lib/clang/18/include`). So when search up its
+                  # parent directories, no built-in headers are found.
+                  #
+                  # By copying over the clang binary over the symlinks in the realisation of the
+                  # `symlinkJoin`, we can fix this; now the search mechanism looks up the parent
+                  # directories of the `clang` binary (which is a copy created by below command),
+                  # until it finds the aforementioned `lib/clang/18/include` (where the `lib` is
+                  # actually a symlink to `llvm.clang-unwrapped.lib + "/lib"`).
+                  postBuild = ''
+                    cp --remove-destination -- ${llvm.clang-unwrapped}/bin/* $out/bin/
+                  '';
+                })
+
                 # for git-clang-format.
                 llvm.libclang.python
-              ];
-
-              buildInputs = [
-                llvm.clang
                 llvm.lld
                 llvm.libllvm
               ];
 
-              # To avoid compile errors since Nix adds extra arguments that are not used
-              # by us.
-              env.NIX_CFLAGS_COMPILE = "-Wno-unused-command-line-argument";
               # To avoid Nix adding compiler flags that are not available on a freestanding
               # environment.
               hardeningDisable = [ "all" ];


### PR DESCRIPTION
This fix makes the unwrapped clang capable to use its built-in headers. Further it tidies up the `mkShell` call a little.

@Ivan-Velickovic Please review, and let me know if the lengthy comment is at least halfway understandable.