### PR TITLE
drivers/serial/meson: remove offset define

### DIFF
--- a/drivers/serial/meson/include/uart.h
+++ b/drivers/serial/meson/include/uart.h
@@ -10,14 +10,6 @@
 #include <sddf/util/util.h>
 #include <sddf/serial/queue.h>
 
-#if defined(CONFIG_PLAT_ODROIDC2)
-#define UART_REGS_OFFSET (0x4c0)
-#elif defined(CONFIG_PLAT_ODROIDC4)
-#define UART_REGS_OFFSET (0x0)
-#else
-#error "Unexpected platform used with UART meson driver"
-#endif
-
 /* The driver is based on the Amlogic S905X3 Data Sheet Revision 02.
 The following register descriptions and layout are from section 13.5.4.*/
 

--- a/drivers/serial/meson/uart.c
+++ b/drivers/serial/meson/uart.c
@@ -151,7 +151,7 @@ static void handle_irq(void)
 
 static void uart_setup(void)
 {
-    uart_regs = (meson_uart_regs_t *)((uintptr_t)device_resources.regions[0].region.vaddr + UART_REGS_OFFSET);
+    uart_regs = (meson_uart_regs_t *)device_resources.regions[0].region.vaddr;
 
     /* Wait until receive and transmit state machines are no longer busy */
     while (uart_regs->sr & (AML_UART_TX_BUSY | AML_UART_RX_BUSY));


### PR DESCRIPTION
Not needed anymore since the tooling gives us the address of the registers as defined in the device tree.