### PR TITLE
Add cache_invalidate, check if missing architecture

### DIFF
--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -159,11 +159,7 @@ static bool handle_mbr_reply()
         return false;
     }
 
-    /* TODO: This is a raw seL4 system call because Microkit does not (currently)
-     * include a corresponding libmicrokit API. */
-#ifdef CONFIG_ARCH_ARM
-    seL4_ARM_VSpace_Invalidate_Data(3, mbr_bk.vaddr, mbr_bk.vaddr + (BLK_TRANSFER_SIZE * mbr_bk.count));
-#endif
+    cache_invalidate(mbr_bk.vaddr, mbr_bk.vaddr + (BLK_TRANSFER_SIZE * mbr_bk.count));
     sddf_memcpy(&msdos_mbr, (void *)mbr_bk.vaddr, sizeof(struct msdos_mbr));
 
     return true;
@@ -218,11 +214,7 @@ static void handle_driver()
         case BLK_REQ_READ:
             if (drv_status == BLK_RESP_OK) {
                 /* Invalidate cache */
-                /* TODO: This is a raw seL4 system call because Microkit does not (currently)
-                    * include a corresponding libmicrokit API. */
-#ifdef CONFIG_ARCH_ARM
-                seL4_ARM_VSpace_Invalidate_Data(3, reqbk.vaddr, reqbk.vaddr + (BLK_TRANSFER_SIZE * reqbk.count));
-#endif
+                cache_invalidate(reqbk.vaddr, reqbk.vaddr + (BLK_TRANSFER_SIZE * reqbk.count));
             }
             break;
         case BLK_REQ_WRITE:

--- a/include/sddf/util/cache.h
+++ b/include/sddf/util/cache.h
@@ -5,5 +5,41 @@
 
 #pragma once
 
+/*
+ * This is a small utility library for performing cache operations in order
+ * to deal with DMA cache coherency. On DMA coherent architectures/platforms
+ * (such as certain RISC-V platforms and x86), these operations are no-ops.
+ *
+ * This library currently has the assumption that all RISC-V platforms are
+ * DMA coherent, it does not support platforms with the Zicbom extension.
+ */
+
+/*
+ * Cleans and invalidates the from start to end. This is not inclusive.
+ * If end is on a cache line boundary, the cache line starting at end
+ * will not be cleaned/invalidated.
+ *
+ * On ARM, this operation ultimately performs the 'dc civac' instruction.
+ * On RISC-V, this is a no-op.
+ */
 void cache_clean_and_invalidate(unsigned long start, unsigned long end);
+
+ /*
+ * Cleans from start to end. This is not inclusive.
+ * If end is on a cache line boundary, the cache line starting at end
+ * will not be cleanend.
+ *
+ * On ARM, this operation ultimately performs the 'dc cvac' instruction.
+ * On RISC-V, this is a no-op.
+ */
 void cache_clean(unsigned long start, unsigned long end);
+
+/*
+ * Invalidates from start to end. This is not inclusive.
+ *
+ * On ARM, this leads to seL4_ARM_VSpace_Invalidate_Data as it is not possible to invalidate
+ * directly from user-space. Note that it may be more efficient to simply do a
+ * cache_clean_and_invalidate instead as it will not result in a system call.
+ * On RISC-V, this is a no-op.
+ */
+void cache_invalidate(unsigned long start, unsigned long end);


### PR DESCRIPTION
Can help avoid a situtation like in [1] where the seL4 header that contains the define was missing which lead the cache maintenance not happening when it should have.

[1]: https://github.com/au-ts/sddf/pull/377