### PR TITLE
Fix ethernet dwmac bug introduced by removing descriptor array

### DIFF
--- a/drivers/network/dwmac-5.10a/ethernet.h
+++ b/drivers/network/dwmac-5.10a/ethernet.h
@@ -10,7 +10,6 @@
 
 /* Helper macros */
 
-#define BIT(x) (1U << x)
 #define MAC_REG(x) ((volatile uint32_t *)(eth_regs + x))
 #define MTL_REG(x) ((volatile uint32_t *)(eth_regs + x))
 #define DMA_REG(x) ((volatile uint32_t *)(eth_regs + x))


### PR DESCRIPTION
After further testing, I discovered that the `dwmac` device alters the values for buffer addresses stored in the hardware during processing, so it is not possible to rely on these values after packets have been processed. Therefore this driver requires a secondary data structure to keep track of these values.

Originally all drivers had this data structure, but it was removed recently when we realised we could read buffer addresses from the hardware ring.