### PR TITLE
libco: fix warnings with __builtin_trap

### DIFF
--- a/libco/aarch64.c
+++ b/libco/aarch64.c
@@ -45,7 +45,7 @@ static void co_entrypoint(cothread_t handle) {
   uintptr_t* buffer = (uintptr_t*)handle;
   void (*entrypoint)(void) = (void (*)(void))buffer[2];
   entrypoint();
-  *(int *)0;  /* Panic if cothread_t entrypoint returns */
+  __builtin_trap();  /* Panic if cothread_t entrypoint returns */
 }
 
 cothread_t co_active() {

--- a/libco/amd64.c
+++ b/libco/amd64.c
@@ -37,7 +37,7 @@ static void co_entrypoint(cothread_t handle) {
   long long* buffer = (long long*)handle;
   void (*entrypoint)(void) = (void (*)(void))buffer[1];
   entrypoint();
-  *(int *)0;  /* Panic if cothread_t entrypoint returns */
+  __builtin_trap();  /* Panic if cothread_t entrypoint returns */
 }
 
 cothread_t co_active() {


### PR DESCRIPTION
Right now libco compiles with these warnings:
```
In file included from /Users/ivanv/ts/sddf/libco/libco.c:15:
/Users/ivanv/ts/sddf/libco/aarch64.c:48:3: warning: indirection of non-volatile null pointer will be deleted, not trap [-Wnull-dereference]
   48 |   *(int *)0;  /* Panic if cothread_t entrypoint returns */
      |   ^~~~~~~~~
/Users/ivanv/ts/sddf/libco/aarch64.c:48:3: note: consider using __builtin_trap() or qualifying pointer with 'volatile'
/Users/ivanv/ts/sddf/libco/aarch64.c:48:3: warning: expression result unused [-Wunused-value]
   48 |   *(int *)0;  /* Panic if cothread_t entrypoint returns */
      |   ^~~~~~~~~
```

This fixes that.