### PR TITLE
blk: use cache_clean_and_invalidate instead of cache_invalidate

### DIFF
--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -159,7 +159,7 @@ static bool handle_mbr_reply()
         return false;
     }
 
-    cache_invalidate(mbr_bk.vaddr, mbr_bk.vaddr + (BLK_TRANSFER_SIZE * mbr_bk.count));
+    cache_clean_and_invalidate(mbr_bk.vaddr, mbr_bk.vaddr + (BLK_TRANSFER_SIZE * mbr_bk.count));
     sddf_memcpy(&msdos_mbr, (void *)mbr_bk.vaddr, sizeof(struct msdos_mbr));
 
     return true;
@@ -214,7 +214,7 @@ static void handle_driver()
         case BLK_REQ_READ:
             if (drv_status == BLK_RESP_OK) {
                 /* Invalidate cache */
-                cache_invalidate(reqbk.vaddr, reqbk.vaddr + (BLK_TRANSFER_SIZE * reqbk.count));
+                cache_clean_and_invalidate(reqbk.vaddr, reqbk.vaddr + (BLK_TRANSFER_SIZE * reqbk.count));
             }
             break;
         case BLK_REQ_WRITE:

--- a/include/sddf/util/cache.h
+++ b/include/sddf/util/cache.h
@@ -33,13 +33,3 @@ void cache_clean_and_invalidate(unsigned long start, unsigned long end);
  * On RISC-V, this is a no-op.
  */
 void cache_clean(unsigned long start, unsigned long end);
-
-/*
- * Invalidates from start to end. This is not inclusive.
- *
- * On ARM, this leads to seL4_ARM_VSpace_Invalidate_Data as it is not possible to invalidate
- * directly from user-space. Note that it may be more efficient to simply do a
- * cache_clean_and_invalidate instead as it will not result in a system call.
- * On RISC-V, this is a no-op.
- */
-void cache_invalidate(unsigned long start, unsigned long end);

--- a/sound/components/virt.c
+++ b/sound/components/virt.c
@@ -227,9 +227,7 @@ int notified_by_driver(void)
         uintptr_t vaddr = data_region_vaddr + pcm.io_or_offset;
 
         // Cache is dirty as device may have written to buffer
-        /* TODO: This is a raw seL4 system call because Microkit does not (currently)
-         * include a corresponding libmicrokit API. */
-        seL4_ARM_VSpace_Invalidate_Data(3, vaddr, vaddr + pcm.len);
+        cache_clean_and_invalidate(vaddr, vaddr + pcm.len);
 
         pcm.io_or_offset = offset;
         if (sound_enqueue_pcm(&client_queues->pcm_res, &pcm) != 0) {

--- a/util/cache.c
+++ b/util/cache.c
@@ -76,15 +76,3 @@ void cache_clean(unsigned long start, unsigned long end)
 #error "Unknown architecture for cache_clean"
 #endif
 }
-
-void cache_invalidate(unsigned long start, unsigned long end)
-{
-#if defined(CONFIG_ARCH_AARCH64)
-    seL4_ARM_VSpace_Invalidate_Data(3, start, end);
-#elif defined(CONFIG_ARCH_RISCV)
-    /* While not all RISC-V platforms are DMA cache-cohernet,
-     * we assume we are targeting one that is and so there is nothing to do. */
-#else
-#error "Unknown architecture for cache_invalidate"
-#endif
-}


### PR DESCRIPTION
While cache_invalidate should be all that is necessary, we cannot only do an invalidate from user-space which means we have to do system calls in order to do the cache maintenance which becomes expensive compared to cache_clean_and_invalidate, even though it has to do a clean.