### PR TITLE
Fixes in comments of driver Makefile snippets

### DIFF
--- a/drivers/blk/mmc/imx/mmc_driver.mk
+++ b/drivers/blk/mmc/imx/mmc_driver.mk
@@ -5,8 +5,6 @@
 #
 # Include this snippet in your project Makefile to build the IMX8 uSDHC driver.
 # Assumes libsddf_util_debug.a is in ${LIBS}.
-# Requires usdhc_regs to be set to the mapped base of the uSDHC registers
-# in the system description file.
 
 USDHC_DRIVER_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 

--- a/drivers/blk/virtio/blk_driver.mk
+++ b/drivers/blk/virtio/blk_driver.mk
@@ -5,7 +5,6 @@
 #
 # Include this snippet in your project Makefile to build the virtIO block driver.
 # Assumes libsddf_util_debug.a is in ${LIBS}.
-# Expects the 'blk_regs' variable to be set by the Microkit SDF
 
 VIRTIO_BLK_DRIVER_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 

--- a/drivers/gpu/virtio/gpu_driver.mk
+++ b/drivers/gpu/virtio/gpu_driver.mk
@@ -8,8 +8,6 @@
 #
 # NOTES:
 #   Generates gpu_driver.elf
-#   Needs the appropriate VirtIO-MMIO region to be set in System Description File.
-# 	This can be dependent on how many VirtIO MMIO devices exist within your system.
 #   Assumes libsddf_util_debug.a is in LIBS
 
 GPU_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))

--- a/drivers/i2c/meson/i2c_driver.mk
+++ b/drivers/i2c/meson/i2c_driver.mk
@@ -10,10 +10,6 @@
 #  Generates i2c_driver.elf
 #  Requires libsddf_util_debug.a in ${LIBS}
 #  Has one parameter: I2C_BUS_NUM to select which bus is being driven
-#  Needs three variables set in system description file:
-#  i2c_bus --- the i2c controller
-#  gpio --- the GPIO registers for the pinmux
-#  clk --- the clock registers
 
 I2C_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 

--- a/drivers/network/imx/eth_driver.mk
+++ b/drivers/network/imx/eth_driver.mk
@@ -8,8 +8,6 @@
 #
 # NOTES
 #  Generates eth_driver.elf
-#  Expects System Description File to set eth_regs to the address of
-#  the registers
 #  Expects libsddf_util_debug.a to be in LIBS
 
 ETHERNET_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))

--- a/drivers/network/meson/eth_driver.mk
+++ b/drivers/network/meson/eth_driver.mk
@@ -8,7 +8,6 @@
 #
 # NOTES:
 #   Generates eth_driver.elf
-#   Needs eth_regs to be set in System Description File
 #   Assumes libsddf_util_debug.a is in LIBS
 
 ETHERNET_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))

--- a/drivers/network/virtio/eth_driver.mk
+++ b/drivers/network/virtio/eth_driver.mk
@@ -7,9 +7,7 @@
 # the VirtIO driver
 #
 # NOTES:
-#   Generates eth.elf
-#   Needs the appropriate VirtIO-MMIO region to be set in System Description File.
-# 	This can be dependent on how many VirtIO MMIO devices exist within your system.
+#   Generates eth_driver.elf
 #   Assumes libsddf_util_debug.a is in LIBS
 
 ETHERNET_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))

--- a/drivers/serial/arm/uart_driver.mk
+++ b/drivers/serial/arm/uart_driver.mk
@@ -5,8 +5,6 @@
 #
 # Include this snippet in your project Makefile to build
 #    the PL011 UART driver
-# Requires uart_base to be set to the mapped address of the UART
-#    registers in the system description file
 
 UART_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 

--- a/drivers/serial/imx/uart_driver.mk
+++ b/drivers/serial/imx/uart_driver.mk
@@ -6,8 +6,6 @@
 # Include this snippet in your project Makefile to build
 # the IMX8 UART driver.
 # Assumes libsddf_util_debug.a is in ${LIBS}.
-# Requires uart_regs to be set to the mapped base of the UART registers
-# in the system description file.
 
 UART_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 

--- a/drivers/serial/meson/uart_driver.mk
+++ b/drivers/serial/meson/uart_driver.mk
@@ -8,8 +8,6 @@
 #
 # NOTES:
 #   Builds uart_driver.elf
-#   Needs uart_base to be set to the mapped address of the UART
-#    registers in the system description file
 
 UART_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 

--- a/drivers/serial/snps/uart_driver.mk
+++ b/drivers/serial/snps/uart_driver.mk
@@ -5,8 +5,6 @@
 #
 # Include this snippet in your project Makefile to build
 #    the Synopsis DesignWare ABP UART driver
-# Requires uart_base to be set to the mapped address of the UART
-#    registers in the system description file
 
 UART_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 

--- a/drivers/timer/imx/timer_driver.mk
+++ b/drivers/timer/imx/timer_driver.mk
@@ -8,8 +8,6 @@
 #
 # NOTES:
 #  Generates timer_driver.elf
-#  Expects variable gpt_regs to be set in the system description file to the
-#      mapped address of the timer registers.
 #  Expects libsddf_util_debug.a to be in ${LIBS}
 
 TIMER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))

--- a/drivers/timer/meson/timer_driver.mk
+++ b/drivers/timer/meson/timer_driver.mk
@@ -8,8 +8,6 @@
 #
 # NOTES:
 #  Generates timer_driver.elf
-#  Expects system file to set variable 'gpt_regs' to the address of
-#     the timer registers (physical address 0xffd0f000 on a meson-g12 SoC)
 #  Expects libsddf_util_debug.a in ${LIBS}
 
 TIMER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))


### PR DESCRIPTION
These kinds of comments I'm removing should be in documentation rather than the Makefile snippets. For the variables to be patched, we do not need them anymore since the move to runtime configuration.