### PR TITLE
examples/serial: add i.MX8MQ-EVK and i.MX8MP-EVK support

### DIFF
--- a/ci/examples.sh
+++ b/ci/examples.sh
@@ -206,7 +206,7 @@ timer() {
 }
 
 serial() {
-    BOARDS=("imx8mm_evk" "maaxboard" "odroidc2" "odroidc4" "qemu_virt_aarch64" "qemu_virt_riscv64" "star64")
+    BOARDS=("imx8mm_evk" "imx8mq_evk" "imx8mp_evk" "maaxboard" "odroidc2" "odroidc4" "qemu_virt_aarch64" "qemu_virt_riscv64" "star64")
     CONFIGS=("debug" "release")
     for BOARD in "${BOARDS[@]}"
     do

--- a/examples/serial/README.md
+++ b/examples/serial/README.md
@@ -14,6 +14,8 @@ The following platforms are supported:
 * odroidc2
 * odroidc4
 * imx8mm_evk
+* imx8mp_evk
+* imx8mq_evk
 * maaxboard
 * qemu_virt_aarch64
 * qemu_virt_riscv64

--- a/examples/serial/build.zig
+++ b/examples/serial/build.zig
@@ -8,6 +8,8 @@ const LazyPath = std.Build.LazyPath;
 
 const MicrokitBoard = enum {
     imx8mm_evk,
+    imx8mp_evk,
+    imx8mq_evk,
     odroidc2,
     odroidc4,
     maaxboard,
@@ -64,6 +66,26 @@ const targets = [_]Target{
     },
     .{
         .board = MicrokitBoard.imx8mm_evk,
+        .zig_target = std.Target.Query{
+            .cpu_arch = .aarch64,
+            .cpu_model = .{ .explicit = &std.Target.aarch64.cpu.cortex_a53 },
+            .cpu_features_add = std.Target.aarch64.featureSet(&[_]std.Target.aarch64.Feature{ .strict_align }),
+            .os_tag = .freestanding,
+            .abi = .none,
+        },
+    },
+    .{
+        .board = MicrokitBoard.imx8mp_evk,
+        .zig_target = std.Target.Query{
+            .cpu_arch = .aarch64,
+            .cpu_model = .{ .explicit = &std.Target.aarch64.cpu.cortex_a53 },
+            .cpu_features_add = std.Target.aarch64.featureSet(&[_]std.Target.aarch64.Feature{ .strict_align }),
+            .os_tag = .freestanding,
+            .abi = .none,
+        },
+    },
+    .{
+        .board = MicrokitBoard.imx8mq_evk,
         .zig_target = std.Target.Query{
             .cpu_arch = .aarch64,
             .cpu_model = .{ .explicit = &std.Target.aarch64.cpu.cortex_a53 },
@@ -166,7 +188,7 @@ pub fn build(b: *std.Build) !void {
     const driver_class = switch (microkit_board_option.?) {
         .qemu_virt_aarch64 => "arm",
         .odroidc2, .odroidc4 => "meson",
-        .maaxboard, .imx8mm_evk => "imx",
+        .maaxboard, .imx8mm_evk, .imx8mp_evk, .imx8mq_evk => "imx",
         .star64 => "snps",
         .qemu_virt_riscv64 => "virtio",
     };

--- a/examples/serial/meta.py
+++ b/examples/serial/meta.py
@@ -54,6 +54,18 @@ BOARDS: List[Board] = [
         serial="soc@0/bus@30800000/spba-bus@30800000/serial@30890000"
     ),
     Board(
+        name="imx8mp_evk",
+        arch=SystemDescription.Arch.AARCH64,
+        paddr_top=0xa_000_000,
+        serial="soc@0/bus@30800000/spba-bus@30800000/serial@30890000"
+    ),
+    Board(
+        name="imx8mq_evk",
+        arch=SystemDescription.Arch.AARCH64,
+        paddr_top=0xa_000_000,
+        serial="soc@0/bus@30800000/serial@30860000",
+    ),
+    Board(
         name="star64",
         arch=SystemDescription.Arch.RISCV64,
         paddr_top=0x100000000,

--- a/examples/serial/serial.mk
+++ b/examples/serial/serial.mk
@@ -51,10 +51,7 @@ else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_riscv64)
 					  -chardev pty,id=virtcon \
 					  -device virtconsole,chardev=virtcon
 	DRIVER_DIR := virtio
-else ifeq ($(strip $(MICROKIT_BOARD)), maaxboard)
-	DRIVER_DIR := imx
-	CPU := cortex-a53
-else ifeq ($(strip $(MICROKIT_BOARD)), imx8mm_evk)
+else ifneq ($(filter $(strip $(MICROKIT_BOARD)),imx8mm_evk imx8mp_evk imx8mq_evk maaxboard),)
 	DRIVER_DIR := imx
 	CPU := cortex-a53
 else ifeq ($(strip $(MICROKIT_BOARD)), star64)


### PR DESCRIPTION
We support these two in the echo server and timer examples, so we can easily do it for the serial one as well.