### PR TITLE
blk/mmc/imx: handle virtualiser notifications while waiting for an IRQ

### DIFF
--- a/include/sddf/blk/storage_info.h
+++ b/include/sddf/blk/storage_info.h
@@ -30,6 +30,8 @@ typedef struct blk_storage_info {
     /* total capacity of the device, specified in BLK_TRANSFER_SIZE sized units. */
     uint64_t capacity;
 } blk_storage_info_t;
+_Static_assert(sizeof(blk_storage_info_t) <= BLK_STORAGE_INFO_REGION_SIZE,
+               "struct blk_storage_info must be smaller than the region size");
 
 /**
  * Load from shared memory whether the block storage device is ready.


### PR DESCRIPTION
Previously, if the virtualiser notified the driver whilst we were running a command (and waiting for an IRQ from the device), we acted as if received an IRQ, not a virtualiser notification. We refactor how notified() handles IRQs vs virtualiser notifications to ensure that these are kept separate in future.

Cherry picked from [`c4afbc2` (#180)](https://github.com/au-ts/sddf/pull/180/commits/c4afbc28902349bac6d9c6c5ef6a42433182c4d4) without the hotplugging changes within.

cc @dreamliner787-9 as this has not been tested after cherry-picking; this should be done before merging. 