### PR TITLE
Add qemu-virt-riscv64 support for echo server. Restructure Makefile

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -29,7 +29,7 @@ jobs:
           wget ${{ env.MICROKIT_URL }}-linux-x86-64.tar.gz
           tar xf microkit-sdk-${{ env.MICROKIT_VERSION }}-linux-x86-64.tar.gz
       - name: Install dependencies (via apt)
-        run: sudo apt update && sudo apt install -y make llvm lld imagemagick device-tree-compiler
+        run: sudo apt update && sudo apt install -y make llvm lld imagemagick device-tree-compiler gcc-riscv64-unknown-elf picolibc-riscv64-unknown-elf
       - name: Download and install AArch64 GCC toolchain
         run: |
           wget -O aarch64-toolchain.tar.xz https://trustworthy.systems/Downloads/microkit/arm-gnu-toolchain-12.3.rel1-x86_64-aarch64-none-elf.tar.xz
@@ -72,6 +72,8 @@ jobs:
       - name: Install dependencies (via Homebrew)
         run: |
           brew install llvm lld make imagemagick dtc
+          brew tap riscv-software-src/riscv
+          brew install riscv-tools
           echo "/opt/homebrew/opt/llvm/bin:$PATH" >> $GITHUB_PATH
       - name: Install Zig
         uses: mlugg/setup-zig@v1.2.1

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -197,7 +197,6 @@ void init(void)
 #ifdef MICROKIT_CONFIG_benchmark
     sddf_printf("BENCH|LOG: MICROKIT_CONFIG_benchmark defined\n");
 #ifndef CONFIG_ARCH_ARM
-#warning "!!! System not running on ARM, benchmarking not implemented !!!"
     sddf_printf("BENCH|LOG: System not running on ARM, benchmarking not implemented.\n");
 #endif
 #endif

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -244,6 +244,10 @@ seL4_Bool fault(microkit_child id, microkit_msginfo msginfo, microkit_msginfo *r
 #if defined(CONFIG_ARCH_ARM)
     sddf_printf("Registers: \npc : %lx\nspsr : %lx\nx0 : %lx\nx1 : %lx\nx2 : %lx\nx3 : %lx\nx4 : %lx\nx5 : %lx\nx6 : %lx\nx7 : %lx\n",
                 regs.pc, regs.spsr, regs.x0, regs.x1, regs.x2, regs.x3, regs.x4, regs.x5, regs.x6, regs.x7);
+#elif defined(CONFIG_ARCH_RISCV)
+    sddf_printf("Registers: \npc : %lx\nra : %lx\nsp : %lx\ngp : %lx\ns0 : %lx\ns1 : %lx\ns2 : %lx\ns3 : %lx\ns4 : "
+                "%lx\ns5 : %lx\n",
+                regs.pc, regs.ra, regs.sp, regs.gp, regs.s0, regs.s1, regs.s2, regs.s3, regs.s4, regs.s5);
 #else
     sddf_printf("Register reading not implemented for current ARCH.\n");
 #endif

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -149,7 +149,7 @@ void notified(microkit_channel ch)
     if (ch == serial_config.tx.id) {
         return;
     } else if (ch == benchmark_config.start_ch) {
-#ifdef MICROKIT_CONFIG_benchmark
+#if defined(MICROKIT_CONFIG_benchmark) && defined(CONFIG_ARCH_ARM)
         sel4bench_reset_counters();
         THREAD_MEMORY_RELEASE();
         sel4bench_start_counters(benchmark_bf);
@@ -163,7 +163,7 @@ void notified(microkit_channel ch)
 #endif
 #endif
     } else if (ch == benchmark_config.stop_ch) {
-#ifdef MICROKIT_CONFIG_benchmark
+#if defined(MICROKIT_CONFIG_benchmark) && defined(CONFIG_ARCH_ARM)
         sel4bench_get_counters(benchmark_bf, &counter_values[0]);
         sel4bench_stop_counters(benchmark_bf);
 
@@ -196,6 +196,10 @@ void init(void)
 
 #ifdef MICROKIT_CONFIG_benchmark
     sddf_printf("BENCH|LOG: MICROKIT_CONFIG_benchmark defined\n");
+#ifndef CONFIG_ARCH_ARM
+#warning "!!! System not running on ARM, benchmarking not implemented !!!"
+    sddf_printf("BENCH|LOG: System not running on ARM, benchmarking not implemented.\n");
+#endif
 #endif
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
     sddf_printf("BENCH|LOG: CONFIG_BENCHMARK_TRACK_UTILISATION defined\n");
@@ -204,7 +208,7 @@ void init(void)
     sddf_printf("BENCH|LOG: CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES defined\n");
 #endif
 
-#ifdef MICROKIT_CONFIG_benchmark
+#if defined(MICROKIT_CONFIG_benchmark) && defined(CONFIG_ARCH_ARM)
     sel4bench_init();
     seL4_Word n_counters = sel4bench_get_num_counters();
     for (seL4_Word counter = 0; counter < MIN(n_counters, ARRAY_SIZE(benchmarking_events)); counter++) {
@@ -237,8 +241,12 @@ seL4_Bool fault(microkit_child id, microkit_msginfo msginfo, microkit_msginfo *r
 
     seL4_UserContext regs;
     seL4_TCB_ReadRegisters(BASE_TCB_CAP + id, false, 0, sizeof(seL4_UserContext) / sizeof(seL4_Word), &regs);
+#if defined(CONFIG_ARCH_ARM)
     sddf_printf("Registers: \npc : %lx\nspsr : %lx\nx0 : %lx\nx1 : %lx\nx2 : %lx\nx3 : %lx\nx4 : %lx\nx5 : %lx\nx6 : %lx\nx7 : %lx\n",
                 regs.pc, regs.spsr, regs.x0, regs.x1, regs.x2, regs.x3, regs.x4, regs.x5, regs.x6, regs.x7);
+#else
+    sddf_printf("Register reading not implemented for current ARCH.\n");
+#endif
 
     switch (microkit_msginfo_get_label(msginfo)) {
     case seL4_Fault_CapFault: {

--- a/benchmark/idle.c
+++ b/benchmark/idle.c
@@ -20,7 +20,7 @@ struct bench *b;
 
 void count_idle(void)
 {
-    #ifdef MICROKIT_CONFIG_benchmark
+#if defined(MICROKIT_CONFIG_benchmark) && defined(CONFIG_ARCH_ARM)
     uint64_t val;
     SEL4BENCH_READ_CCNT(val);
     b->prev = val;
@@ -37,7 +37,7 @@ void count_idle(void)
 
         b->prev = b->ts;
     }
-    #endif
+#endif
 }
 
 void notified(microkit_channel ch)

--- a/ci/examples.sh
+++ b/ci/examples.sh
@@ -171,7 +171,7 @@ build_gpu_zig() {
 }
 
 network() {
-    BOARDS=("imx8mm_evk" "imx8mp_evk" "imx8mq_evk" "maaxboard" "odroidc2" "odroidc4" "qemu_virt_aarch64")
+    BOARDS=("qemu_virt_riscv64" "imx8mm_evk" "imx8mp_evk" "imx8mq_evk" "maaxboard" "odroidc2" "odroidc4" "qemu_virt_aarch64")
     CONFIGS=("debug" "release" "benchmark")
     for BOARD in "${BOARDS[@]}"
     do

--- a/examples/echo_server/Makefile
+++ b/examples/echo_server/Makefile
@@ -4,61 +4,23 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-BUILD_DIR ?= build
-export MICROKIT_CONFIG ?= debug
-
 ifeq ($(strip $(MICROKIT_SDK)),)
 $(error MICROKIT_SDK must be specified)
 endif
-export override MICROKIT_SDK:=$(abspath ${MICROKIT_SDK})
 
-ifeq ($(strip $(TOOLCHAIN)),)
-	TOOLCHAIN := aarch64-none-elf
-	export TOOLCHAIN := aarch64-none-elf
-	export LIBC := $(dir $(realpath $(shell aarch64-none-elf-gcc --print-file-name libc.a)))
+ifeq ($(strip $(MICROKIT_BOARD)),)
+$(error MICROKIT_BOARD must be specified)
 endif
-
-ifeq ($(strip $(MICROKIT_BOARD)), odroidc4)
-	export DRIV_DIR := meson
-	export SERIAL_DRIV_DIR := meson
-	export TIMER_DRV_DIR := meson
-	export CPU := cortex-a55
-else ifeq ($(strip $(MICROKIT_BOARD)), odroidc2)
-	export DRIV_DIR := meson
-	export SERIAL_DRIV_DIR := meson
-	export TIMER_DRV_DIR := meson
-	export CPU := cortex-a53
-else ifneq ($(filter $(strip $(MICROKIT_BOARD)),imx8mm_evk imx8mp_evk imx8mq_evk maaxboard),)
-	export DRIV_DIR := imx
-	export SERIAL_DRIV_DIR := imx
-	export TIMER_DRV_DIR := imx
-	export CPU := cortex-a53
-else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_aarch64)
-	export DRIV_DIR := virtio
-	export SERIAL_DRIV_DIR := arm
-	export TIMER_DRV_DIR := arm
-	export CPU := cortex-a53
-	QEMU := qemu-system-aarch64
-else
-$(error Unsupported MICROKIT_BOARD given)
-endif
-
-export BUILD_DIR:=$(abspath ${BUILD_DIR})
-export MICROKIT_SDK:=$(abspath ${MICROKIT_SDK})
-export TOP := $(abspath $(dir ${MAKEFILE_LIST}))
-
-export CC := $(TOOLCHAIN)-gcc
-export LD := $(TOOLCHAIN)-ld
-export AS := $(TOOLCHAIN)-as
-export AR := $(TOOLCHAIN)-ar
-export RANLIB := $(TOOLCHAIN)-ranlib
-export OBJCOPY := $(TOOLCHAIN)-objcopy
-export MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
+export MICROKIT_BOARD
+BUILD_DIR ?= build
 export SDDF=$(abspath ../..)
-export ECHO_INCLUDE:=$(abspath .)/include
+export BUILD_DIR:=$(abspath ${BUILD_DIR})
+export override MICROKIT_SDK:=$(abspath ${MICROKIT_SDK})
 
 IMAGE_FILE := $(BUILD_DIR)/loader.img
 REPORT_FILE := $(BUILD_DIR)/report.txt
+
+export ECHO_INCLUDE:=$(abspath .)/include
 
 all: ${IMAGE_FILE}
 

--- a/examples/echo_server/README.md
+++ b/examples/echo_server/README.md
@@ -20,9 +20,25 @@ rather than simple implementations.
 
 For now, we rely on the newlibc packaged with the embedded C toolchains.
 
+### For ARM boards
 The specific toolchain we use for testing and benchmarking the network sub-system is
 the `aarch64-none-elf` GCC toolchain distributed by ARM. You can download it from
 [here](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads).
+
+### For RISC-V boards
+The toolchain we use is the `riscv64-none-elf`/`riscv64-unknown-elf` GCC toolchain.
+As its not centrally distributed, below are OS specific instructions:
+
+#### MacOS
+With the [Homebrew](https://brew.sh/) package manager, you can do:
+
+    $ brew tap riscv-software-src/riscv
+    $ brew install riscv-tools
+
+#### Linux (with apt)
+On a Debian-like system, you can do:
+
+    $ sudo apt install gcc-riscv64-unknown-elf picolibc-riscv64-unknown-elf
 
 ## Building
 
@@ -34,6 +50,7 @@ The following platforms are supported:
 * odroidc4
 * odroidc2
 * qemu_virt_aarch64
+* qemu_virt_riscv64
 
 ```sh
 make MICROKIT_BOARD=<board> MICROKIT_SDK=<path/to/sdk> MICROKIT_CONFIG=(benchmark/release/debug)
@@ -50,3 +67,5 @@ Checks to make before benchmarking:
 * Turn off all debug prints.
 * Run with LWIP asserts turned off as well (`LWIP_NOASSERT`).
 * Make sure compiler optimisations are enabled.
+
+Note that for qemu_virt_riscv64, see instructions for accessing serial console in [serial example README](../serial/README.md).

--- a/examples/echo_server/README.md
+++ b/examples/echo_server/README.md
@@ -18,27 +18,34 @@ instead of LLVM like all the other examples. As we use this example to perform b
 it is important that the functions that lwIP uses from the standard library are optimised
 rather than simple implementations.
 
-For now, we rely on the newlibc packaged with the embedded C toolchains.
+For now, we rely on the libc packaged with the embedded C toolchains.
 
-### For ARM boards
-The specific toolchain we use for testing and benchmarking the network sub-system is
-the `aarch64-none-elf` GCC toolchain distributed by ARM. You can download it from
+### ARM
+
+When targeting ARM boards, the specific toolchain we use for testing and benchmarking the echo
+server is the `aarch64-none-elf` GCC toolchain distributed by ARM. You can download it from
 [here](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads).
 
-### For RISC-V boards
-The toolchain we use is the `riscv64-none-elf`/`riscv64-unknown-elf` GCC toolchain.
-As its not centrally distributed, below are OS specific instructions:
+### RISC-V
 
-#### MacOS
-With the [Homebrew](https://brew.sh/) package manager, you can do:
-
-    $ brew tap riscv-software-src/riscv
-    $ brew install riscv-tools
+When targeting RISC-V boards, we use the embedded GCC toolchain which is `riscv64-none-elf`
+or `riscv64-unknown-elf` depending on your environment. This toolchain is not distributed
+centrally so below are OS specific instructions:
 
 #### Linux (with apt)
-On a Debian-like system, you can do:
 
-    $ sudo apt install gcc-riscv64-unknown-elf picolibc-riscv64-unknown-elf
+On a Debian-like system, you can do:
+```sh
+sudo apt install gcc-riscv64-unknown-elf picolibc-riscv64-unknown-elf
+```
+
+#### macOS
+
+With Homebrew:
+```sh
+brew tap riscv-software-src/riscv
+brew install riscv-tools
+```
 
 ## Building
 
@@ -58,14 +65,15 @@ make MICROKIT_BOARD=<board> MICROKIT_SDK=<path/to/sdk> MICROKIT_CONFIG=(benchmar
 
 ## Benchmarking
 
-In order to run the benchmarks, set `MICROKIT_CONFIG=benchmark`. Currently only Aarch64 boards have
-support for collecting of benchmarking data. The system has
+In order to run the benchmarks, set `MICROKIT_CONFIG=benchmark`. The system has
 been designed to interact with [ipbench](https://sourceforge.net/projects/ipbench/)
 to take measurements.
+
+> [!NOTE]
+> Benchmarking is only supported for AArch64 boards, RISC-V benchmarking is not supported yet,
+> see https://github.com/au-ts/sddf/issues/421 for details.
 
 Checks to make before benchmarking:
 * Turn off all debug prints.
 * Run with LWIP asserts turned off as well (`LWIP_NOASSERT`).
 * Make sure compiler optimisations are enabled.
-
-Note that for qemu_virt_riscv64, see instructions for accessing serial console in [serial example README](../serial/README.md).

--- a/examples/echo_server/README.md
+++ b/examples/echo_server/README.md
@@ -41,7 +41,8 @@ make MICROKIT_BOARD=<board> MICROKIT_SDK=<path/to/sdk> MICROKIT_CONFIG=(benchmar
 
 ## Benchmarking
 
-In order to run the benchmarks, set `MICROKIT_CONFIG=benchmark`. The system has
+In order to run the benchmarks, set `MICROKIT_CONFIG=benchmark`. Currently only Aarch64 boards have
+support for collecting of benchmarking data. The system has
 been designed to interact with [ipbench](https://sourceforge.net/projects/ipbench/)
 to take measurements.
 

--- a/examples/echo_server/meta.py
+++ b/examples/echo_server/meta.py
@@ -36,6 +36,14 @@ BOARDS: List[Board] = [
         ethernet="virtio_mmio@a003e00"
     ),
     Board(
+        name="qemu_virt_riscv64",
+        arch=SystemDescription.Arch.RISCV64,
+        paddr_top=0xa_0000_000,
+        serial="soc/serial@10000000",
+        timer="soc/rtc@101000",
+        ethernet="soc/virtio_mmio@10008000"
+    ),
+    Board(
         name="odroidc2",
         arch=SystemDescription.Arch.AARCH64,
         paddr_top=0x60000000,

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,8 @@
               nativeBuildInputs = with pkgs; [
                 pkgsCross.aarch64-embedded.stdenv.cc.bintools
                 pkgsCross.aarch64-embedded.stdenv.cc
+                pkgsCross.riscv64-embedded.stdenv.cc.bintools
+                pkgsCross.riscv64-embedded.stdenv.cc
                 zig
                 qemu
                 gnumake

--- a/network/lib_sddf_lwip/lib_sddf_lwip.mk
+++ b/network/lib_sddf_lwip/lib_sddf_lwip.mk
@@ -103,7 +103,7 @@ $(foreach f,$(LIB_SDDF_LWIP_LWIP_FILES), \
 )
 
 clean::
-	$(RM) -f lib_sddf_lwip_out*
+	$(RM) -f lib_sddf_lwip_out/*
 
 clobber:: clean
 	$(RM) -f lib_sddf_lwip*.a


### PR DESCRIPTION
Following changes:
- Update benchmark/benchmark.c and benchmark/idle.c to wrap arch-specific code sections in `CONFIG_ARCH_ARM` `ifdef`s. Leave skeleton for future RISC-V support.
- Restructure `echo_server` Makefile to stick to the same format as other examples: `Makefile` only creates the build directory, copies files over, minor error handling for missing params, main build file targets. `<system>.mk` does all the heavy lifting of board configs, qemu command definiton, toolchain definitions etc.
- Add qemu-virt-riscv64 support to the echo server example.