### PR TITLE
Fix uart bug causing rx queues to be serviced when rx is disabled

### DIFF
--- a/drivers/serial/arm/uart.c
+++ b/drivers/serial/arm/uart.c
@@ -95,7 +95,7 @@ static void handle_irq(void)
 {
     uint32_t uart_int_reg = uart_regs->mis;
     while (uart_int_reg & (PL011_IMSC_RX_TIMEOUT | PL011_IMSC_RX_INT) || uart_int_reg & PL011_IMSC_TX_INT) {
-        if (uart_int_reg & (PL011_IMSC_RX_TIMEOUT | PL011_IMSC_RX_INT)) {
+        if (config.rx_enabled && uart_int_reg & (PL011_IMSC_RX_TIMEOUT | PL011_IMSC_RX_INT)) {
             rx_return();
         }
         if (uart_int_reg & PL011_IMSC_TX_INT) {

--- a/drivers/serial/imx/uart.c
+++ b/drivers/serial/imx/uart.c
@@ -98,7 +98,7 @@ static void handle_irq(void)
     uint32_t uart_cr1 = uart_regs->cr1;
     while (uart_sr1 & UART_SR1_ABNORMAL || uart_sr1 & UART_SR1_RX_RDY
            || (uart_cr1 & UART_CR1_TX_READY_INT && uart_sr1 & UART_SR1_TX_RDY)) {
-        if (uart_sr1 & UART_SR1_RX_RDY) {
+        if (config.rx_enabled && uart_sr1 & UART_SR1_RX_RDY) {
             rx_return();
         }
         if (uart_cr1 & UART_CR1_TX_READY_INT && uart_sr1 & UART_SR1_TX_RDY) {

--- a/drivers/serial/meson/uart.c
+++ b/drivers/serial/meson/uart.c
@@ -129,7 +129,7 @@ static void handle_irq(void)
     uint32_t uart_cr = uart_regs->cr;
     while (uart_sr & UART_INTR_ABNORMAL || !(uart_sr & AML_UART_RX_EMPTY)
            || (uart_cr & AML_UART_TX_INT_EN && !(uart_sr & AML_UART_TX_FULL))) {
-        if (!(uart_sr & AML_UART_RX_EMPTY)) {
+        if (config.rx_enabled && !(uart_sr & AML_UART_RX_EMPTY)) {
             rx_return();
         }
         if (uart_cr & AML_UART_TX_INT_EN && !(uart_sr & AML_UART_TX_FULL)) {

--- a/drivers/serial/ns16550a/uart.c
+++ b/drivers/serial/ns16550a/uart.c
@@ -117,7 +117,7 @@ static void handle_irq(void)
 {
     uint32_t irq_status = *REG_PTR(UART_IIR);
     uint32_t line_status = *REG_PTR(UART_LSR);
-    if (irq_status & UART_IIR_RX) {
+    if (config.rx_enabled && irq_status & UART_IIR_RX) {
         rx_return();
     }
 

--- a/drivers/serial/virtio/console.c
+++ b/drivers/serial/virtio/console.c
@@ -331,7 +331,9 @@ void console_setup()
     assert((uintptr_t)tx_virtq.used % 4 == 0);
 
     /* Load the Rx queue with free buffers */
-    rx_provide();
+    if (config.rx_enabled) {
+        rx_provide();
+    }
 
     // Setup RX queue first
     assert(uart_regs->QueueNumMax >= RX_COUNT);
@@ -368,8 +370,10 @@ static void handle_irq()
     if (irq_status & VIRTIO_MMIO_IRQ_VQUEUE) {
         // We don't know whether the IRQ is related to a change to the RX queue
         // or TX queue, so we check both.
-        rx_return();
-        rx_provide(); // Refill the virtio Rx queue
+        if (config.rx_enabled) {
+            rx_return();
+            rx_provide(); // Refill the virtio Rx queue
+        }
         tx_return();
         tx_provide();
         // We have handled the used buffer notification


### PR DESCRIPTION
Due to a technicality with our testing set up, it was not noticed that it is possible for uart drivers to access none initialised rx data structures if the UART rx FIFO is not empty. This PR stops this from happening.