### PR TITLE
docs: add list of available drivers

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -1,0 +1,73 @@
+<!--
+    Copyright 2025, UNSW
+
+    SPDX-License-Identifier: BSD-2-Clause
+-->
+
+# Available drivers
+
+Below is a list of all the avaiable drivers in sDDF, grouped by
+their device class.
+
+Each driver is listed by the device family it is written for
+and a list of Device Tree compatible strings it is known to work with.
+
+## Block
+
+* i.MX8 uSDHC
+    * `fsl,imx8mq-usdhc`
+* virtIO block
+    * `virtio,mmio`
+
+## I<sup>2</sup>C
+
+* Meson
+    * `amlogic,meson-axg-i2c`
+
+## Network
+
+* DWMAC
+    * `nxp,imx8mp-dwmac-eqos`
+    * `snps,dwmac-5.10a`
+    * `snps,dwmac-5.20`
+* i.MX8
+    * `fsl,imx8mq-fec`
+* Meson
+    * `amlogic,meson-gxbb-dwmac`
+    * `amlogic,meson-g12a-dwmac`
+* virtIO network
+    * `virtio,mmio`
+
+## GPU
+
+* virtIO GPU (2D only)
+    * `virtio,mmio`
+
+## Serial
+
+* ARM UART
+    * `arm,pl011`
+* i.MX8 UART
+    * `fsl,imx8mq-uart`
+    * `fsl,imx8mm-uart`
+    * `fsl,imx8mp-uart`
+* NS16550A
+    * `starfive,jh7110-uart`
+    * `ns16550a`
+* virtIO console
+    * `virtio,mmio`
+
+## Timer
+
+* ARM architectural timer
+    * `arm,armv8-timer`
+* Google Goldfish RTC
+    * `google,goldfish-rtc`
+* i.MX8 General Purpose Timer
+    * `fsl,imx8mm-gpt`
+    * `fsl,imx8mq-gpt`
+    * `fsl,imx8mp-gpt`
+* Meson
+    * `amlogic,meson-gxbb-wdt`
+* StarFive JH7110
+    * `starfive,jh7110-timer`


### PR DESCRIPTION
It will be useful for users to know what we actual have available, this doc should help with that.

Before merging:
* [ ] Don't really like just saying 'Meson', maybe we should rename to `amlogic`, same with i.MX8 should probably be `freescale` or `fsl`.