### PR TITLE
Szymon/goldfish rtc driver

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -29,6 +29,7 @@ Files:
     drivers/timer/imx/config.json
     drivers/timer/jh7110/config.json
     drivers/timer/meson/config.json
+    drivers/timer/goldfish/config.json
 Copyright: UNSW
 License: BSD-2-Clause
 

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -237,8 +237,12 @@ seL4_Bool fault(microkit_child id, microkit_msginfo msginfo, microkit_msginfo *r
 
     seL4_UserContext regs;
     seL4_TCB_ReadRegisters(BASE_TCB_CAP + id, false, 0, sizeof(seL4_UserContext) / sizeof(seL4_Word), &regs);
+#ifdef CONFIG_ARCH_ARM
     sddf_printf("Registers: \npc : %lx\nspsr : %lx\nx0 : %lx\nx1 : %lx\nx2 : %lx\nx3 : %lx\nx4 : %lx\nx5 : %lx\nx6 : %lx\nx7 : %lx\n",
                 regs.pc, regs.spsr, regs.x0, regs.x1, regs.x2, regs.x3, regs.x4, regs.x5, regs.x6, regs.x7);
+#else
+    sddf_printf("Register dumping not implemented for current ARCH.\n");
+#endif
 
     switch (microkit_msginfo_get_label(msginfo)) {
     case seL4_Fault_CapFault: {

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -237,12 +237,8 @@ seL4_Bool fault(microkit_child id, microkit_msginfo msginfo, microkit_msginfo *r
 
     seL4_UserContext regs;
     seL4_TCB_ReadRegisters(BASE_TCB_CAP + id, false, 0, sizeof(seL4_UserContext) / sizeof(seL4_Word), &regs);
-#ifdef CONFIG_ARCH_ARM
     sddf_printf("Registers: \npc : %lx\nspsr : %lx\nx0 : %lx\nx1 : %lx\nx2 : %lx\nx3 : %lx\nx4 : %lx\nx5 : %lx\nx6 : %lx\nx7 : %lx\n",
                 regs.pc, regs.spsr, regs.x0, regs.x1, regs.x2, regs.x3, regs.x4, regs.x5, regs.x6, regs.x7);
-#else
-    sddf_printf("Register dumping not implemented for current ARCH.\n");
-#endif
 
     switch (microkit_msginfo_get_label(msginfo)) {
     case seL4_Fault_CapFault: {

--- a/build.zig
+++ b/build.zig
@@ -19,6 +19,7 @@ const DriverClass = struct {
         meson,
         imx,
         jh7110,
+        goldfish
     };
 
     const Network = enum {

--- a/ci/examples.sh
+++ b/ci/examples.sh
@@ -193,7 +193,7 @@ i2c() {
 }
 
 timer() {
-    BOARDS=("imx8mm_evk" "imx8mp_evk" "imx8mq_evk" "maaxboard" "odroidc2" "odroidc4" "qemu_virt_aarch64" "star64")
+    BOARDS=("imx8mm_evk" "imx8mp_evk" "imx8mq_evk" "maaxboard" "odroidc2" "odroidc4" "qemu_virt_aarch64" "qemu_virt_riscv64" "star64")
     CONFIGS=("debug" "release")
     for BOARD in "${BOARDS[@]}"
     do

--- a/drivers/timer/goldfish/config.json
+++ b/drivers/timer/goldfish/config.json
@@ -1,0 +1,18 @@
+{
+    "compatible": [
+        "google,goldfish-rtc"
+    ],
+    "resources": {
+        "regions": [
+            {
+                "name": "regs",
+                "dt_index": 0
+            }
+        ],
+        "irqs": [
+            {
+                "dt_index": 0
+            }
+        ]
+    }
+}

--- a/drivers/timer/goldfish/timer.c
+++ b/drivers/timer/goldfish/timer.c
@@ -11,9 +11,7 @@
 #include <sddf/util/udivmodti4.h>
 #include <sddf/resources/device.h>
 
-
 #define MAX_TIMEOUTS 6
-
 
 /* taken from: https://github.com/torvalds/linux/blob/master/include/clocksource/timer-goldfish.h */
 typedef struct {
@@ -28,23 +26,21 @@ typedef struct {
     uint32_t TIMER_CLEAR_INTERRUPT;     /* 0x1c: set to 1 to clear interrupt */
 } goldfish_timer_regs_t;
 
-
 __attribute__((__section__(".device_resources"))) device_resources_t device_resources;
 static volatile goldfish_timer_regs_t *timer_regs;
 
 static inline uint64_t get_ticks_in_ns(void)
 {
-    uint64_t time = (uint64_t) timer_regs->TIMER_TIME_LOW;
-    time |= ((uint64_t) timer_regs->TIMER_TIME_HIGH) << 32;
+    uint64_t time = (uint64_t)timer_regs->TIMER_TIME_LOW;
+    time |= ((uint64_t)timer_regs->TIMER_TIME_HIGH) << 32;
     return time;
 }
 
 void set_timeout(uint64_t timeout)
 {
-    timer_regs->TIMER_ALARM_HIGH = (uint32_t) (timeout >> 32);
-    timer_regs->TIMER_ALARM_LOW = (uint32_t) timeout;
+    timer_regs->TIMER_ALARM_HIGH = (uint32_t)(timeout >> 32);
+    timer_regs->TIMER_ALARM_LOW = (uint32_t)timeout;
     timer_regs->TIMER_IRQ_ENABLED = 1U;
-
 }
 
 static uint64_t timeouts[MAX_TIMEOUTS];
@@ -68,7 +64,6 @@ static void process_timeouts(uint64_t curr_time)
     if (next_timeout != UINT64_MAX) {
         set_timeout(next_timeout);
     }
-
 }
 
 void init()
@@ -76,7 +71,7 @@ void init()
     assert(device_resources_check_magic(&device_resources));
     assert(device_resources.num_irqs == 1);
     assert(device_resources.num_regions == 1);
-    timer_regs = (goldfish_timer_regs_t*) device_resources.regions[0].region.vaddr;
+    timer_regs = (goldfish_timer_regs_t *)device_resources.regions[0].region.vaddr;
 
     for (int i = 0; i < MAX_TIMEOUTS; i++) {
         timeouts[i] = UINT64_MAX;
@@ -110,8 +105,8 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
         break;
     }
     default:
-        sddf_dprintf("TIMER DRIVER|LOG: Unknown request %lu to timer from channel %u\n", microkit_msginfo_get_label(msginfo),
-                     ch);
+        sddf_dprintf("TIMER DRIVER|LOG: Unknown request %lu to timer from channel %u\n",
+                     microkit_msginfo_get_label(msginfo), ch);
         break;
     }
 

--- a/drivers/timer/goldfish/timer.c
+++ b/drivers/timer/goldfish/timer.c
@@ -16,14 +16,14 @@
 /* taken from: https://github.com/torvalds/linux/blob/master/include/clocksource/timer-goldfish.h */
 typedef struct {
     /* Registers */
-    uint32_t timer_time_low;            /* 0x00: get low bits of current time and update timer_time_high */
-    uint32_t timer_time_high;           /* 0x04: get high bits of time at last timer_time_low read */
-    uint32_t timer_alarm_low;           /* 0x08: set low bits of alarm and activate it */
-    uint32_t timer_alarm_high;          /* 0x0c: set high bits of next alarm */
-    uint32_t timer_irq_enabled;         /* 0x10: set to 1 to enable alarm interrupt */
-    uint32_t timer_clear_alarm;         /* 0x14: set to 1 to disarm an existing alarm */
-    uint32_t timer_alarm_status;        /* 0x18: alarm status (1 running; 0 not) */
-    uint32_t timer_clear_interrupt;     /* 0x1c: set to 1 to clear interrupt */
+    uint32_t time_low;            /* 0x00: get low bits of current time and update time_high */
+    uint32_t time_high;           /* 0x04: get high bits of time at last time_low read */
+    uint32_t alarm_low;           /* 0x08: set low bits of alarm and activate it */
+    uint32_t alarm_high;          /* 0x0c: set high bits of next alarm */
+    uint32_t irq_enabled;         /* 0x10: set to 1 to enable alarm interrupt */
+    uint32_t clear_alarm;         /* 0x14: set to 1 to disarm an existing alarm */
+    uint32_t alarm_status;        /* 0x18: alarm status (1 running; 0 not) */
+    uint32_t clear_interrupt;     /* 0x1c: set to 1 to clear interrupt */
 } goldfish_timer_regs_t;
 
 __attribute__((__section__(".device_resources"))) device_resources_t device_resources;
@@ -31,16 +31,16 @@ static volatile goldfish_timer_regs_t *timer_regs;
 
 static inline uint64_t get_ticks_in_ns(void)
 {
-    uint64_t time = (uint64_t)timer_regs->timer_time_low;
-    time |= ((uint64_t)timer_regs->timer_time_high) << 32;
+    uint64_t time = (uint64_t)timer_regs->time_low;
+    time |= ((uint64_t)timer_regs->time_high) << 32;
     return time;
 }
 
 void set_timeout(uint64_t timeout)
 {
-    timer_regs->timer_alarm_high = (uint32_t)(timeout >> 32);
-    timer_regs->timer_alarm_low = (uint32_t)timeout;
-    timer_regs->timer_irq_enabled = 1U;
+    timer_regs->alarm_high = (uint32_t)(timeout >> 32);
+    timer_regs->alarm_low = (uint32_t)timeout;
+    timer_regs->irq_enabled = 1U;
 }
 
 static uint64_t timeouts[MAX_TIMEOUTS];
@@ -84,7 +84,7 @@ void notified(microkit_channel ch)
     microkit_deferred_irq_ack(ch);
 
     /* Handled irq -> clear device interrupt */
-    timer_regs->timer_clear_interrupt = 1;
+    timer_regs->clear_interrupt = 1;
     uint64_t curr_time = get_ticks_in_ns();
     process_timeouts(curr_time);
 }

--- a/drivers/timer/goldfish/timer.c
+++ b/drivers/timer/goldfish/timer.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <microkit.h>
+#include <sddf/timer/protocol.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <sddf/util/udivmodti4.h>
+#include <sddf/resources/device.h>
+
+
+#define MAX_TIMEOUTS 6
+
+
+/* taken from: https://github.com/torvalds/linux/blob/master/include/clocksource/timer-goldfish.h */
+typedef struct {
+    /* Registers */
+    uint32_t TIMER_TIME_LOW;            /* 0x00: get low bits of current time and update TIMER_TIME_HIGH */
+    uint32_t TIMER_TIME_HIGH;           /* 0x04: get high bits of time at last TIMER_TIME_LOW read */
+    uint32_t TIMER_ALARM_LOW;           /* 0x08: set low bits of alarm and activate it */
+    uint32_t TIMER_ALARM_HIGH;          /* 0x0c: set high bits of next alarm */
+    uint32_t TIMER_IRQ_ENABLED;         /* 0x10: set to 1 to enable alarm interrupt */
+    uint32_t TIMER_CLEAR_ALARM;         /* 0x14: set to 1 to disarm an existing alarm */
+    uint32_t TIMER_ALARM_STATUS;        /* 0x18: alarm status (1 running; 0 not) */
+    uint32_t TIMER_CLEAR_INTERRUPT;     /* 0x1c: set to 1 to clear interrupt */
+} goldfish_timer_regs_t;
+
+
+__attribute__((__section__(".device_resources"))) device_resources_t device_resources;
+static volatile goldfish_timer_regs_t *timer_regs;
+
+static inline uint64_t get_ticks_in_ns(void)
+{
+    uint64_t time = (uint64_t) timer_regs->TIMER_TIME_LOW;
+    time |= ((uint64_t) timer_regs->TIMER_TIME_HIGH) << 32;
+    return time;
+}
+
+void set_timeout(uint64_t timeout)
+{
+    timer_regs->TIMER_ALARM_HIGH = (uint32_t) (timeout >> 32);
+    timer_regs->TIMER_ALARM_LOW = (uint32_t) timeout;
+    timer_regs->TIMER_IRQ_ENABLED = 1U;
+
+}
+
+static uint64_t timeouts[MAX_TIMEOUTS];
+
+static void process_timeouts(uint64_t curr_time)
+{
+    for (int i = 0; i < MAX_TIMEOUTS; i++) {
+        if (timeouts[i] <= curr_time) {
+            microkit_notify(i);
+            timeouts[i] = UINT64_MAX;
+        }
+    }
+
+    uint64_t next_timeout = UINT64_MAX;
+    for (int i = 0; i < MAX_TIMEOUTS; i++) {
+        if (timeouts[i] < next_timeout) {
+            next_timeout = timeouts[i];
+        }
+    }
+
+    if (next_timeout != UINT64_MAX) {
+        set_timeout(next_timeout);
+        sddf_printf("Is there a timeout: %d\n", timer_regs->TIMER_ALARM_STATUS);
+    }
+
+}
+
+void init()
+{
+    assert(device_resources_check_magic(&device_resources));
+    assert(device_resources.num_irqs == 1);
+    assert(device_resources.num_regions == 1);
+    timer_regs = (goldfish_timer_regs_t*) device_resources.regions[0].region.vaddr;
+
+    for (int i = 0; i < MAX_TIMEOUTS; i++) {
+        timeouts[i] = UINT64_MAX;
+    }
+}
+
+void notified(microkit_channel ch)
+{
+    assert(ch == device_resources.irqs[0].id);
+    microkit_deferred_irq_ack(ch);
+
+    /* Handled irq -> clear device interrupt */
+    timer_regs->TIMER_CLEAR_INTERRUPT = 1;
+    uint64_t curr_time = get_ticks_in_ns();
+    process_timeouts(curr_time);
+}
+
+seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
+{
+    switch (microkit_msginfo_get_label(msginfo)) {
+    case SDDF_TIMER_GET_TIME: {
+        uint64_t time_ns = get_ticks_in_ns();
+        seL4_SetMR(0, time_ns);
+        return microkit_msginfo_new(0, 1);
+    }
+    case SDDF_TIMER_SET_TIMEOUT: {
+        uint64_t curr_time = get_ticks_in_ns();
+        uint64_t offset_us = (uint64_t)(seL4_GetMR(0));
+        timeouts[ch] = curr_time + offset_us;
+        process_timeouts(curr_time);
+        break;
+    }
+    default:
+        sddf_dprintf("TIMER DRIVER|LOG: Unknown request %lu to timer from channel %u\n", microkit_msginfo_get_label(msginfo),
+                     ch);
+        break;
+    }
+
+    return microkit_msginfo_new(0, 0);
+}

--- a/drivers/timer/goldfish/timer.c
+++ b/drivers/timer/goldfish/timer.c
@@ -67,7 +67,6 @@ static void process_timeouts(uint64_t curr_time)
 
     if (next_timeout != UINT64_MAX) {
         set_timeout(next_timeout);
-        sddf_printf("Is there a timeout: %d\n", timer_regs->TIMER_ALARM_STATUS);
     }
 
 }

--- a/drivers/timer/goldfish/timer.c
+++ b/drivers/timer/goldfish/timer.c
@@ -16,14 +16,14 @@
 /* taken from: https://github.com/torvalds/linux/blob/master/include/clocksource/timer-goldfish.h */
 typedef struct {
     /* Registers */
-    uint32_t TIMER_TIME_LOW;            /* 0x00: get low bits of current time and update TIMER_TIME_HIGH */
-    uint32_t TIMER_TIME_HIGH;           /* 0x04: get high bits of time at last TIMER_TIME_LOW read */
-    uint32_t TIMER_ALARM_LOW;           /* 0x08: set low bits of alarm and activate it */
-    uint32_t TIMER_ALARM_HIGH;          /* 0x0c: set high bits of next alarm */
-    uint32_t TIMER_IRQ_ENABLED;         /* 0x10: set to 1 to enable alarm interrupt */
-    uint32_t TIMER_CLEAR_ALARM;         /* 0x14: set to 1 to disarm an existing alarm */
-    uint32_t TIMER_ALARM_STATUS;        /* 0x18: alarm status (1 running; 0 not) */
-    uint32_t TIMER_CLEAR_INTERRUPT;     /* 0x1c: set to 1 to clear interrupt */
+    uint32_t timer_time_low;            /* 0x00: get low bits of current time and update timer_time_high */
+    uint32_t timer_time_high;           /* 0x04: get high bits of time at last timer_time_low read */
+    uint32_t timer_alarm_low;           /* 0x08: set low bits of alarm and activate it */
+    uint32_t timer_alarm_high;          /* 0x0c: set high bits of next alarm */
+    uint32_t timer_irq_enabled;         /* 0x10: set to 1 to enable alarm interrupt */
+    uint32_t timer_clear_alarm;         /* 0x14: set to 1 to disarm an existing alarm */
+    uint32_t timer_alarm_status;        /* 0x18: alarm status (1 running; 0 not) */
+    uint32_t timer_clear_interrupt;     /* 0x1c: set to 1 to clear interrupt */
 } goldfish_timer_regs_t;
 
 __attribute__((__section__(".device_resources"))) device_resources_t device_resources;
@@ -31,16 +31,16 @@ static volatile goldfish_timer_regs_t *timer_regs;
 
 static inline uint64_t get_ticks_in_ns(void)
 {
-    uint64_t time = (uint64_t)timer_regs->TIMER_TIME_LOW;
-    time |= ((uint64_t)timer_regs->TIMER_TIME_HIGH) << 32;
+    uint64_t time = (uint64_t)timer_regs->timer_time_low;
+    time |= ((uint64_t)timer_regs->timer_time_high) << 32;
     return time;
 }
 
 void set_timeout(uint64_t timeout)
 {
-    timer_regs->TIMER_ALARM_HIGH = (uint32_t)(timeout >> 32);
-    timer_regs->TIMER_ALARM_LOW = (uint32_t)timeout;
-    timer_regs->TIMER_IRQ_ENABLED = 1U;
+    timer_regs->timer_alarm_high = (uint32_t)(timeout >> 32);
+    timer_regs->timer_alarm_low = (uint32_t)timeout;
+    timer_regs->timer_irq_enabled = 1U;
 }
 
 static uint64_t timeouts[MAX_TIMEOUTS];
@@ -84,7 +84,7 @@ void notified(microkit_channel ch)
     microkit_deferred_irq_ack(ch);
 
     /* Handled irq -> clear device interrupt */
-    timer_regs->TIMER_CLEAR_INTERRUPT = 1;
+    timer_regs->timer_clear_interrupt = 1;
     uint64_t curr_time = get_ticks_in_ns();
     process_timeouts(curr_time);
 }

--- a/drivers/timer/goldfish/timer_driver.mk
+++ b/drivers/timer/goldfish/timer_driver.mk
@@ -1,0 +1,27 @@
+#
+# Copyright 2025, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Include this snippet in your project Makefile to build
+# the goldfish-rtc timer driver
+#
+# NOTES:
+#  Generates timer_driver.elf
+#  Expects libsddf_util_debug.a to be in ${LIBS}
+
+TIMER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+timer_driver.elf: timer/timer.o
+	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
+
+timer/timer.o: ${TIMER_DIR}/timer.c ${CHECK_FLAGS_BOARD_MD5} |timer
+	${CC} ${CFLAGS} -o $@ -c $<
+
+timer:
+	mkdir -p timer
+
+clean::
+	rm -rf timer
+clobber::
+	rm -f timer_driver.elf

--- a/examples/timer/Makefile
+++ b/examples/timer/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2024, UNSW
+# Copyright 2025, UNSW
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
@@ -7,45 +7,16 @@
 ifeq ($(strip $(MICROKIT_SDK)),)
 $(error MICROKIT_SDK must be specified)
 endif
+
+ifeq ($(strip $(MICROKIT_BOARD)),)
+$(error MICROKIT_BOARD must be specified)
+endif
+export MICROKIT_BOARD
+BUILD_DIR ?= build
+export SDDF := $(abspath ../..)
+export BUILD_DIR := $(abspath ${BUILD_DIR})
 override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 
-BUILD_DIR ?= build
-# By default we make a debug build so that the client debug prints can be seen.
-MICROKIT_CONFIG ?= debug
-IMAGE_FILE := loader.img
-
-ifeq ($(strip $(MICROKIT_BOARD)), odroidc4)
-	export TIMER_DRIVER_DIR := meson
-	export CPU := cortex-a55
-else ifeq ($(strip $(MICROKIT_BOARD)), odroidc2)
-	export TIMER_DRIVER_DIR := meson
-	export CPU := cortex-a53
-else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_aarch64)
-	export TIMER_DRIVER_DIR := arm
-	export CPU := cortex-a53
-	export QEMU := qemu-system-aarch64
-	export QEMU_ARCH_ARGS := -machine virt,virtualization=on -cpu cortex-a53 -device loader,file=$(IMAGE_FILE),addr=0x70000000,cpu-num=0
-else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_riscv64)
-	export TIMER_DRIVER_DIR := goldfish
-	export QEMU := qemu-system-riscv64
-	export QEMU_ARCH_ARGS := -machine virt -kernel $(IMAGE_FILE)
-else ifeq ($(strip $(MICROKIT_BOARD)), star64)
-	export TIMER_DRIVER_DIR := jh7110
-else ifneq ($(filter $(strip $(MICROKIT_BOARD)),imx8mm_evk imx8mp_evk imx8mq_evk maaxboard),)
-	export TIMER_DRIVER_DIR := imx
-	export CPU := cortex-a53
-else
-$(error Unsupported MICROKIT_BOARD given)
-endif
-
-CC := clang
-LD := ld.lld
-export MICROKIT_TOOL ?= $(abspath $(MICROKIT_SDK)/bin/microkit)
-
-export BOARD_DIR := $(abspath $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG))
-export SDDF := $(abspath ../..)
-export TOP:= $(abspath $(dir ${MAKEFILE_LIST}))
-export ARCH := ${shell grep 'CONFIG_SEL4_ARCH  ' $(BOARD_DIR)/include/kernel/gen_config.h | cut -d' ' -f4}
 IMAGE_FILE := $(BUILD_DIR)/loader.img
 REPORT_FILE := $(BUILD_DIR)/report.txt
 

--- a/examples/timer/Makefile
+++ b/examples/timer/Makefile
@@ -12,6 +12,7 @@ override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 BUILD_DIR ?= build
 # By default we make a debug build so that the client debug prints can be seen.
 MICROKIT_CONFIG ?= debug
+IMAGE_FILE := loader.img
 
 ifeq ($(strip $(MICROKIT_BOARD)), odroidc4)
 	export TIMER_DRIVER_DIR := meson
@@ -22,7 +23,12 @@ else ifeq ($(strip $(MICROKIT_BOARD)), odroidc2)
 else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_aarch64)
 	export TIMER_DRIVER_DIR := arm
 	export CPU := cortex-a53
-	QEMU := qemu-system-aarch64
+	export QEMU := qemu-system-aarch64
+	export QEMU_ARCH_ARGS := -machine virt,virtualization=on -cpu cortex-a53 -device loader,file=$(IMAGE_FILE),addr=0x70000000,cpu-num=0
+else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_riscv64)
+	export TIMER_DRIVER_DIR := goldfish
+	export QEMU := qemu-system-riscv64
+	export QEMU_ARCH_ARGS := -machine virt -kernel $(IMAGE_FILE)
 else ifeq ($(strip $(MICROKIT_BOARD)), star64)
 	export TIMER_DRIVER_DIR := jh7110
 else ifneq ($(filter $(strip $(MICROKIT_BOARD)),imx8mm_evk imx8mp_evk imx8mq_evk maaxboard),)

--- a/examples/timer/README.md
+++ b/examples/timer/README.md
@@ -19,6 +19,7 @@ The following platforms are supported:
 * odroidc2
 * odroidc4
 * qemu_virt_aarch64
+* qemu_virt_riscv64
 * star64
 
 ### Make

--- a/examples/timer/meta.py
+++ b/examples/timer/meta.py
@@ -24,6 +24,12 @@ BOARDS: List[Board] = [
         timer="timer"
     ),
     Board(
+        name="qemu_virt_riscv64",
+        arch=SystemDescription.Arch.RISCV64,
+        paddr_top=0xa_0000_000,
+        timer="soc/rtc@101000",
+    ),
+    Board(
         name="odroidc2",
         arch=SystemDescription.Arch.AARCH64,
         paddr_top=0x80000000,

--- a/examples/timer/timer.mk
+++ b/examples/timer/timer.mk
@@ -1,5 +1,5 @@
 #
-# Copyright 2024, UNSW
+# Copyright 2025, UNSW
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
@@ -8,25 +8,71 @@ ifeq ($(strip $(MICROKIT_SDK)),)
 $(error MICROKIT_SDK must be specified)
 endif
 
-METAPROGRAM := $(TOP)/meta.py
+ifeq ($(strip $(SDDF)),)
+$(error SDDF must be specified)
+endif
 
 BUILD_DIR ?= build
 # By default we make a debug build so that the client debug prints can be seen.
 MICROKIT_CONFIG ?= debug
+IMAGE_FILE := loader.img
+REPORT_FILE := report.txt
 
+ifeq ($(strip $(TOOLCHAIN)),)
+	TOOLCHAIN := clang
+endif
+ifeq ($(strip $(TOOLCHAIN)), clang)
+	CC := clang
+	LD := ld.lld
+	AR := llvm-ar
+	RANLIB := llvm-ranlib
+	OBJCOPY := llvm-objcopy
+else
+	CC := $(TOOLCHAIN)-gcc
+	LD := $(TOOLCHAIN)-ld
+	AS := $(TOOLCHAIN)-as
+	AR := $(TOOLCHAIN)-ar
+	RANLIB := $(TOOLCHAIN)-ranlib
+	OBJCOPY := $(TOOLCHAIN)-objcopy
+endif
 DTC := dtc
 PYTHON ?= python3
 
-CC := clang
-LD := ld.lld
-AR := llvm-ar
-RANLIB := llvm-ranlib
-OBJCOPY := llvm-objcopy
-
 MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
 
-BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+ifeq ($(strip $(MICROKIT_BOARD)), odroidc4)
+	export TIMER_DRIVER_DIR := meson
+	export CPU := cortex-a55
+else ifeq ($(strip $(MICROKIT_BOARD)), odroidc2)
+	export TIMER_DRIVER_DIR := meson
+	export CPU := cortex-a53
+else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_aarch64)
+	export TIMER_DRIVER_DIR := arm
+	export CPU := cortex-a53
+	export QEMU := qemu-system-aarch64
+	export QEMU_ARCH_ARGS := -machine virt,virtualization=on -cpu cortex-a53 -device loader,file=$(IMAGE_FILE),addr=0x70000000,cpu-num=0
+else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_riscv64)
+	export TIMER_DRIVER_DIR := goldfish
+	export QEMU := qemu-system-riscv64
+	export QEMU_ARCH_ARGS := -machine virt -kernel $(IMAGE_FILE)
+else ifeq ($(strip $(MICROKIT_BOARD)), star64)
+	export TIMER_DRIVER_DIR := jh7110
+else ifneq ($(filter $(strip $(MICROKIT_BOARD)),imx8mm_evk imx8mp_evk imx8mq_evk maaxboard),)
+	export TIMER_DRIVER_DIR := imx
+	export CPU := cortex-a53
+else
+$(error Unsupported MICROKIT_BOARD given)
+endif
+
+TOP:= ${SDDF}/examples/timer
+METAPROGRAM := $(TOP)/meta.py
 UTIL := $(SDDF)/util
+TIMER_DRIVER := $(SDDF)/drivers/timer/$(TIMER_DRIVER_DIR)
+BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+SYSTEM_FILE := timer.system
+DTS := $(SDDF)/dts/$(MICROKIT_BOARD).dts
+DTB := $(MICROKIT_BOARD).dtb
+ARCH := ${shell grep 'CONFIG_SEL4_ARCH  ' $(BOARD_DIR)/include/kernel/gen_config.h | cut -d' ' -f4}
 
 IMAGES := timer_driver.elf client.elf
 
@@ -48,13 +94,6 @@ CFLAGS := -nostdlib \
 LDFLAGS := -L$(BOARD_DIR)/lib
 LIBS := --start-group -lmicrokit -Tmicrokit.ld libsddf_util_debug.a --end-group
 
-IMAGE_FILE := loader.img
-DTS := $(SDDF)/dts/$(MICROKIT_BOARD).dts
-DTB := $(MICROKIT_BOARD).dtb
-SYSTEM_FILE := timer.system
-REPORT_FILE := report.txt
-CLIENT_OBJS := client.o
-TIMER_DRIVER := $(SDDF)/drivers/timer/$(TIMER_DRIVER_DIR)
 
 all: $(IMAGE_FILE)
 CHECK_FLAGS_BOARD_MD5:=.board_cflags-$(shell echo -- ${CFLAGS} ${MICROKIT_BOARD} ${MICROKIT_CONFIG} | shasum | sed 's/ *-//')

--- a/examples/timer/timer.mk
+++ b/examples/timer/timer.mk
@@ -15,7 +15,6 @@ BUILD_DIR ?= build
 MICROKIT_CONFIG ?= debug
 
 DTC := dtc
-QEMU := qemu-system-aarch64
 PYTHON ?= python3
 
 CC := clang
@@ -86,12 +85,11 @@ $(IMAGE_FILE) $(REPORT_FILE): $(SYSTEM_FILE)
 	$(MICROKIT_TOOL) $(SYSTEM_FILE) --search-path $(BUILD_DIR) --board $(MICROKIT_BOARD) --config $(MICROKIT_CONFIG) -o $(IMAGE_FILE) -r $(REPORT_FILE)
 
 qemu: $(IMAGE_FILE)
-	$(QEMU) -machine virt,virtualization=on \
-			-cpu cortex-a53 \
+	$(QEMU) $(QEMU_ARCH_ARGS) \
 			-serial mon:stdio \
-			-device loader,file=$(IMAGE_FILE),addr=0x70000000,cpu-num=0 \
 			-m size=2G \
-			-nographic
+			-nographic \
+			-d guest_errors
 
 clean::
 	rm -f client.o


### PR DESCRIPTION
Adds:
- google goldfish RTC driver, used by qemu-virt-riscv64 board.
- Updates examples/timer to use the driver
- ~~WIP: updates to echo_server to build successfully (atm conditionally compiles dumping ARM regs in benchmark.c)~~ Will be moved to separate PR


Driver based on:
- Linux src: https://github.com/torvalds/linux/blob/48a5eed9ad584315c30ed35204510536235ce402/drivers/rtc/rtc-goldfish.c
- Android src: https://github.com/qemu/qemu/blob/1dae461a913f9da88df05de6e2020d3134356f2e/hw/rtc/goldfish_rtc.c