### PR TITLE
I2C: added infinite read support in protocol, misc. cleanup for Meson

### DIFF
--- a/drivers/i2c/meson/driver.h
+++ b/drivers/i2c/meson/driver.h
@@ -17,10 +17,10 @@
 #include "gpio.h"
 #include "clk.h"
 
-enum data_direction {
-    DATA_DIRECTION_WRITE = 0x0,
-    DATA_DIRECTION_READ = 0x1
-};
+typedef uint8_t data_direction_t;
+#define DATA_DIRECTION_WRITE    (0x0)
+#define DATA_DIRECTION_READ     (0x1)
+#define DATA_DIRECTION_READC    (0x3)   // Allows bitwise check for read or readc
 
 // Driver state
 typedef struct _i2c_ifState {
@@ -39,13 +39,10 @@ typedef struct _i2c_ifState {
        zero, no read/write is in progress and we can interpret the current byte as a token.*/
     uint8_t rw_remaining;
 
-    enum data_direction data_direction;
+    data_direction_t data_direction;
     /* I2C bus address of the current request being handled */
     size_t addr;
 } i2c_ifState_t;
-
-#define DATA_DIRECTION_WRITE (0x0)
-#define DATA_DIRECTION_READ (0x1)
 
 // Ctl register fields
 #define REG_CTRL_START      (BIT(0))

--- a/include/sddf/i2c/queue.h
+++ b/include/sddf/i2c/queue.h
@@ -41,17 +41,23 @@ enum i2c_token {
     I2C_TOKEN_END = 0x0,
     /* START: Begin a transfer. Causes master device to capture bus. */
     I2C_TOKEN_START = 0x1,
-    /* ADDRESS WRITE: Used to wake up the target device on the bus.
+    /* ADDRESS WRITE: Address target and unset READ bit.
      * The byte immediately following this token is an integer (N) length of the succeeding
-       write. Max 256 (1**8). The next N bytes are the payload. */
+       write. Max 255. The next N bytes are the payload. */
     I2C_TOKEN_ADDR_WRITE = 0x2,
-    /* ADDRESS READ: Same as ADDRW but sets up DATA tokens as reads.
-       FIXME: N bytes must be padded after read to suit current transport layer. This should
-              be replaced, ideally by using a separate shared buffer for return data*/
+    /* ADDRESS READ: Address target and set READ bit. This is the final READ in a chain.
+     * The byte immediately following this token is an integer (N) length of the desired read.
+     * Max size 255.
+     */
     I2C_TOKEN_ADDR_READ = 0x3,
+    /* CONTINUING READ: same as ADDRESS READ, but doesn't end the read operation. Allows
+     * chaining of multiple reads for arbitrarily long read operations. A multi-read chain
+     * should consist of several READCs terminated by a final READ.
+     */
+    I2C_TOKEN_ADDR_READC = 0x4,
     /* STOP: Used to send the STOP condition on the bus to end a transaction.
      * Causes master to release the bus. */
-    I2C_TOKEN_STOP = 0x4,
+    I2C_TOKEN_STOP = 0x5,
 };
 
 typedef struct i2c_queue_entry {


### PR DESCRIPTION
* Added support for infinite reads with a new token - continuing read (READC). Reads > 256 bytes should consist of N-1 blocks of READC, terminated with a READ to finalise where N=|_size/256._|

* Removed redundant and bug-prone data direction code in token conversion function.

* Removed DATA_DIRECTION enum since there was also an identical, aliased #define definition of all the enum members. Dropping the enum also allows the two variations of READ to share a single bit to check if an operation is a read without it being redundant.

* Closed up some areas of excessive white space.

* Changed token_load logic to control based on the I2C protocol tokens when ingesting instead of meson tokens - should be less bug prone in future.

* Corrected outdated in-code documentation for I2C protocol tokens.