### PR TITLE
Fix build directory structure

### DIFF
--- a/drivers/network/imx/eth_driver.mk
+++ b/drivers/network/imx/eth_driver.mk
@@ -19,11 +19,11 @@ ${CHECK_NETDRV_FLAGS_MD5}:
 	-rm -f .netdrv_cflags-*
 	touch $@
 
-eth_driver.elf: imx/ethernet.o
+eth_driver.elf: network/imx/ethernet.o
 	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
 
-imx/ethernet.o: ${ETHERNET_DRIVER_DIR}/ethernet.c ${CHECK_NETDRV_FLAGS_MD5}
-	mkdir -p imx
+network/imx/ethernet.o: ${ETHERNET_DRIVER_DIR}/ethernet.c ${CHECK_NETDRV_FLAGS_MD5}
+	mkdir -p network/imx
 	${CC} -c ${CFLAGS} ${CFLAGS_network} -I ${ETHERNET_DRIVER_DIR} -o $@ $<
 
 

--- a/drivers/network/meson/eth_driver.mk
+++ b/drivers/network/meson/eth_driver.mk
@@ -19,11 +19,11 @@ ${CHECK_NETDRV_FLAGS_MD5}:
 	-rm -f .netdrv_cflags-*
 	touch $@
 
-eth_driver.elf: meson/ethernet.o
+eth_driver.elf: network/meson/ethernet.o
 	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
 
-meson/ethernet.o: ${ETHERNET_DRIVER_DIR}/ethernet.c ${CHECK_NETDRV_FLAGS_MD5}
-	mkdir -p meson
+network/meson/ethernet.o: ${ETHERNET_DRIVER_DIR}/ethernet.c ${CHECK_NETDRV_FLAGS_MD5}
+	mkdir -p network/meson
 	${CC} -c ${CFLAGS} ${CFLAGS_network} -I ${ETHERNET_DRIVER_DIR} -o $@ $<
 
 -include meson/ethernet.d

--- a/drivers/network/virtio/eth_driver.mk
+++ b/drivers/network/virtio/eth_driver.mk
@@ -20,11 +20,11 @@ ${CHECK_NETDRV_FLAGS_MD5}:
 	-rm -f .netdrv_cflags-*
 	touch $@
 
-eth_driver.elf: virtio/ethernet.o
+eth_driver.elf: network/virtio/ethernet.o
 	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
 
-virtio/ethernet.o: ${ETHERNET_DRIVER_DIR}/ethernet.c ${CHECK_NETDRV_FLAGS}
-	mkdir -p virtio
+network/virtio/ethernet.o: ${ETHERNET_DRIVER_DIR}/ethernet.c ${CHECK_NETDRV_FLAGS}
+	mkdir -p network/virtio
 	${CC} -c ${CFLAGS} ${CFLAGS_network} -I ${ETHERNET_DRIVER_DIR} -o $@ $<
 
 -include virtio/ethernet.d

--- a/serial/components/serial_components.mk
+++ b/serial/components/serial_components.mk
@@ -11,6 +11,7 @@
 #
 
 SERIAL_IMAGES:= serial_virt_rx.elf serial_virt_tx.elf
+SERIAL_COMPONENT_OBJ := $(addprefix serial/components/, serial_virt_tx.o serial_virt_rx.o)
 
 CFLAGS_serial := -I ${SDDF}/include
 
@@ -20,13 +21,17 @@ ${CHECK_SERIAL_FLAGS_MD5}:
 	-rm -f .serial_cflags-*
 	touch $@
 
+${SERIAL_COMPONENT_OBJ}: |serial/components
+${SERIAL_COMPONENT_OBJ}: ${CHECK_SERIAL_FLAGS_MD5}
 
-serial_virt_%.elf: virt_%.o libsddf_util_debug.a
+serial/components/serial_virt_%.o: ${SDDF}/serial/components/virt_%.c
+	${CC} ${CFLAGS} ${CFLAGS_serial} -o $@ -c $<
+
+%.elf: serial/components/%.o libsddf_util_debug.a
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
-virt_tx.o virt_rx.o: ${CHECK_SERIAL_FLAGS_MD5}
-virt_%.o: ${SDDF}/serial/components/virt_%.c 
-	${CC} ${CFLAGS} ${CFLAGS_serial} -o $@ -c $<
+serial/components:
+	mkdir -p $@
 
 clean::
 	rm -f serial_virt_[rt]x.[od] .serial_cflags-*
@@ -34,6 +39,5 @@ clean::
 clobber::
 	rm -f ${SERIAL_IMAGES}
 
-
--include virt_rx.d
--include virt_tx.d
+-include serial/components/serial_virt_rx.d
+-include serial/components/serial_virt_tx.d


### PR DESCRIPTION
When building the network and serial subsystems, I noticed that some object files seem to be in the wrong place/misnamed.

The object files for both the serial virtualisers were placed in the root build directory with the system elfs, and named virt_tx.o and virt_rx.o with no prefix.

The ethernet driver object files were placed in a subdirectory of the build directory corresponding to the device class, but I believe it makes more sense for this subdirectory to reside in the `network` directory, as there is no indication as to what device class the directory corresponds to.

This PR moves the ethernet driver object file directory into the `build/network` directory, and renames the serial virtualiser object files from "virt_[rt]x.o" to "serial_virt_[rt]x.o", and creates the directory `build/serial/components` for them to be placed in.