### PR TITLE
build.zig: remove redundant QEMU args

### DIFF
--- a/examples/serial/build.zig
+++ b/examples/serial/build.zig
@@ -253,7 +253,7 @@ pub fn build(b: *std.Build) !void {
         const qemu_cmd = b.addSystemCommand(&[_][]const u8{
             "qemu-system-aarch64",
             "-machine",
-            "virt,virtualization=on,highmem=off,secure=off",
+            "virt,virtualization=on",
             "-cpu",
             "cortex-a53",
             "-serial",

--- a/examples/timer/build.zig
+++ b/examples/timer/build.zig
@@ -270,7 +270,7 @@ pub fn build(b: *std.Build) !void {
         const qemu_cmd = b.addSystemCommand(&[_][]const u8{
             "qemu-system-aarch64",
             "-machine",
-            "virt,virtualization=on,highmem=off,secure=off",
+            "virt,virtualization=on",
             "-cpu",
             "cortex-a53",
             "-serial",


### PR DESCRIPTION
We don't use these in the Makefiles.

`secure` is off by default and there is no benefit to doing `highmem=off`.