### PR TITLE
sel4bench: Fix idle.c thread stopping PMU counters

### DIFF
--- a/benchmark/idle.c
+++ b/benchmark/idle.c
@@ -21,11 +21,14 @@ struct bench *b;
 void count_idle(void)
 {
     #ifdef MICROKIT_CONFIG_benchmark
-    b->prev = sel4bench_get_cycle_count();
+    uint64_t val;
+    SEL4BENCH_READ_CCNT(val);
+    b->prev = val;
     b->ccount = 0;
 
     while (1) {
-        __atomic_store_n(&b->ts, (uint64_t)sel4bench_get_cycle_count(), __ATOMIC_RELAXED);
+        SEL4BENCH_READ_CCNT(val);
+        __atomic_store_n(&b->ts, val, __ATOMIC_RELAXED);
         uint64_t diff = b->ts - b->prev;
 
         if (diff < MAGIC_CYCLES) {

--- a/include/sddf/benchmark/sel4bench.h
+++ b/include/sddf/benchmark/sel4bench.h
@@ -216,18 +216,6 @@ static FASTFN void sel4bench_init()
     sel4bench_private_write_cntens(BIT(SEL4BENCH_ARMV8A_COUNTER_CCNT));
 }
 
-static FASTFN ccnt_t sel4bench_get_cycle_count()
-{
-    ccnt_t val;
-    uint32_t enable_word = sel4bench_private_read_cntens(); //store running state
-
-    sel4bench_private_write_cntenc(BIT(SEL4BENCH_ARMV8A_COUNTER_CCNT)); //stop CCNT
-    SEL4BENCH_READ_CCNT(val); //read its value
-    sel4bench_private_write_cntens(enable_word); //start it again if it was running
-
-    return val;
-}
-
 /* being declared FASTFN allows this function (once inlined) to cache miss; I
  * think it's worthwhile in the general case, for performance reasons.
  * moreover, it's small enough that it'll be suitably aligned most of the time


### PR DESCRIPTION
NOTE: the Following changes only affect ARM results. Related `seL4_libs` change: https://github.com/seL4/seL4_libs/pull/32

`sel4bench_get_cycle_count()` for some reason stopped PMU counters before reading from them and started afterwards. This was used in a busy loop in idle.c, causing it to miscount cycles spent in the idle thread, and most likely overall cycle counts, since any PD's/Kernel's activity that interrupted the idle thread in the middle of the function after stopping the PMU counter but before restarting it will not have its cycles counted.
* Removes `sel4bench_get_cycle_count()` and replaces its (single) use in idle.c with `SEL4BENCH_READ_CCNT()` macro.

# Affected results
In storage benchmarks, when computing CPU frequency, time spent in a benchmark or throughput using cycle counts on Odroid C4 I was getting weirdly consistent and *wrong* values (e.g. for CPU frequency it was roughly 1GHz vs the expected 1.2GHz).

This was caused by the PMU being stopped in the idle thread's busy loop (I reuse the same idle thread as used for the echo_server benchmarks), hence cycle count for the idle thread was LOWER than in reality, and total cycle count was LOWER than in reality.

# Further possible benchmark result effects
This could mean the following changes for STORAGE benchmark results:
- Higher cycle count for the idle thread, and higher overall cycle count
- Lower overall CPU utilisation (as we now log the correct number of cycles spent in the idle thread, which is slightly higher)

Additionally, as the idle thread is also used in the ethernet driver, it might change the overall CPU utilisation (lower it) and increase the per-packet cycle count.