### PR TITLE
Clean up sel4bench

### DIFF
--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -181,7 +181,7 @@ void notified(microkit_channel ch)
         dump_log_summary(entries);
 #endif
     } else {
-        sddf_printf("Bench thread notified on unexpected channel\n");
+        sddf_printf("BENCH|LOG: Bench thread notified on unexpected channel %u\n", ch);
     }
 }
 
@@ -192,13 +192,13 @@ void init(void)
     serial_putchar_init(serial_config.tx.id, &serial_tx_queue_handle);
 
 #ifdef MICROKIT_CONFIG_benchmark
-    sddf_printf("MICROKIT_CONFIG_benchmark defined\n");
+    sddf_printf("BENCH|LOG: MICROKIT_CONFIG_benchmark defined\n");
 #endif
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
-    sddf_printf("CONFIG_BENCHMARK_TRACK_UTILISATION defined\n");
+    sddf_printf("BENCH|LOG: CONFIG_BENCHMARK_TRACK_UTILISATION defined\n");
 #endif
 #ifdef CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES
-    sddf_printf("CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES defined\n");
+    sddf_printf("BENCH|LOG: CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES defined\n");
 #endif
 
 #ifdef MICROKIT_CONFIG_benchmark
@@ -228,9 +228,9 @@ void init(void)
 #ifdef CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES
     int res_buf = seL4_BenchmarkSetLogBuffer(LOG_BUFFER_CAP);
     if (res_buf) {
-        sddf_printf("Could not set log buffer:  %llx\n", res_buf);
+        sddf_printf("BENCH|ERROR: Could not set log buffer: %d\n", res_buf);
     } else {
-        sddf_printf("Log buffer set\n");
+        sddf_printf("BENCH|LOG: Log buffer set\n");
     }
 #endif
 }

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -70,7 +70,8 @@ static void print_total_util(uint64_t *buffer)
     uint64_t number_schedules = buffer[BENCHMARK_TOTAL_NUMBER_SCHEDULES];
     uint64_t kernel = buffer[BENCHMARK_TOTAL_KERNEL_UTILISATION];
     uint64_t entries = buffer[BENCHMARK_TOTAL_NUMBER_KERNEL_ENTRIES];
-    sddf_printf("Total utilisation details: \n{\nKernelUtilisation: %lu\nKernelEntries: %lu\nNumberSchedules: %lu\nTotalUtilisation: %lu\n}\n",
+    sddf_printf("Total utilisation details: \n{\nKernelUtilisation: %lu\nKernelEntries: %lu\nNumberSchedules: "
+                "%lu\nTotalUtilisation: %lu\n}\n",
                 kernel, entries, number_schedules, total);
 }
 
@@ -80,7 +81,8 @@ static void print_child_util(uint64_t *buffer, uint8_t id)
     uint64_t number_schedules = buffer[BENCHMARK_TCB_NUMBER_SCHEDULES];
     uint64_t kernel = buffer[BENCHMARK_TCB_KERNEL_UTILISATION];
     uint64_t entries = buffer[BENCHMARK_TCB_NUMBER_KERNEL_ENTRIES];
-    sddf_printf("Utilisation details for PD: %s (%u)\n{\nKernelUtilisation: %lu\nKernelEntries: %lu\nNumberSchedules: %lu\nTotalUtilisation: %lu\n}\n",
+    sddf_printf("Utilisation details for PD: %s (%u)\n{\nKernelUtilisation: %lu\nKernelEntries: %lu\nNumberSchedules: "
+                "%lu\nTotalUtilisation: %lu\n}\n",
                 child_name(id), id, kernel, entries, number_schedules, total);
 }
 
@@ -131,12 +133,13 @@ static void dump_log_summary(uint64_t log_size)
         index++;
     }
 
-    sddf_printf("Number of system call invocations  %llx and fastpaths  %llx\n", syscall_entries, fastpaths);
-    sddf_printf("Number of interrupt invocations  %llx\n", interrupt_entries);
-    sddf_printf("Number of user-level faults  %llx\n", userlevelfault_entries);
-    sddf_printf("Number of VM faults  %llx\n", vmfault_entries);
-    sddf_printf("Number of debug faults  %llx\n", debug_fault);
-    sddf_printf("Number of others  %llx\n", other);
+    sddf_printf("System call invocations %lu", syscall_entries);
+    sddf_printf("Fastpaths %lu\n", fastpaths);
+    sddf_printf("Interrupt invocations %lu\n", interrupt_entries);
+    sddf_printf("User-level faults %lu\n", userlevelfault_entries);
+    sddf_printf("VM faults %lu\n", vmfault_entries);
+    sddf_printf("Debug faults %lu\n", debug_fault);
+    sddf_printf("Others %lu\n", other);
 }
 #endif
 
@@ -166,7 +169,7 @@ void notified(microkit_channel ch)
 
         sddf_printf("{\n");
         for (int i = 0; i < ARRAY_SIZE(benchmarking_events); i++) {
-            sddf_printf("%s: %lX\n", counter_names[i], counter_values[i]);
+            sddf_printf("%s: %lu\n", counter_names[i], counter_values[i]);
         }
         sddf_printf("}\n");
 #endif

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -7,7 +7,6 @@
 #include <microkit.h>
 #include <sel4/benchmark_track_types.h>
 #include <sel4/benchmark_utilisation_types.h>
-#include <sddf/benchmark/bench.h>
 #include <sddf/benchmark/sel4bench.h>
 #include <sddf/benchmark/config.h>
 #include <sddf/serial/queue.h>

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -204,20 +204,13 @@ void init(void)
 #ifdef MICROKIT_CONFIG_benchmark
     sel4bench_init();
     seL4_Word n_counters = sel4bench_get_num_counters();
-
-    counter_bitfield_t mask = 0;
-
-    for (seL4_Word counter = 0; counter < n_counters; counter++) {
-        if (counter >= ARRAY_SIZE(benchmarking_events)) {
-            break;
-        }
+    for (seL4_Word counter = 0; counter < MIN(n_counters, ARRAY_SIZE(benchmarking_events)); counter++) {
         sel4bench_set_count_event(counter, benchmarking_events[counter]);
-        mask |= BIT(counter);
+        benchmark_bf |= BIT(counter);
     }
 
     sel4bench_reset_counters();
-    sel4bench_start_counters(mask);
-    benchmark_bf = mask;
+    sel4bench_start_counters(benchmark_bf);
 #else
     sddf_dprintf("BENCH|LOG: Bench running in debug mode, no access to counters\n");
 #endif

--- a/benchmark/idle.c
+++ b/benchmark/idle.c
@@ -5,10 +5,10 @@
 
 #include <stdint.h>
 #include <microkit.h>
-#include <sddf/benchmark/sel4bench.h>
 #include <sddf/util/util.h>
 #include <sddf/util/fence.h>
 #include <sddf/util/printf.h>
+#include <sddf/benchmark/sel4bench.h>
 #include <sddf/benchmark/bench.h>
 #include <sddf/benchmark/config.h>
 

--- a/examples/echo_server/echo.c
+++ b/examples/echo_server/echo.c
@@ -15,7 +15,6 @@
 #include <sddf/serial/config.h>
 #include <sddf/timer/client.h>
 #include <sddf/timer/config.h>
-#include <sddf/benchmark/sel4bench.h>
 #include <sddf/benchmark/config.h>
 #include "lwip/pbuf.h"
 

--- a/examples/echo_server/utilization_socket.c
+++ b/examples/echo_server/utilization_socket.c
@@ -10,7 +10,6 @@
 #include "lwip/pbuf.h"
 #include "lwip/tcp.h"
 
-#include <sddf/util/util.h>
 #include <sddf/benchmark/bench.h>
 #include <sddf/util/printf.h>
 

--- a/include/sddf/benchmark/sel4bench.h
+++ b/include/sddf/benchmark/sel4bench.h
@@ -10,37 +10,12 @@
 #include <sddf/util/util.h>
 #include <microkit.h>
 
-/* A counter is an index to a performance counter on a platform.
- * The max counter index is sizeof(seL4_Word) */
-typedef seL4_Word counter_t;
-/* A counter_bitfield is used to select multiple counters.
- * Each bit corresponds to a counter id */
-typedef seL4_Word counter_bitfield_t;
+/* This library contains a selection of libseL4bench used for sDDF benchmarking. libsel4bench can be found here:
+https://github.com/seL4/seL4_libs
 
-/* An event id is the hardware id of an event.
- * See the events.h for your architecture for specific events, caveats,
- * gotchas, and other trickery. */
-typedef seL4_Word event_id_t;
+The definitions are specific to ARMv8 - different definitions will need to used for different architectures. */
 
-//function attributes
-//functions that need to be inlined for speed
-#define FASTFN inline __attribute__((always_inline))
-//functions that must not cache miss
-#define CACHESENSFN __attribute__((noinline, aligned(64)))
-
-#define DIV_ROUND_UP(n,d)   \
-    ({ typeof (n) _n = (n); \
-       typeof (d) _d = (d); \
-       (_n/_d + (_n % _d == 0 ? 0 : 1)); \
-   })
-
-//counters and related constants
-#define SEL4BENCH_ARMV8A_NUM_COUNTERS 4
-
-#define SEL4BENCH_ARMV8A_COUNTER_CCNT 31
-
-
-/* generic events */
+/* seL4 tracked benchmarking events. */
 #define SEL4BENCH_EVENT_CACHE_L1I_MISS              0x01
 #define SEL4BENCH_EVENT_CACHE_L1D_MISS              0x03
 #define SEL4BENCH_EVENT_TLB_L1I_MISS                0x02
@@ -48,30 +23,34 @@ typedef seL4_Word event_id_t;
 #define SEL4BENCH_EVENT_EXECUTE_INSTRUCTION         0x08
 #define SEL4BENCH_EVENT_BRANCH_MISPREDICT           0x10
 
-#define SEL4BENCH_EVENT_MEMORY_ACCESS               0x13
-/*
- * PMCR:
- *
- *  bits 31:24 = implementor
- *  bits 23:16 = idcode
- *  bits 15:11 = number of counters
- *  bits 10:6  = reserved, sbz
- *  bit  5 = disable CCNT when non-invasive debug is prohibited
- *  bit  4 = export events to ETM
- *  bit  3 = cycle counter divides by 64
- *  bit  2 = write 1 to reset cycle counter to zero
- *  bit  1 = write 1 to reset all counters to zero
- *  bit  0 = enable bit
- */
+/* Armv8 constants. */
+#define SEL4BENCH_ARMV8A_COUNTER_CCNT 31
 #define SEL4BENCH_ARMV8A_PMCR_N(x)       (((x) & 0xFFFF) >> 11u)
 #define SEL4BENCH_ARMV8A_PMCR_ENABLE     BIT(0)
 #define SEL4BENCH_ARMV8A_PMCR_RESET_ALL  BIT(1)
 #define SEL4BENCH_ARMV8A_PMCR_RESET_CCNT BIT(2)
-#define SEL4BENCH_ARMV8A_PMCR_DIV64      BIT(3) /* Should CCNT be divided by 64? */
+#define SEL4BENCH_ARMV8A_PMCR_DIV64      BIT(3)
 
-#define PMUSERENR   "PMUSERENR_EL0"
-#define PMINTENCLR  "PMINTENCLR_EL1"
-#define PMINTENSET  "PMINTENSET_EL1"
+/* A counter is an index to a performance counter on a platform.
+ * The max counter index is sizeof(seL4_Word). */
+typedef seL4_Word counter_t;
+
+/* A counter_bitfield is used to select multiple counters.
+ * Each bit corresponds to a counter id. */
+typedef seL4_Word counter_bitfield_t;
+
+/* An event id is the hardware id of an event. */
+typedef seL4_Word event_id_t;
+
+typedef uint64_t ccnt_t;
+
+/* Functions that need to be inlined for speed. */
+#define FASTFN inline __attribute__((always_inline))
+
+/* Functions that must not cache miss. */
+#define CACHESENSFN __attribute__((noinline, aligned(64)))
+
+/* PMU registers. */
 #define PMCR        "PMCR_EL0"
 #define PMCNTENCLR  "PMCNTENCLR_EL0"
 #define PMCNTENSET  "PMCNTENSET_EL0"
@@ -79,13 +58,6 @@ typedef seL4_Word event_id_t;
 #define PMSELR      "PMSELR_EL0"
 #define PMXEVTYPER  "PMXEVTYPER_EL0"
 #define PMCCNTR     "PMCCNTR_EL0"
-
-#define PMOVSSERT   "PMOVSSET_EL0"
-#define PMOVSCLR    "PMOVSCLR_EL0"
-
-#define CCNT_FORMAT "%"PRIu64
-typedef uint64_t ccnt_t;
-
 
 #define PMU_WRITE(reg, v)                      \
     do {                                       \
@@ -97,11 +69,11 @@ typedef uint64_t ccnt_t;
 
 #define SEL4BENCH_READ_CCNT(var) PMU_READ(PMCCNTR, var);
 
-
 static FASTFN void sel4bench_private_write_pmcr(uint32_t val)
 {
     PMU_WRITE(PMCR, val);
 }
+
 static FASTFN uint32_t sel4bench_private_read_pmcr(void)
 {
     uint32_t val;
@@ -111,13 +83,6 @@ static FASTFN uint32_t sel4bench_private_read_pmcr(void)
 
 #define MODIFY_PMCR(op, val) sel4bench_private_write_pmcr(sel4bench_private_read_pmcr() op (val))
 
-/*
- * CNTENS/CNTENC (Count Enable Set/Clear)
- *
- * Enables the Cycle Count Register, PMCCNTR_EL0, and any implemented event counters
- * PMEVCNTR<x>. Reading this register shows which counters are enabled.
- *
- */
 static FASTFN void sel4bench_private_write_cntens(uint32_t mask)
 {
     PMU_WRITE(PMCNTENSET, mask);
@@ -130,19 +95,11 @@ static FASTFN uint32_t sel4bench_private_read_cntens(void)
     return mask;
 }
 
-/*
- * Disables the Cycle Count Register, PMCCNTR_EL0, and any implemented event counters
- * PMEVCNTR<x>. Reading this register shows which counters are enabled.
- */
 static FASTFN void sel4bench_private_write_cntenc(uint32_t mask)
 {
     PMU_WRITE(PMCNTENCLR, mask);
 }
 
-/*
- * Reads or writes the value of the selected event counter, PMEVCNTR<n>_EL0.
- * PMSELR_EL0.SEL determines which event counter is selected.
- */
 static FASTFN uint32_t sel4bench_private_read_pmcnt(void)
 {
     uint32_t val;
@@ -155,24 +112,9 @@ static FASTFN void sel4bench_private_write_pmcnt(uint32_t val)
     PMU_WRITE(PMXEVCNTR, val);
 }
 
-/*
- * Selects the current event counter PMEVCNTR<x> or the cycle counter, CCNT
- */
 static FASTFN void sel4bench_private_write_pmnxsel(uint32_t val)
 {
     PMU_WRITE(PMSELR, val);
-}
-
-/*
- * When PMSELR_EL0.SEL selects an event counter, this accesses a PMEVTYPER<n>_EL0
- * register. When PMSELR_EL0.SEL selects the cycle counter, this accesses PMCCFILTR_EL0.
- */
-static FASTFN uint32_t sel4bench_private_read_evtsel(void)
-{
-
-    uint32_t val;
-    PMU_READ(PMXEVTYPER, val);
-    return val;
 }
 
 static FASTFN void sel4bench_private_write_evtsel(uint32_t val)
@@ -180,118 +122,133 @@ static FASTFN void sel4bench_private_write_evtsel(uint32_t val)
     PMU_WRITE(PMXEVTYPER, val);
 }
 
-static FASTFN uint32_t sel4bench_private_read_overflow(void)
+/**
+ * Initialise the sel4bench library.  Nothing else is guaranteed to work, and
+ * may produce strange failures, if you don't do this first.
+ *
+ * Starts the cycle counter, which is guaranteed to run until
+ * `sel4bench_destroy()` is called.
+ */
+static FASTFN void sel4bench_init()
 {
-    uint32_t val;
-    PMU_READ(PMOVSSERT, val);
-    PMU_WRITE(PMOVSCLR, val); // Clear the overflow bit so we can detect it again.
-    return val;
+    // ensure all counters are in the stopped state
+    sel4bench_private_write_cntenc(-1);
+
+    // clear div 64 flag
+    MODIFY_PMCR(&, ~SEL4BENCH_ARMV8A_PMCR_DIV64);
+
+    // reset all counters
+    MODIFY_PMCR( |, SEL4BENCH_ARMV8A_PMCR_RESET_ALL | SEL4BENCH_ARMV8A_PMCR_RESET_CCNT);
+
+    // enable counters globally.
+    MODIFY_PMCR( |, SEL4BENCH_ARMV8A_PMCR_ENABLE);
+
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+    // select instruction count incl. PL2 by default */
+    sel4bench_private_write_pmnxsel(0x1f);
+    sel4bench_private_write_evtsel(BIT(27));
+#endif
+    // start CCNT
+    sel4bench_private_write_cntens(BIT(SEL4BENCH_ARMV8A_COUNTER_CCNT));
 }
 
+/**
+ * Query how many performance counters are supported on this CPU, excluding the
+ * cycle counter.
+ *
+ * Note that the return value is of type `seL4_Word`; consequently, this library
+ * supports a number of counters less than or equal to the machine word size in
+ * bits.
+
+ * @return quantity of counters on this CPU
+ */
 static FASTFN seL4_Word sel4bench_get_num_counters()
 {
     return SEL4BENCH_ARMV8A_PMCR_N(sel4bench_private_read_pmcr());
 }
 
-static FASTFN void sel4bench_init()
-{
-    //ensure all counters are in the stopped state
-    sel4bench_private_write_cntenc(-1);
-
-    //Clear div 64 flag
-    MODIFY_PMCR(&, ~SEL4BENCH_ARMV8A_PMCR_DIV64);
-
-    //Reset all counters
-    MODIFY_PMCR( |, SEL4BENCH_ARMV8A_PMCR_RESET_ALL | SEL4BENCH_ARMV8A_PMCR_RESET_CCNT);
-
-    //Enable counters globally.
-    MODIFY_PMCR( |, SEL4BENCH_ARMV8A_PMCR_ENABLE);
-
-#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-    // Select instruction count incl. PL2 by default */
-    sel4bench_private_write_pmnxsel(0x1f);
-    sel4bench_private_write_evtsel(BIT(27));
-#endif
-    //start CCNT
-    sel4bench_private_write_cntens(BIT(SEL4BENCH_ARMV8A_COUNTER_CCNT));
-}
-
-/* being declared FASTFN allows this function (once inlined) to cache miss; I
- * think it's worthwhile in the general case, for performance reasons.
- * moreover, it's small enough that it'll be suitably aligned most of the time
- */
-static FASTFN ccnt_t sel4bench_get_counter(counter_t counter)
-{
-    sel4bench_private_write_pmnxsel(counter); //select the counter on the PMU
-
-    counter = BIT(counter); //from here on in, we operate on a bitfield
-
-    uint32_t enable_word = sel4bench_private_read_cntens();
-
-    sel4bench_private_write_cntenc(counter); //stop the counter
-    uint32_t val = sel4bench_private_read_pmcnt(); //read its value
-    sel4bench_private_write_cntens(enable_word); //start it again if it was running
-
-    return val;
-}
-
-/* this reader function is too complex to be inlined, so we force it to be
- * cacheline-aligned in order to avoid icache misses with the counters off.
- * (relevant note: GCC compiles this function to be exactly one ARMV7 cache
- * line in size) however, the pointer dereference is overwhelmingly likely to
- * produce a dcache miss, which will occur with the counters off
+/**
+ * Query the value of a set of counters.
+ *
+ * `values` must point to an array of a length at least equal to the highest
+ * counter index to be read (to a maximum of `sel4bench_get_num_counters()`).
+ * Each counter to be read will be written to its corresponding index in this
+ * array.
+ *
+ * @param counters bitfield indicating which counter(s) in `values` to query
+ * @param values   array of counters
+ *
+ * @return current cycle count as in `sel4bench_get_cycle_count()`
  */
 static CACHESENSFN ccnt_t sel4bench_get_counters(counter_bitfield_t mask, ccnt_t *values)
 {
-    //we don't really have time for a NULL or bounds check here
+    // store current running state
+    uint32_t enable_word = sel4bench_private_read_cntens();
 
-    uint32_t enable_word = sel4bench_private_read_cntens(); //store current running state
-
-    sel4bench_private_write_cntenc(
-        enable_word); //stop running counters (we do this instead of stopping the ones we're interested in because it saves an instruction)
+    // stop running counters (we do this instead of stopping the ones we're interested in because it saves an instruction)
+    sel4bench_private_write_cntenc(enable_word);
 
     unsigned int counter = 0;
-    for (; mask != 0; mask >>= 1, counter++) { //for each counter...
-        if (mask & 1) { //... if we care about it...
-            sel4bench_private_write_pmnxsel(counter); //select it,
-            values[counter] = sel4bench_private_read_pmcnt(); //and read its value
+    for (; mask != 0; mask >>= 1, counter++) {
+        if (mask & 1) {
+            sel4bench_private_write_pmnxsel(counter);
+            values[counter] = sel4bench_private_read_pmcnt();
         }
     }
 
     ccnt_t ccnt;
-    SEL4BENCH_READ_CCNT(ccnt); //finally, read CCNT
+    SEL4BENCH_READ_CCNT(ccnt);
 
-    sel4bench_private_write_cntens(enable_word); //start the counters again
+    sel4bench_private_write_cntens(enable_word);
 
     return ccnt;
 }
 
+/**
+ * Assign a counter to track a specific event.  Events are processor-specific,
+ * though some common ones might be exposed through preprocessor constants.
+ *
+ * @param counter counter to configure
+ * @param event   event to track
+ */
 static FASTFN void sel4bench_set_count_event(counter_t counter, event_id_t event)
 {
-    sel4bench_private_write_pmnxsel(counter); //select counter
-    sel4bench_private_write_pmcnt(0); //reset it
-    return sel4bench_private_write_evtsel(event); //change the event
+    // select counter
+    sel4bench_private_write_pmnxsel(counter);
+    // reset it
+    sel4bench_private_write_pmcnt(0);
+    // change the event
+    return sel4bench_private_write_evtsel(event);
 }
 
+/**
+ * Start counting events on a set of performance counters.
+ *
+ * @param counters bitfield indicating which counter(s) to start
+ */
 static FASTFN void sel4bench_start_counters(counter_bitfield_t mask)
 {
-    /* conveniently, ARM performance counters work exactly like this,
-     * so we just write the value directly to COUNTER_ENABLE_SET
-     */
     return sel4bench_private_write_cntens(mask);
 }
 
+/**
+ * Stop counting events on a set of performance counters.
+ *
+ * Note: Some processors may not support this operation.
+ *
+ * @param counters bitfield indicating which counter(s) to stop
+ */
 static FASTFN void sel4bench_stop_counters(counter_bitfield_t mask)
 {
-    /* conveniently, ARM performance counters work exactly like this,
-     * so we just write the value directly to COUNTER_ENABLE_SET
-     * (protecting the CCNT)
-     */
     return sel4bench_private_write_cntenc(mask & ~BIT(SEL4BENCH_ARMV8A_COUNTER_CCNT));
 }
 
+/**
+ * Reset all performance counters to zero.  Note that the cycle counter is not a
+ * performance counter, and is not reset.
+ *
+ */
 static FASTFN void sel4bench_reset_counters(void)
 {
-    //Reset all counters except the CCNT
     MODIFY_PMCR( |, SEL4BENCH_ARMV8A_PMCR_RESET_ALL);
 }


### PR DESCRIPTION
After the recent discovery fixed by #350, it seemed necessary to look through our included functions in `sel4_bench.h` to make sure there was nothing else incorrect. I did not find anything, but did some clean up of the included code and the files using it.

seL4 bench changes in this PR:
- Remove unused includes in c files performing benchmarking.
- Add a note about the source of our seL4 bench functions, and the ARMv8 specificity.
- Remove any definitions that we are not using.
- Add descriptions for public functions, and remove them for private functions.

This PR also includes some tidy up of `benchmark.c`:
- Changing the format of utilisation figures printed from hex to decimal - this makes sense, as they are always converted to decimal by whoever is performing the benchmark afterwards.
- Restructure of the printing functions to reduce complexity. These changes were previously in my multicore PR #255, but I moved them here.
- Name changes to the private benchmarking functions - it doesn't make sense to use the `seL4_` or `microkit_` prefixes here.