### PR TITLE
examples/blk: Fix blk.mk for drivers using timers

### DIFF
--- a/drivers/blk/mmc/imx/usdhc.c
+++ b/drivers/blk/mmc/imx/usdhc.c
@@ -1096,12 +1096,12 @@ void notified(microkit_channel ch)
 
 void init()
 {
-    assert(device_resources.num_regions == 1);
-    assert(device_resources.num_irqs == 1);
-
     assert(device_resources_check_magic(&device_resources));
     assert(blk_config_check_magic(&blk_config));
     assert(timer_config_check_magic(&timer_config));
+    
+    assert(device_resources.num_regions == 1);
+    assert(device_resources.num_irqs == 1);
 
     usdhc_regs = device_resources.regions[0].region.vaddr;
 

--- a/drivers/blk/mmc/imx/usdhc.c
+++ b/drivers/blk/mmc/imx/usdhc.c
@@ -1099,6 +1099,9 @@ void init()
     assert(device_resources.num_regions == 1);
     assert(device_resources.num_irqs == 1);
 
+    assert(blk_config_check_magic(&blk_config));
+    assert(timer_config_check_magic(&timer_config));
+
     usdhc_regs = device_resources.regions[0].region.vaddr;
 
     reset_driver_and_card_state();

--- a/drivers/blk/mmc/imx/usdhc.c
+++ b/drivers/blk/mmc/imx/usdhc.c
@@ -1099,7 +1099,6 @@ void init()
     assert(device_resources_check_magic(&device_resources));
     assert(blk_config_check_magic(&blk_config));
     assert(timer_config_check_magic(&timer_config));
-    
     assert(device_resources.num_regions == 1);
     assert(device_resources.num_irqs == 1);
 

--- a/drivers/blk/mmc/imx/usdhc.c
+++ b/drivers/blk/mmc/imx/usdhc.c
@@ -1099,6 +1099,7 @@ void init()
     assert(device_resources.num_regions == 1);
     assert(device_resources.num_irqs == 1);
 
+    assert(device_resources_check_magic(&device_resources));
     assert(blk_config_check_magic(&blk_config));
     assert(timer_config_check_magic(&timer_config));
 

--- a/examples/blk/blk.mk
+++ b/examples/blk/blk.mk
@@ -127,6 +127,10 @@ $(DTB): $(DTS)
 
 $(SYSTEM_FILE): $(METAPROGRAM) $(IMAGES) $(DTB)
 	$(PYTHON) $(METAPROGRAM) --sddf $(SDDF) --board $(MICROKIT_BOARD) --dtb $(DTB) --output . --sdf $(SYSTEM_FILE) $(PARTITION_ARG)
+ifdef TIMER_DRIVER_DIR
+	$(OBJCOPY) --update-section .device_resources=timer_driver_device_resources.data timer_driver.elf
+	$(OBJCOPY) --update-section .timer_client_config=timer_client_blk_driver.data blk_driver.elf
+endif
 	$(OBJCOPY) --update-section .device_resources=blk_driver_device_resources.data blk_driver.elf
 	$(OBJCOPY) --update-section .blk_driver_config=blk_driver.data blk_driver.elf
 	$(OBJCOPY) --update-section .blk_virt_config=blk_virt.data blk_virt.elf


### PR DESCRIPTION
* Add objcopy for timer_driver device resources and timer_client_config for blk_driver if the block driver uses a timer driver.


- [x] With `make`: Tested the build now works for `maaxboard` (timer PD no longer panics). 
- [x] With `make`: Tested `qemu_virt_aarch64` still builds correctly.
- [x] With `make`: Tested `qemu_virt_riscv64` still builds correctly.