### PR TITLE
drivers/blk/virtio: add missing void parameters

### DIFF
--- a/drivers/blk/virtio/block.c
+++ b/drivers/blk/virtio/block.c
@@ -82,7 +82,7 @@ uint16_t last_seen_used = 0;
 /* Block device configuration, populated during initiliastion. */
 volatile struct virtio_blk_config *virtio_config;
 
-void handle_response()
+void handle_response(void)
 {
     bool notify = false;
 
@@ -272,7 +272,7 @@ void handle_request()
     }
 }
 
-void handle_irq()
+void handle_irq(void)
 {
     uint32_t irq_status = regs->InterruptStatus;
     if (irq_status & VIRTIO_MMIO_IRQ_VQUEUE) {


### PR DESCRIPTION
Cherry-picked from https://github.com/au-ts/sddf/pull/298 to make that PR less hectic.