### PR TITLE
Add missing include to bench header

### DIFF
--- a/include/sddf/benchmark/bench.h
+++ b/include/sddf/benchmark/bench.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 struct bench {
     uint64_t ccount;
     uint64_t prev;


### PR DESCRIPTION
`sddf/benchmark/bench.h` is missing a `#include <stdint.h>`.