### PR TITLE
drivers:timer:jh7110: prevent potential race

### DIFF
--- a/drivers/timer/jh7110/timer.c
+++ b/drivers/timer/jh7110/timer.c
@@ -84,9 +84,10 @@ static uint64_t get_ticks_in_ns(void)
     uint64_t value_l = (uint64_t)(STARFIVE_TIMER_MAX_TICKS - counter_regs->value);
     uint64_t value_h = (uint64_t)counter_timer_elapses;
 
-    /* Include unhandled interrupt in value_h */
+    /* Account for potential pending counter IRQ */
     if (counter_regs->intclr == 1) {
         value_h += 1;
+        value_l = (uint64_t)(STARFIVE_TIMER_MAX_TICKS - counter_regs->value);
     }
 
     uint64_t value_ticks = (value_h << 32) | value_l;


### PR DESCRIPTION
While writing the zcu102 timer driver (also using 2 32-bit counters) I noticed that we might have a race condition in this driver. The following interleaving would have resulted in a wrong time reading, when processing timeouts off by up to 2^32-1 ticks in the future (potentially triggering multiple timeouts falsely):

1. IRQ for TIMEOUT counter
2. enter `get_ticks_in_ns()`
4. store `value_l` as value from the other counter (not the TIMEOUT one) register
3. store`value_h` as read from `counter_timer_elapses` global
5. **!! IRQ of OVERFLOW  for the counter !! (pending, not handled)**
6. check if IRQ pending for OVERFLOW counter
	1. yes -> increment `value_h` . But `value_l` read before overflow!
7. now new `value_h` and old `value_l` give a value in the future, off by up to $2^{32}-1$ ticks!

After the fix, the same scenario does not have an issue:

1. IRQ for TIMEOUT counter
2. enter `get_ticks_in_ns()`
4. store `value_l` as value from the other counter (not the TIMEOUT one) register
3. store`value_h` as read from `counter_timer_elapses` global
5. **!! IRQ of OVERFLOW  for the counter !! (pending, not handled)**
6. check if IRQ pending for OVERFLOW counter
	1. yes -> increment `value_h`. **UPDATE `value_l` with most recent reading from the overflowed counter.
7. now new `value_h` and new `value_l` give a correct value for time

I have not yet checked other timer drivers, but pretty sure they all use 64-bit counters so we should be fine.