### PR TITLE
Block example fixes

### DIFF
--- a/ci/examples.sh
+++ b/ci/examples.sh
@@ -219,7 +219,7 @@ serial() {
 }
 
 blk() {
-    BOARDS=("qemu_virt_aarch64")
+    BOARDS=("qemu_virt_aarch64" "qemu_virt_riscv64" "maaxboard")
     CONFIGS=("debug" "release")
     for BOARD in "${BOARDS[@]}"
     do

--- a/drivers/blk/mmc/imx/blk_driver.mk
+++ b/drivers/blk/mmc/imx/blk_driver.mk
@@ -8,19 +8,19 @@
 
 USDHC_DRIVER_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
-mmc_driver.elf: blk/mmc/imx/mmc_driver.o
+blk_driver.elf: blk/mmc/imx/blk_driver.o
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
-blk/mmc/imx/mmc_driver.o: ${USDHC_DRIVER_DIR}/usdhc.c |blk/mmc/imx
+blk/mmc/imx/blk_driver.o: ${USDHC_DRIVER_DIR}/usdhc.c |blk/mmc/imx
 	$(CC) -c $(CFLAGS) -o $@ $<
 
--include mmc_driver.d
+-include blk_driver.d
 
 blk/mmc/imx:
 	mkdir -p $@
 
 clean::
-	rm -f blk/mmc/imx/mmc_driver.[do]
+	rm -f blk/mmc/imx/blk_driver.[do]
 
 clobber::
 	rm -rf blk/mmc

--- a/examples/blk/blk.mk
+++ b/examples/blk/blk.mk
@@ -55,6 +55,11 @@ else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_riscv64)
 	BLK_DRIVER_DIR := virtio
 	QEMU := qemu-system-riscv64
 	QEMU_ARCH_ARGS := -machine virt -kernel $(IMAGE_FILE)
+else ifeq ($(strip $(MICROKIT_BOARD)), maaxboard)
+	ARCH := aarch64
+	CPU := cortex-a53
+	BLK_DRIVER_DIR := mmc/imx
+	TIMER_DRIVER_DIR := imx
 else
 $(error Unsupported MICROKIT_BOARD given)
 endif
@@ -101,6 +106,11 @@ BLK_COMPONENTS := $(SDDF)/blk/components
 all: $(IMAGE_FILE)
 
 include ${BLK_DRIVER}/blk_driver.mk
+
+ifdef TIMER_DRIVER_DIR
+include $(SDDF)/drivers/timer/$(TIMER_DRIVER_DIR)/timer_driver.mk
+IMAGES += timer_driver.elf
+endif
 
 include ${SDDF}/util/util.mk
 include ${BLK_COMPONENTS}/blk_components.mk

--- a/examples/blk/meta.py
+++ b/examples/blk/meta.py
@@ -16,6 +16,8 @@ class Board:
     blk: str
     # Default partition if the user has not specified one
     partition: int
+    # Some block drivers need a timer driver as well, the example
+    # itself does not need a timer driver.
     timer: Optional[str]
 
 


### PR DESCRIPTION
I forgot to add the MaaXBoard into the CI list for building the block example which would have caught this. PR fixes the Makefile and updates the CI script.