### PR TITLE
blk: use uint64_t for request block number

### DIFF
--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -247,7 +247,7 @@ static bool handle_client(int cli_id)
 
     blk_req_code_t cli_code = 0;
     uintptr_t cli_offset = 0;
-    uint32_t cli_block_number = 0;
+    uint64_t cli_block_number = 0;
     uint16_t cli_count = 0;
     uint32_t cli_req_id = 0;
 
@@ -264,7 +264,7 @@ static bool handle_client(int cli_id)
         err = blk_dequeue_req(&h, &cli_code, &cli_offset, &cli_block_number, &cli_count, &cli_req_id);
         assert(!err);
 
-        uint32_t drv_block_number = 0;
+        uint64_t drv_block_number = 0;
         drv_block_number = cli_block_number + (clients[cli_id].start_sector / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE));
 
         blk_resp_status_t resp_status = BLK_RESP_ERR_UNSPEC;

--- a/drivers/blk/mmc/imx/usdhc.c
+++ b/drivers/blk/mmc/imx/usdhc.c
@@ -991,8 +991,8 @@ void handle_clients(void)
             return;
         }
 
-        LOG_DRIVER("Received command: code=%d, offset=0x%lx, block_number=%lu, count=%d, id=%d\n",
-                   req_code, req_offset, req_block_number, req_count, req_id);
+        LOG_DRIVER("Received command: code=%d, offset=0x%lx, block_number=%lu, count=%d, id=%d\n", req_code, req_offset,
+                   req_block_number, req_count, req_id);
 
         driver_state.clients = ClientStateInflight;
         fallthrough;

--- a/drivers/blk/mmc/imx/usdhc.c
+++ b/drivers/blk/mmc/imx/usdhc.c
@@ -975,7 +975,7 @@ void handle_clients(void)
 {
     static blk_req_code_t req_code;
     static uintptr_t req_offset;
-    static uint32_t req_block_number;
+    static uint64_t req_block_number;
     static uint16_t req_count;
     static uint32_t req_id;
     int err;
@@ -991,7 +991,7 @@ void handle_clients(void)
             return;
         }
 
-        LOG_DRIVER("Received command: code=%d, offset=0x%lx, block_number=%d, count=%d, id=%d\n",
+        LOG_DRIVER("Received command: code=%d, offset=0x%lx, block_number=%lu, count=%d, id=%d\n",
                    req_code, req_offset, req_block_number, req_count, req_id);
 
         driver_state.clients = ClientStateInflight;

--- a/drivers/blk/virtio/block.c
+++ b/drivers/blk/virtio/block.c
@@ -128,7 +128,7 @@ void handle_request()
     while (!blk_queue_empty_req(&blk_queue) && ialloc_num_free(&ialloc_desc) >= 3) {
         blk_req_code_t req_code;
         uintptr_t phys_addr;
-        uint32_t block_number;
+        uint64_t block_number;
         uint16_t count;
         uint32_t id;
         int err = blk_dequeue_req(&blk_queue, &req_code, &phys_addr, &block_number, &count, &id);

--- a/include/sddf/blk/queue.h
+++ b/include/sddf/blk/queue.h
@@ -176,12 +176,8 @@ static inline uint32_t blk_queue_length_resp(blk_queue_handle_t *h)
  *
  * @return -1 when request queue is full, 0 on success.
  */
-static inline int blk_enqueue_req(blk_queue_handle_t *h,
-                                  blk_req_code_t code,
-                                  uintptr_t io_or_offset,
-                                  uint64_t block_number,
-                                  uint16_t count,
-                                  uint32_t id)
+static inline int blk_enqueue_req(blk_queue_handle_t *h, blk_req_code_t code, uintptr_t io_or_offset,
+                                  uint64_t block_number, uint16_t count, uint32_t id)
 {
     struct blk_req *brp;
     struct blk_req_queue *brqp;
@@ -250,12 +246,8 @@ static inline int blk_enqueue_resp(blk_queue_handle_t *h,
  *
  * @return -1 when request queue is empty, 0 on success.
  */
-static inline int blk_dequeue_req(blk_queue_handle_t *h,
-                                  blk_req_code_t *code,
-                                  uintptr_t *io_or_offset,
-                                  uint64_t *block_number,
-                                  uint16_t *count,
-                                  uint32_t *id)
+static inline int blk_dequeue_req(blk_queue_handle_t *h, blk_req_code_t *code, uintptr_t *io_or_offset,
+                                  uint64_t *block_number, uint16_t *count, uint32_t *id)
 {
     struct blk_req *brp;
     struct blk_req_queue *brqp;

--- a/include/sddf/blk/queue.h
+++ b/include/sddf/blk/queue.h
@@ -40,7 +40,7 @@ typedef enum blk_resp_status {
 typedef struct blk_req {
     blk_req_code_t code; /* request code */
     uint64_t io_or_offset; /* offset of buffer within buffer memory region or io address of buffer */
-    uint32_t block_number; /* block number to read/write to */
+    uint64_t block_number; /* block number to read/write to */
     uint16_t count; /* number of blocks to read/write */
     uint32_t id; /* stores request ID */
 } blk_req_t;
@@ -179,7 +179,7 @@ static inline uint32_t blk_queue_length_resp(blk_queue_handle_t *h)
 static inline int blk_enqueue_req(blk_queue_handle_t *h,
                                   blk_req_code_t code,
                                   uintptr_t io_or_offset,
-                                  uint32_t block_number,
+                                  uint64_t block_number,
                                   uint16_t count,
                                   uint32_t id)
 {
@@ -253,7 +253,7 @@ static inline int blk_enqueue_resp(blk_queue_handle_t *h,
 static inline int blk_dequeue_req(blk_queue_handle_t *h,
                                   blk_req_code_t *code,
                                   uintptr_t *io_or_offset,
-                                  uint32_t *block_number,
+                                  uint64_t *block_number,
                                   uint16_t *count,
                                   uint32_t *id)
 {


### PR DESCRIPTION
If we start dealing with block devices in the terabytes, we do risk overflow.