### PR TITLE
examples/serial: one serial for everything for QEMU RISC-V

### DIFF
--- a/examples/serial/README.md
+++ b/examples/serial/README.md
@@ -32,8 +32,6 @@ After building, the system image to load will be `build/loader.img`.
 If you wish to simulate on one of the QEMU platforms (qemu_virt_aarch64 or qemu_virt_riscv64),
 you can append `qemu` to your make command to start QEMU after everything compiles.
 
-Note that for qemu_virt_riscv64, please see [specific instructions for running it](#virtio_console).
-
 ### Zig
 
 You can also build this example with the Zig build system:
@@ -81,33 +79,6 @@ You should see the following output when doing so:
 ```
 VIRT_RX|LOG: switching to client 1
 ```
-
-### Running with virtIO console {#virtio_console}
-
-Currently, the qemu_virt_riscv64 platform uses the virtIO console device provided by
-QEMU for input/output in the example. This means that when you start the example, you
-only see debug output that goes to the default console:
-```sh
-'client0' is client 0
-'client1' is client 1
-```
-
-All the input/output instead happens via a tty device exposed by QEMU. When starting QEMU
-it will say what device virtIO console will be on, e.g:
-```
-char device redirected to /dev/ttys007 (label virtcon)
-```
-
-Instead of giving input to one of the clients via the stdio of QEMU, you will need to use a
-program such as `minicom`, `picocom` or `gtkterm` to interact with the serial device.
-
-For example:
-```sh
-picocom -b 115200 /dev/ttys007
-```
-
-Inputting characters should be visible, but debug output (i.e. from the virtualisers) will still be
-in the terminal where you started QEMU.
 
 ## Configuration
 

--- a/examples/serial/build.zig
+++ b/examples/serial/build.zig
@@ -312,8 +312,10 @@ pub fn build(b: *std.Build) !void {
             "qemu-system-riscv64",
             "-machine",
             "virt",
+            "-mon",
+            "console",
             "-serial",
-            "mon:stdio",
+            "chardev:console",
             "-kernel",
             final_image_dest,
             "-m",
@@ -323,9 +325,9 @@ pub fn build(b: *std.Build) !void {
             "-device",
             "virtio-serial-device",
             "-chardev",
-            "pty,id=virtcon",
+            "stdio,id=console,mux=on,signal=off",
             "-device",
-            "virtconsole,chardev=virtcon",
+            "virtconsole,chardev=console",
             "-nographic",
         });
     }

--- a/examples/serial/serial.mk
+++ b/examples/serial/serial.mk
@@ -46,10 +46,12 @@ else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_aarch64)
 else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_riscv64)
 	QEMU_ARCH_ARGS := -machine virt \
 					  -kernel $(IMAGE_FILE) \
+					  -mon console \
+					  -serial chardev:console \
 					  -global virtio-mmio.force-legacy=false \
 					  -device virtio-serial-device \
-					  -chardev pty,id=virtcon \
-					  -device virtconsole,chardev=virtcon
+					  -chardev stdio,id=console,mux=on,signal=off \
+					  -device virtconsole,chardev=console
 	DRIVER_DIR := virtio
 else ifneq ($(filter $(strip $(MICROKIT_BOARD)),imx8mm_evk imx8mp_evk imx8mq_evk maaxboard),)
 	DRIVER_DIR := imx
@@ -133,10 +135,7 @@ $(IMAGE_FILE) $(REPORT_FILE): $(IMAGES) $(SYSTEM_FILE)
 	MICROKIT_SDK=${MICROKIT_SDK} $(MICROKIT_TOOL) $(SYSTEM_FILE) --search-path $(BUILD_DIR) --board $(MICROKIT_BOARD) --config $(MICROKIT_CONFIG) -o $(IMAGE_FILE) -r $(REPORT_FILE)
 
 qemu: ${IMAGE_FILE}
-	$(QEMU) -serial mon:stdio \
-			-m size=2G \
-			-nographic \
-			$(QEMU_ARCH_ARGS)
+	$(QEMU) -m size=2G -nographic $(QEMU_ARCH_ARGS)
 
 clean::
 	${RM} -f *.elf


### PR DESCRIPTION
Previously we, annoyingly, had to open a separate terminal to read the virtIO console character device!

Thanks to Julia, we no longer have to do this and can instead have on stdio that contains the input/output for both the default (ns16650a) serial and our virtIO console serial driver.