### PR TITLE
examples/echo_server: improve README

### DIFF
--- a/examples/echo_server/README.md
+++ b/examples/echo_server/README.md
@@ -6,10 +6,19 @@
 
 # Network echo server
 
+This example shows off the networking sub-system by having a
+[lwIP](https://savannah.nongnu.org/projects/lwip/) based client talking to an ethernet device.
+
+The client simply accepts RX traffic and sends it back out (hence the name 'echo server').
+
 ## Dependencies
 
 Due to the echo server relying on libc functionality, it currently only works with GCC
-instead of LLVM like all the other examples.
+instead of LLVM like all the other examples. As we use this example to perform benchmarking,
+it is important that the functions that lwIP uses from the standard library are optimised
+rather than simple implementations.
+
+For now, we rely on the newlibc packaged with the embedded C toolchains.
 
 The specific toolchain we use for testing and benchmarking the network sub-system is
 the `aarch64-none-elf` GCC toolchain distributed by ARM. You can download it from
@@ -17,8 +26,15 @@ the `aarch64-none-elf` GCC toolchain distributed by ARM. You can download it fro
 
 ## Building
 
+The following platforms are supported:
+* imx8mm_evk
+* imx8mp_evk
+* maaxboard
+* odroidc4
+* qemu_virt_aarch64
+
 ```sh
-make BUILD_DIR=<path/to/build> MICROKIT_SDK=<path/to/sdk> MICROKIT_CONFIG=(benchmark/release/debug)
+make MICROKIT_BOARD=<board> MICROKIT_SDK=<path/to/sdk> MICROKIT_CONFIG=(benchmark/release/debug)
 ```
 
 ## Benchmarking


### PR DESCRIPTION
* list supported platforms.
* explain why we use GCC for now.
* briefly explain the purpose of the example.

We should document the benchmarking process a bit more, but I will leave that for another time.