### PR TITLE
util:cache.c: move dsb barrier outside of the loop.

### DIFF
--- a/util/cache.c
+++ b/util/cache.c
@@ -59,8 +59,8 @@ void cache_clean_and_invalidate(unsigned long start, unsigned long end)
     for (index = LINE_INDEX(start); index < LINE_INDEX(end_rounded); index++) {
         vaddr = index << CONFIG_L1_CACHE_LINE_SIZE_BITS;
         asm volatile("dc civac, %0" : : "r"(vaddr));
-        asm volatile("dsb sy" ::: "memory");
     }
+    asm volatile("dsb sy" ::: "memory");
 #endif
 }
 
@@ -87,7 +87,7 @@ void cache_clean(unsigned long start, unsigned long end)
     for (index = LINE_INDEX(start); index < LINE_INDEX(end_rounded); index++) {
         vaddr = index << CONFIG_L1_CACHE_LINE_SIZE_BITS;
         asm volatile("dc cvac, %0" : : "r"(vaddr));
-        asm volatile("dmb sy" ::: "memory");
     }
+    asm volatile("dmb sy" ::: "memory");
 #endif
 }


### PR DESCRIPTION
* Fix suggested by: @alwin-joshy.
* block benchmark improvements in virtualiser cpu util scaling _exponentially_ with request size, to sub exponential scaling.

## Conditions under which improvement identified:
Tested on branch https://github.com/au-ts/sddf/compare/szymon/benchmark_blk_rebased_sdmmc .
Idenitfied while running a block storage benchmark issuing 256 random READ requests on Odroid C4 (ARM64), SD cards used: Samsung EVO Plus 64 GB, SanDisk Extreme PRO 64GB A2, SanDisk Ultra A1 64 GB. 

## Benchmarking results
The CPU utilisation for this benchmark drops significantly for all request sizes, after this change (I have been running my storage benchmarks with this mod included).

### With `dsb` barrier INSIDE the loop (before this change):
Key points on the graph: Virtualiser (solid red line) runs for a very big portion of overall CPU activity. CPU activity for LionsOS is high (dashed green line).
[block_read_cyclecount_dsb_inside.pdf](https://github.com/user-attachments/files/18762711/block_read_cyclecount_dsb_inside.pdf)
Note: Dashed lines show CPU utilisation - the y axis on RHS, solid blue, red, green and light blue lines are CPU cycles spent in each of the Protection Domain during the benchmark at different request sizes - the y axis on LHS. *The LHS y axis is log-scale, so linear relations are actually exponential*

### WIth `dsb` barrier OUTSIDE the loop (after this change):
Key points on the graph: Virtualiser (solid red line) runs for a significant, but smaller portion of overall CPU activity. CPU activity for LionsOS decreases significantly with increasing request size (as expected, given the systems spends more time waiting for I/O from SD device).
[block_read_cyclecount_dsb_outside.pdf](https://github.com/user-attachments/files/18762746/block_read_cyclecount_dsb_outside.pdf)


## Not verified, potential improvements:
Potentially could lower CPU util / slightly improve throughput of ethernet driver benchmarks for ARM based boards, or other drivers which use `cache_clean_and_invalidate()` or `cache_clean()`.

