### PR TITLE
drivers/i2c/meson: fix undefined behaviour

### DIFF
--- a/drivers/i2c/meson/i2c.c
+++ b/drivers/i2c/meson/i2c.c
@@ -414,7 +414,8 @@ static inline void i2c_load_tokens(volatile struct i2c_regs *regs)
                    request_data_offset, tk_offset, wdata_offset, rdata_offset);
 
         // Discover next operation
-        uint8_t meson_token, data;
+        uint8_t meson_token;
+        uint32_t data;
         if (i2c_ifState.rw_remaining == 0) {
             LOG_DRIVER("Accepting new token...\n");
             // Get meson_token if no read/write is in progress.


### PR DESCRIPTION
In `i2c_load_tokens` we're bit-shifting the value of data by potentially more than 8-bits which is undefined behaviour in C if data is uint8_t.

To fix this, we can just make data a uint32_t which makes sense since wdata0 is also uint32_t.