### PR TITLE
dts: update qemu_virt_aarch64.dts

### DIFF
--- a/dts/qemu_virt_aarch64.dts
+++ b/dts/qemu_virt_aarch64.dts
@@ -11,6 +11,7 @@
 
 / {
 	interrupt-parent = <0x8002>;
+	dma-coherent;
 	model = "linux,dummy-virt";
 	#size-cells = <0x02>;
 	#address-cells = <0x02>;
@@ -160,7 +161,7 @@
 		dma-coherent;
 		interrupts = <0x00 0x20 0x01>;
 		reg = <0x00 0xa002000 0x00 0x200>;
-		compatible = "virtio,mmio-blk";
+		compatible = "virtio,mmio";
 	};
 
 	virtio_mmio@a002200 {
@@ -209,6 +210,55 @@
 		dma-coherent;
 		interrupts = <0x00 0x27 0x01>;
 		reg = <0x00 0xa002e00 0x00 0x200>;
+		compatible = "virtio,mmio";
+	};
+
+	virtio_mmio@a003000 {
+		dma-coherent;
+		interrupts = <0x00 0x28 0x01>;
+		reg = <0x00 0xa003000 0x00 0x200>;
+		compatible = "virtio,mmio";
+	};
+
+	virtio_mmio@a003200 {
+		dma-coherent;
+		interrupts = <0x00 0x29 0x01>;
+		reg = <0x00 0xa003200 0x00 0x200>;
+		compatible = "virtio,mmio";
+	};
+
+	virtio_mmio@a003400 {
+		dma-coherent;
+		interrupts = <0x00 0x2a 0x01>;
+		reg = <0x00 0xa003400 0x00 0x200>;
+		compatible = "virtio,mmio";
+	};
+
+	virtio_mmio@a003600 {
+		dma-coherent;
+		interrupts = <0x00 0x2b 0x01>;
+		reg = <0x00 0xa003600 0x00 0x200>;
+		compatible = "virtio,mmio";
+	};
+
+	virtio_mmio@a003800 {
+		dma-coherent;
+		interrupts = <0x00 0x2c 0x01>;
+		reg = <0x00 0xa003800 0x00 0x200>;
+		compatible = "virtio,mmio";
+	};
+
+	virtio_mmio@a003a00 {
+		dma-coherent;
+		interrupts = <0x00 0x2d 0x01>;
+		reg = <0x00 0xa003a00 0x00 0x200>;
+		compatible = "virtio,mmio";
+	};
+
+	virtio_mmio@a003c00 {
+		dma-coherent;
+		interrupts = <0x00 0x2e 0x01>;
+		reg = <0x00 0xa003c00 0x00 0x200>;
 		compatible = "virtio,mmio";
 	};
 
@@ -339,6 +389,10 @@
 		clock-frequency = <0x16e3600>;
 		#clock-cells = <0x00>;
 		compatible = "fixed-clock";
+	};
+
+	aliases {
+		serial0 = "/pl011@9000000";
 	};
 
 	chosen {


### PR DESCRIPTION
I had modified the DTS slightly from what QEMU spits out via dumpdtb when developing the sdfgen tooling. This commit makes the DTS for QEMU exactly what it spits out with dumpdtb.