### PR TITLE
Remove serial signalling protocol from producers to consumers

### DIFF
--- a/examples/serial/client.c
+++ b/examples/serial/client.c
@@ -29,28 +29,17 @@ void init(void)
 uint16_t char_count;
 void notified(microkit_channel ch)
 {
-    bool reprocess = true;
     char c;
-    while (reprocess) {
-        while (!serial_dequeue(&rx_queue_handle, &c)) {
-            if (c == '\r') {
-                sddf_putchar_unbuffered('\\');
-                sddf_putchar_unbuffered('r');
-            } else {
-                sddf_putchar_unbuffered(c);
-            }
-            char_count++;
-            if (char_count % 10 == 0) {
-                sddf_printf("\n%s has received %u characters so far!\n", microkit_name, char_count);
-            }
+    while (!serial_dequeue(&rx_queue_handle, &c)) {
+        if (c == '\r') {
+            sddf_putchar_unbuffered('\\');
+            sddf_putchar_unbuffered('r');
+        } else {
+            sddf_putchar_unbuffered(c);
         }
-
-        serial_request_producer_signal(&rx_queue_handle);
-        reprocess = false;
-
-        if (!serial_queue_empty(&rx_queue_handle, rx_queue_handle.queue->head)) {
-            serial_cancel_producer_signal(&rx_queue_handle);
-            reprocess = true;
+        char_count++;
+        if (char_count % 10 == 0) {
+            sddf_printf("\n%s has received %u characters so far!\n", microkit_name, char_count);
         }
     }
 }

--- a/include/sddf/serial/queue.h
+++ b/include/sddf/serial/queue.h
@@ -18,8 +18,6 @@ typedef struct serial_queue {
     uint32_t tail;
     /* index to remove from */
     uint32_t head;
-    /* flag to indicate whether consumer requires signalling */
-    uint32_t consumer_signalled;
     /* flag to indicate whether producer requires signalling */
     uint32_t producer_signalled;
 } serial_queue_t;
@@ -364,19 +362,6 @@ static inline void serial_request_consumer_signal(serial_queue_handle_t *queue_h
 }
 
 /**
- * Indicate to producer of the queue that consumer requires signalling.
- *
- * @param queue queue handle of queue that requires signalling upon enqueuing.
- */
-static inline void serial_request_producer_signal(serial_queue_handle_t *queue_handle)
-{
-    queue_handle->queue->consumer_signalled = 0;
-#ifdef CONFIG_ENABLE_SMP_SUPPORT
-    THREAD_MEMORY_RELEASE();
-#endif
-}
-
-/**
  * Indicate that producer has been signalled.
  *
  * @param queue queue handle of the queue that has been signalled.
@@ -390,19 +375,6 @@ static inline void serial_cancel_consumer_signal(serial_queue_handle_t *queue_ha
 }
 
 /**
- * Indicate that consumer has been signalled.
- *
- * @param queue queue handle of the queue that has been signalled.
- */
-static inline void serial_cancel_producer_signal(serial_queue_handle_t *queue_handle)
-{
-    queue_handle->queue->consumer_signalled = 1;
-#ifdef CONFIG_ENABLE_SMP_SUPPORT
-    THREAD_MEMORY_RELEASE();
-#endif
-}
-
-/**
  * Producer of the queue requires signalling.
  *
  * @param queue queue handle of the queue to check.
@@ -410,14 +382,4 @@ static inline void serial_cancel_producer_signal(serial_queue_handle_t *queue_ha
 static inline bool serial_require_consumer_signal(serial_queue_handle_t *queue_handle)
 {
     return !queue_handle->queue->producer_signalled;
-}
-
-/**
- * Consumer of the queue requires signalling.
- *
- * @param queue queue handle of the queue to check.
- */
-static inline bool serial_require_producer_signal(serial_queue_handle_t *queue_handle)
-{
-    return !queue_handle->queue->consumer_signalled;
 }

--- a/util/putchar_serial.c
+++ b/util/putchar_serial.c
@@ -30,10 +30,7 @@ void _sddf_putchar(char character)
     /* Make changes visible to virtualiser if character is flush or if queue is now filled */
     if (serial_queue_full(tx_queue_handle, local_tail) || character == FLUSH_CHAR) {
         serial_update_shared_tail(tx_queue_handle, local_tail);
-        if (serial_require_producer_signal(tx_queue_handle)) {
-            serial_cancel_producer_signal(tx_queue_handle);
-            microkit_notify(tx_ch);
-        }
+        microkit_notify(tx_ch);
     }
 }
 
@@ -46,10 +43,7 @@ void sddf_putchar_unbuffered(char character)
     serial_enqueue_local(tx_queue_handle, &local_tail, character);
 
     serial_update_shared_tail(tx_queue_handle, local_tail);
-    if (serial_require_producer_signal(tx_queue_handle)) {
-        serial_cancel_producer_signal(tx_queue_handle);
-        microkit_notify(tx_ch);
-    }
+    microkit_notify(tx_ch);
 }
 
 /* Initialise the serial putchar library. */


### PR DESCRIPTION
Currently, both the consumer and producer of a serial queue only signal each other if their corresponding flags are set - there are two flags for each queue. This is in contrast to the networking subsystem, where the consumer never signals the producer, and the producer only signals the consumer depending on the value of the flag.

Since the serial subsystem is using a signalling protocol for both directions of communication, it makes the code quite complicated to read and understand for those who are unfamiliar with the protocol. Since the serial subsystem is not performance critical, and the risk of over signalling even with unconditional signalling is very low, I have decided to remove one direction of the signalling protocol so that producers of serial queues signal consumers unconditionally after a batch of work has been enqueued. 

The consumer side of the protocol remains unchanged, as typically producers do not require signals from consumers - it is only required when a queue has become full and there is still more data to be enqueued. Since under normal conditions this does not occur frequently, it makes sense to keep the protocol for this direction of communication.

Merge after #301.