### PR TITLE
examples: assert sdfgen version in meta.py scripts

### DIFF
--- a/examples/blk/meta.py
+++ b/examples/blk/meta.py
@@ -4,6 +4,9 @@ import argparse
 from typing import List, Optional
 from dataclasses import dataclass
 from sdfgen import SystemDescription, Sddf, DeviceTree
+from importlib.metadata import version
+
+assert version('sdfgen').split(".")[1] == "23", "Unexpected sdfgen version"
 
 ProtectionDomain = SystemDescription.ProtectionDomain
 

--- a/examples/echo_server/meta.py
+++ b/examples/echo_server/meta.py
@@ -6,6 +6,9 @@ import random
 from dataclasses import dataclass
 from typing import List, Tuple
 from sdfgen import SystemDescription, Sddf, DeviceTree
+from importlib.metadata import version
+
+assert version('sdfgen').split(".")[1] == "23", "Unexpected sdfgen version"
 
 ProtectionDomain = SystemDescription.ProtectionDomain
 MemoryRegion = SystemDescription.MemoryRegion

--- a/examples/i2c/meta.py
+++ b/examples/i2c/meta.py
@@ -4,6 +4,9 @@ import argparse
 from typing import List
 from dataclasses import dataclass
 from sdfgen import SystemDescription, Sddf, DeviceTree
+from importlib.metadata import version
+
+assert version('sdfgen').split(".")[1] == "23", "Unexpected sdfgen version"
 
 ProtectionDomain = SystemDescription.ProtectionDomain
 MemoryRegion = SystemDescription.MemoryRegion

--- a/examples/serial/meta.py
+++ b/examples/serial/meta.py
@@ -4,6 +4,9 @@ import argparse
 from typing import List
 from dataclasses import dataclass
 from sdfgen import SystemDescription, Sddf, DeviceTree
+from importlib.metadata import version
+
+assert version('sdfgen').split(".")[1] == "23", "Unexpected sdfgen version"
 
 ProtectionDomain = SystemDescription.ProtectionDomain
 

--- a/examples/timer/meta.py
+++ b/examples/timer/meta.py
@@ -4,6 +4,9 @@ import argparse
 from typing import List
 from dataclasses import dataclass
 from sdfgen import SystemDescription, Sddf, DeviceTree
+from importlib.metadata import version
+
+assert version('sdfgen').split(".")[1] == "23", "Unexpected sdfgen version"
 
 ProtectionDomain = SystemDescription.ProtectionDomain
 


### PR DESCRIPTION
Until the sDDF parts of sdfgen become part of this repo, it is common for the sdfgen version and what the metaprogram expects to become out of sync. This is especially common now due to us frequently changing both projects as sdfgen is still immature.

This assert means that at least the user knows if they are using the wrong version.

Co-authored-off-by: Courtney Darville <courtneydarville94@outlook.com>