### PR TITLE
Fixes to build.zigs for API change

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -283,7 +283,7 @@ fn addGpuDriver(
 fn addPd(b: *std.Build, options: std.Build.ExecutableOptions) *std.Build.Step.Compile {
     const pd = b.addExecutable(options);
     pd.addObjectFile(libmicrokit);
-    pd.setLinkerScriptPath(libmicrokit_linker_script);
+    pd.setLinkerScript(libmicrokit_linker_script);
     pd.addIncludePath(libmicrokit_include);
 
     return pd;

--- a/examples/blk/build.zig
+++ b/examples/blk/build.zig
@@ -101,7 +101,7 @@ pub fn build(b: *std.Build) void {
 
     client.addIncludePath(.{ .cwd_relative = libmicrokit_include });
     client.addObjectFile(.{ .cwd_relative = libmicrokit });
-    client.setLinkerScriptPath(.{ .cwd_relative = libmicrokit_linker_script });
+    client.setLinkerScript(.{ .cwd_relative = libmicrokit_linker_script });
 
     const blk_driver = sddf_dep.artifact(b.fmt("driver_blk_{s}.elf", .{ blk_driver_class }));
 

--- a/examples/gpu/build.zig
+++ b/examples/gpu/build.zig
@@ -120,7 +120,7 @@ pub fn build(b: *std.Build) void {
 
     client.addIncludePath(.{ .cwd_relative = libmicrokit_include });
     client.addObjectFile(.{ .cwd_relative = libmicrokit });
-    client.setLinkerScriptPath(.{ .cwd_relative = libmicrokit_linker_script });
+    client.setLinkerScript(.{ .cwd_relative = libmicrokit_linker_script });
 
     b.installArtifact(client);
     b.installArtifact(sddf_dep.artifact("gpu_virt.elf"));

--- a/examples/i2c/build.zig
+++ b/examples/i2c/build.zig
@@ -134,7 +134,7 @@ pub fn build(b: *std.Build) void {
 
     client_pn532.addIncludePath(.{ .cwd_relative = libmicrokit_include });
     client_pn532.addObjectFile(.{ .cwd_relative = libmicrokit });
-    client_pn532.setLinkerScriptPath(.{ .cwd_relative = libmicrokit_linker_script });
+    client_pn532.setLinkerScript(.{ .cwd_relative = libmicrokit_linker_script });
 
     b.installArtifact(client_pn532);
 
@@ -143,7 +143,7 @@ pub fn build(b: *std.Build) void {
 
     client_ds3231.addIncludePath(.{ .cwd_relative = libmicrokit_include });
     client_ds3231.addObjectFile(.{ .cwd_relative = libmicrokit });
-    client_ds3231.setLinkerScriptPath(.{ .cwd_relative = libmicrokit_linker_script });
+    client_ds3231.setLinkerScript(.{ .cwd_relative = libmicrokit_linker_script });
 
     b.installArtifact(client_ds3231);
 

--- a/examples/serial/build.zig
+++ b/examples/serial/build.zig
@@ -140,7 +140,7 @@ pub fn build(b: *std.Build) void {
 
     serial_server.addIncludePath(.{ .cwd_relative = libmicrokit_include });
     serial_server.addObjectFile(.{ .cwd_relative = libmicrokit });
-    serial_server.setLinkerScriptPath(.{ .cwd_relative = libmicrokit_linker_script });
+    serial_server.setLinkerScript(.{ .cwd_relative = libmicrokit_linker_script });
 
     b.installArtifact(serial_server);
 

--- a/examples/timer/build.zig
+++ b/examples/timer/build.zig
@@ -123,7 +123,7 @@ pub fn build(b: *std.Build) void {
 
     client.addIncludePath(.{ .cwd_relative = libmicrokit_include });
     client.addObjectFile(.{ .cwd_relative = libmicrokit });
-    client.setLinkerScriptPath(.{ .cwd_relative = libmicrokit_linker_script });
+    client.setLinkerScript(.{ .cwd_relative = libmicrokit_linker_script });
 
     b.installArtifact(client);
 


### PR DESCRIPTION
setLinkerScriptPath has been replaced by setLinkerScript. It does the exact same thing, it's just a name change.