### PR TITLE
drivers:timer:cdns zcu102 timer driver using cadence TTC device

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -32,6 +32,7 @@ Files:
     drivers/timer/jh7110/config.json
     drivers/timer/meson/config.json
     drivers/timer/goldfish/config.json
+    drivers/timer/cdns/config.json
 Copyright: UNSW
 License: BSD-2-Clause
 

--- a/build.zig
+++ b/build.zig
@@ -17,6 +17,7 @@ const DriverClass = struct {
 
     const Timer = enum {
         arm,
+        cdns,
         meson,
         imx,
         jh7110,

--- a/ci/matrix.py
+++ b/ci/matrix.py
@@ -104,6 +104,7 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
             "qemu_virt_aarch64",
             "qemu_virt_riscv64",
             "star64",
+            "zcu102",
         ],
         "boards_test": [
             "imx8mq_evk",
@@ -114,6 +115,7 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
             "qemu_virt_aarch64",
             "qemu_virt_riscv64",
             "star64",
+            "zcu102",
         ],
     },
 }

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -73,3 +73,5 @@ and a list of Device Tree compatible strings it is known to work with.
     * `amlogic,meson-gxbb-wdt`
 * StarFive JH7110
     * `starfive,jh7110-timer`
+* Cadence
+    * `cdns,ttc`

--- a/drivers/timer/cdns/config.json
+++ b/drivers/timer/cdns/config.json
@@ -1,0 +1,22 @@
+{
+    "compatible": [
+        "cdns,ttc"
+    ],
+    "resources": {
+        "regions": [
+            {
+                "name": "regs",
+                "dt_index": 0
+            }
+        ],
+        "irqs": [
+            {
+                "dt_index": 0
+            },
+            {
+                "dt_index": 1
+            }
+
+        ]
+    }
+}

--- a/drivers/timer/cdns/timer.c
+++ b/drivers/timer/cdns/timer.c
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2024, UNSW
+ * Copyright 2025, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <microkit.h>
+#include <sddf/timer/protocol.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <sddf/resources/device.h>
+
+__attribute__((__section__(".device_resources"))) device_resources_t device_resources;
+
+/*
+ * Zynq UltraScale+ MPSoC contains a timer (Cadence Triple Timer Clock) with 3 32-bit counters.
+ * Only 2 of the 3 timers are used in this driver. All 3 timers by default are connected to
+ * the LSBUS clock in the Low Power Domain, (controlled by LPD_LSBUS_CTRL).
+ */
+
+#define CDNS_TIMER_MAX_PRESCALE 0xf
+/* prescale: rate = clk_src/[2^(N+1)] */
+#define CDNS_TIMER_PRESCALE_VALUE 0x1
+#if defined(CONFIG_PLAT_ZYNQMP)
+/*
+ * By default, the LSBUS clock is using IOPLL clock as source, and divides down by 15 to 100MHz.
+ * See: https://docs.amd.com/r/en-US/ug1087-zynq-ultrascale-registers/LPD_LSBUS_CTRL-CRL_APB-Register.
+ * You can read the IOPLL clk value in u-boot using `clk dump` and view the source and divider value for
+ * LSBUS by reading LPD_LSBUS_CTRL register.
+*/
+#define CDNS_TIMER_REF_CLOCK_RATE (100UL * 1000UL * 1000UL)
+#else
+#error "unknown LSBUS clock frequency (timer device reference clock)"
+#endif
+/* default source clock, scaled down by a factor of 2^(CDNS_TIMER_PRESCALE_VALUE+1) if enabled prescale */
+#define CDNS_TIMER_TICKS_PER_SECOND (CDNS_TIMER_REF_CLOCK_RATE >> ((CDNS_TIMER_PRESCALE_VALUE & CDNS_TIMER_MAX_PRESCALE) + 1))
+
+#define TTC_COUNTER_TIMER 0
+#define TTC_TIMEOUT_TIMER 1
+
+#define TTC_NUM_TIMERS 3
+
+#define CDNS_TIMER_MAX_TICKS UINT32_MAX
+#define CDNS_TIMER_CTL_RESET 0x21
+#define CDNS_TIMER_DISABLE 0x1
+#define CDNS_TIMER_CNT_RESET BIT(4)
+/* Clock control values */
+#define CDNS_TIMER_ENABLE_PRESCALE BIT(0)
+/* Counter control values */
+#define CDNS_TIMER_ENABLE_INTERVAL_MODE BIT(1)
+#define CDNS_TIMER_ENABLE_DECREMENT_MODE BIT(2)
+#define CDNS_TIMER_ENABLE_MATCH_MODE BIT(3)
+/* interrupt enable values */
+#define CDNS_TIMER_ENABLE_INTERVAL_INTERRUPT BIT(0)
+#define CDNS_TIMER_ENABLE_MATCH1_INTERRUPT BIT(1)
+#define CDNS_TIMER_ENABLE_MATCH2_INTERRUPT BIT(2)
+#define CDNS_TIMER_ENABLE_MATCH3_INTERRUPT BIT(3)
+#define CDNS_TIMER_ENABLE_OVERFLOW_INTERRUPT BIT(4)
+#define CDNS_TIMER_ENABLE_EVNT_OVERFLOW_INTERRUPT BIT(5)
+
+typedef struct {
+    /* Registers (for each of the 3 counters in the Triple Timer Clock)
+     * NOTE: 0th timer is used as a general time counter, 1st timer is used as a timeout timer.
+     * Last timer is unused. */
+    uint32_t clk_ctrl[TTC_NUM_TIMERS];     /* 0x00: clock control registers */
+    uint32_t cnt_ctrl[TTC_NUM_TIMERS];     /* 0x0C: counter control registers: Operational mode and reset */
+    uint32_t cnt_val[TTC_NUM_TIMERS];      /* 0x18: current counter values */
+    uint32_t interval_val[TTC_NUM_TIMERS]; /* 0x24: interval value (from which/to which the counter counts) */
+    uint32_t match_1[TTC_NUM_TIMERS];      /* 0x30: 1st match values */
+    uint32_t match_2[TTC_NUM_TIMERS];      /* 0x3C: 2nd match values */
+    uint32_t match_3[TTC_NUM_TIMERS];      /* 0x48: 3rd match values */
+    uint32_t int_sts[TTC_NUM_TIMERS];      /* 0x54: status for interval, match, overflow and event interrupts */
+    uint32_t int_en[TTC_NUM_TIMERS];       /* 0x60: enable interrupts */
+    uint32_t event_ctrl[TTC_NUM_TIMERS];   /* 0x6C: (not used) enable event timer, stop timer */
+    uint32_t event[TTC_NUM_TIMERS];        /* 0x78: (not used) width of external pulse */
+} cdns_timer_regs_t;
+
+/* Keeps track of how many counter timer overflows happens,
+ * as the counter is 32-bit. This is used as high bits of
+ * a 64-bit counter.
+ */
+uint32_t counter_timer_elapses = 0;
+volatile cdns_timer_regs_t *timer_regs;
+microkit_channel counter_irq;
+microkit_channel timeout_irq;
+
+/* offset for the 2 interrupt channels */
+#define CLIENT_CH_START 2
+#define MAX_TIMEOUTS 6
+static uint64_t timeouts[MAX_TIMEOUTS];
+
+static inline uint64_t get_ticks_in_ns(void)
+{
+    uint64_t value_h = (uint64_t)counter_timer_elapses;
+    uint64_t value_l = (uint64_t)timer_regs->cnt_val[TTC_COUNTER_TIMER];
+
+    /* Include unhandled interrupt in value_h */
+    if (timer_regs->int_sts[TTC_COUNTER_TIMER] & CDNS_TIMER_ENABLE_OVERFLOW_INTERRUPT) {
+        value_h++;
+        value_l = (uint64_t)timer_regs->cnt_val[TTC_COUNTER_TIMER];
+        /*
+         * XXX: Weird behaviour: If overflow IRQ happens here (while handling TIMEOUT IRQ), and the IRQ status register for
+         * TTC_COUNTER_TIMER (the overflow one) gets read (cleared), sometimes the IRQ for overflow
+         * gets delivered (notified() called), but sometimes not. Current solution is to increment the global counter_timer_elapses
+         * in this function, and if during handling overflow IRQ the IRQ status register is cleared, do not increment.
+         */
+        counter_timer_elapses++;
+    }
+    uint64_t value_ticks = (value_h << 32) | value_l;
+
+    /* convert from ticks to nanoseconds */
+    uint64_t value_whole_seconds = value_ticks / CDNS_TIMER_TICKS_PER_SECOND;
+    uint64_t value_subsecond_ticks = value_ticks % CDNS_TIMER_TICKS_PER_SECOND;
+    uint64_t value_subsecond_ns = (value_subsecond_ticks * NS_IN_S) / CDNS_TIMER_TICKS_PER_SECOND;
+    uint64_t value_ns = value_whole_seconds * NS_IN_S + value_subsecond_ns;
+
+    return value_ns;
+}
+
+void set_timeout(uint64_t ns)
+{
+    /* stop the timeout timer */
+    timer_regs->cnt_ctrl[TTC_TIMEOUT_TIMER] |= CDNS_TIMER_DISABLE;
+    uint64_t ticks_whole_seconds = (ns / NS_IN_S) * CDNS_TIMER_TICKS_PER_SECOND;
+    uint64_t ticks_remainder = (ns % NS_IN_S) * CDNS_TIMER_TICKS_PER_SECOND / NS_IN_S;
+    uint64_t num_ticks = ticks_whole_seconds + ticks_remainder;
+
+    if (num_ticks > CDNS_TIMER_MAX_TICKS) {
+        /* truncate num_ticks to maximum timeout, will use multiple interrupts to process the requested timeout. */
+        num_ticks = CDNS_TIMER_MAX_TICKS;
+    }
+    timer_regs->interval_val[TTC_TIMEOUT_TIMER] = (uint32_t)num_ticks;
+    timer_regs->cnt_ctrl[TTC_TIMEOUT_TIMER] |= CDNS_TIMER_CNT_RESET;
+    timer_regs->cnt_ctrl[TTC_TIMEOUT_TIMER] ^= CDNS_TIMER_DISABLE;
+}
+
+static void process_timeouts(uint64_t curr_time)
+{
+    for (int i = 0; i < MAX_TIMEOUTS; i++) {
+        if (timeouts[i] <= curr_time) {
+            microkit_notify(CLIENT_CH_START + i);
+            timeouts[i] = UINT64_MAX;
+        }
+    }
+
+    uint64_t next_timeout = UINT64_MAX;
+    for (int i = 0; i < MAX_TIMEOUTS; i++) {
+        if (timeouts[i] < next_timeout) {
+            next_timeout = timeouts[i];
+        }
+    }
+
+    if (next_timeout != UINT64_MAX) {
+        uint64_t ns = next_timeout - curr_time;
+        set_timeout(ns);
+    }
+}
+
+void init()
+{
+    assert(device_resources_check_magic(&device_resources));
+    assert(device_resources.num_irqs == 2);
+    assert(device_resources.num_regions == 1);
+
+    for (int i = 0; i < MAX_TIMEOUTS; i++) {
+        timeouts[i] = UINT64_MAX;
+    }
+
+    timer_regs = (cdns_timer_regs_t *)device_resources.regions[0].region.vaddr;
+    counter_irq = device_resources.irqs[TTC_COUNTER_TIMER].id;
+    timeout_irq = device_resources.irqs[TTC_TIMEOUT_TIMER].id;
+
+    /* Table 14-9 */
+    /* stop timers */
+    timer_regs->cnt_ctrl[TTC_COUNTER_TIMER] |= CDNS_TIMER_DISABLE;
+    timer_regs->cnt_ctrl[TTC_TIMEOUT_TIMER] |= CDNS_TIMER_DISABLE;
+    /* Reset counter control registers */
+    timer_regs->cnt_ctrl[TTC_COUNTER_TIMER] = CDNS_TIMER_CTL_RESET;
+    timer_regs->clk_ctrl[TTC_COUNTER_TIMER] = 0x0;
+    timer_regs->interval_val[TTC_COUNTER_TIMER] = 0x0;
+    timer_regs->match_1[TTC_COUNTER_TIMER] = 0x0;
+    timer_regs->match_2[TTC_COUNTER_TIMER] = 0x0;
+    timer_regs->match_3[TTC_COUNTER_TIMER] = 0x0;
+    timer_regs->int_en[TTC_COUNTER_TIMER] = 0x0;
+    timer_regs->int_sts[TTC_COUNTER_TIMER] = 0x0;
+
+    timer_regs->cnt_ctrl[TTC_TIMEOUT_TIMER] = CDNS_TIMER_CTL_RESET;
+    timer_regs->clk_ctrl[TTC_TIMEOUT_TIMER] = 0x0;
+    timer_regs->interval_val[TTC_TIMEOUT_TIMER] = 0x0;
+    timer_regs->match_1[TTC_TIMEOUT_TIMER] = 0x0;
+    timer_regs->match_2[TTC_TIMEOUT_TIMER] = 0x0;
+    timer_regs->match_3[TTC_TIMEOUT_TIMER] = 0x0;
+    timer_regs->int_en[TTC_TIMEOUT_TIMER] = 0x0;
+    timer_regs->int_sts[TTC_TIMEOUT_TIMER] = 0x0;
+    /* Reset counters */
+    timer_regs->cnt_ctrl[TTC_COUNTER_TIMER] |= CDNS_TIMER_CNT_RESET;
+    timer_regs->cnt_ctrl[TTC_TIMEOUT_TIMER] |= CDNS_TIMER_CNT_RESET;
+
+    /* Setup 0th timer as overflow timer */
+    timer_regs->int_en[TTC_COUNTER_TIMER] = CDNS_TIMER_ENABLE_OVERFLOW_INTERRUPT;
+
+    /* Setup 1st timer as timeout timer, using interval mode */
+    timer_regs->int_en[TTC_TIMEOUT_TIMER] = CDNS_TIMER_ENABLE_INTERVAL_INTERRUPT;
+    timer_regs->cnt_ctrl[TTC_TIMEOUT_TIMER] |= CDNS_TIMER_ENABLE_INTERVAL_MODE;
+
+    /* Set up prescaler, divide down from 100MHz to CDNS_TIMER_TICKS_PER_SECOND */
+    timer_regs->clk_ctrl[TTC_COUNTER_TIMER] = ((CDNS_TIMER_PRESCALE_VALUE & CDNS_TIMER_MAX_PRESCALE) << 1)
+                                            | CDNS_TIMER_ENABLE_PRESCALE;
+    timer_regs->clk_ctrl[TTC_TIMEOUT_TIMER] = ((CDNS_TIMER_PRESCALE_VALUE & CDNS_TIMER_MAX_PRESCALE) << 1)
+                                            | CDNS_TIMER_ENABLE_PRESCALE;
+
+    /* Start the TTC_COUNTER_TIMER */
+    timer_regs->cnt_ctrl[TTC_COUNTER_TIMER] ^= CDNS_TIMER_DISABLE;
+}
+
+void notified(microkit_channel ch)
+{
+    assert(ch == counter_irq || ch == timeout_irq);
+    if (ch == counter_irq) {
+        /* Overflow on timekeeping counter, interrupt cleared on read by device */
+        if (timer_regs->int_sts[TTC_COUNTER_TIMER] & CDNS_TIMER_ENABLE_OVERFLOW_INTERRUPT) {
+            ++counter_timer_elapses;
+        } else {
+            /*
+             * race condition: get_ticks_in_ns() was called from timeout_irq handling, and overflow timer
+             * issued irq during handling, counter_timer_elapses already incremented
+             */
+        }
+    } else if (ch == timeout_irq) {
+        /* Timeout counter reached 0, stop the timeout timer */
+        timer_regs->cnt_ctrl[TTC_TIMEOUT_TIMER] |= CDNS_TIMER_DISABLE;
+        uint64_t curr_time = get_ticks_in_ns();
+        process_timeouts(curr_time);
+        /* interrupt cleared on read by device */
+        uint32_t int_sts = timer_regs->int_sts[TTC_TIMEOUT_TIMER];
+        assert(int_sts == CDNS_TIMER_ENABLE_INTERVAL_INTERRUPT);
+    } else {
+        sddf_dprintf("TIMER DRIVER|LOG: unexpected notification from channel %u\n", ch);
+        return;
+    }
+    microkit_deferred_irq_ack(ch);
+}
+
+seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
+{
+    switch (microkit_msginfo_get_label(msginfo)) {
+    case SDDF_TIMER_GET_TIME: {
+        uint64_t time_ns = get_ticks_in_ns();
+        seL4_SetMR(0, time_ns);
+        return microkit_msginfo_new(0, 1);
+    }
+    case SDDF_TIMER_SET_TIMEOUT: {
+        uint64_t curr_time = get_ticks_in_ns();
+        uint64_t offset_us = (uint64_t)(seL4_GetMR(0));
+        timeouts[ch - CLIENT_CH_START] = curr_time + offset_us;
+        process_timeouts(curr_time);
+        break;
+    }
+    default:
+        sddf_dprintf("TIMER DRIVER|LOG: Unknown request %lu to timer from channel %u\n",
+                     microkit_msginfo_get_label(msginfo), ch);
+        break;
+    }
+
+    return microkit_msginfo_new(0, 0);
+}

--- a/drivers/timer/cdns/timer_driver.mk
+++ b/drivers/timer/cdns/timer_driver.mk
@@ -1,0 +1,27 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Include this snippet in your project Makefile to build
+# the Candence timer driver
+#
+# NOTES:
+#  Generates timer_driver.elf
+#  Expects libsddf_util_debug.a to be in ${LIBS}
+
+TIMER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+timer_driver.elf: timer/timer.o
+	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
+
+timer/timer.o: ${TIMER_DIR}/timer.c ${CHECK_FLAGS_BOARD_MD5} |timer
+	${CC} ${CFLAGS} -o $@ -c $<
+
+timer:
+	mkdir -p timer
+
+clean::
+	rm -rf timer
+clobber::
+	rm -f timer_driver.elf

--- a/drivers/timer/jh7110/timer.c
+++ b/drivers/timer/jh7110/timer.c
@@ -127,9 +127,9 @@ static void process_timeouts(uint64_t curr_time)
         uint64_t ticks_remainder = (ns % NS_IN_S) * STARFIVE_TIMER_TICKS_PER_SECOND / NS_IN_S;
         uint64_t num_ticks = ticks_whole_seconds + ticks_remainder;
 
-        assert(num_ticks <= STARFIVE_TIMER_MAX_TICKS);
         if (num_ticks > STARFIVE_TIMER_MAX_TICKS) {
-            sddf_dprintf("ERROR: num_ticks: 0x%lx\n", num_ticks);
+            /* truncate num_ticks to maximum timeout, will use multiple interrupts to process the requested timeout. */
+            num_ticks = STARFIVE_TIMER_MAX_TICKS;
         }
 
         timeout_regs->load = num_ticks;

--- a/examples/timer/README.md
+++ b/examples/timer/README.md
@@ -21,6 +21,7 @@ The following platforms are supported:
 * qemu_virt_aarch64
 * qemu_virt_riscv64
 * star64
+* zcu102
 
 ### Make
 

--- a/examples/timer/build.zig
+++ b/examples/timer/build.zig
@@ -16,6 +16,7 @@ const MicrokitBoard = enum {
     imx8mm_evk,
     imx8mp_evk,
     imx8mq_evk,
+    zcu102,
 };
 
 const Target = struct {
@@ -122,6 +123,16 @@ const targets = [_]Target{
             .abi = .none,
         },
     },
+    .{
+        .board = MicrokitBoard.zcu102,
+        .zig_target = std.Target.Query{
+            .cpu_arch = .aarch64,
+            .cpu_model = .{ .explicit = &std.Target.aarch64.cpu.cortex_a53 },
+            .cpu_features_add = std.Target.aarch64.featureSet(&[_]std.Target.aarch64.Feature{.strict_align}),
+            .os_tag = .freestanding,
+            .abi = .none,
+        },
+    },
 };
 
 fn findTarget(board: MicrokitBoard) std.Target.Query {
@@ -192,6 +203,7 @@ pub fn build(b: *std.Build) !void {
         .odroidc2, .odroidc4 => "meson",
         .star64 => "jh7110",
         .maaxboard, .imx8mm_evk, .imx8mp_evk, .imx8mq_evk => "imx",
+        .zcu102 => "cdns",
     };
 
     const driver = sddf_dep.artifact(b.fmt("driver_timer_{s}.elf", .{driver_class}));

--- a/examples/timer/meta.py
+++ b/examples/timer/meta.py
@@ -74,6 +74,12 @@ BOARDS: List[Board] = [
         paddr_top=0xA0000000,
         timer="soc@0/bus@30000000/timer@302d0000",
     ),
+    Board(
+        name="zcu102",
+        arch=SystemDescription.Arch.AARCH64,
+        paddr_top=0xA0000000,
+        timer="axi/timer@ff140000",
+    ),
 ]
 
 

--- a/examples/timer/timer.mk
+++ b/examples/timer/timer.mk
@@ -60,6 +60,9 @@ else ifeq ($(strip $(MICROKIT_BOARD)), star64)
 else ifneq ($(filter $(strip $(MICROKIT_BOARD)),imx8mm_evk imx8mp_evk imx8mq_evk maaxboard),)
 	TIMER_DRIVER_DIR := imx
 	CPU := cortex-a53
+else ifeq ($(strip $(MICROKIT_BOARD)), zcu102)
+	TIMER_DRIVER_DIR := cdns
+	CPU := cortex-a53
 else
 $(error Unsupported MICROKIT_BOARD given)
 endif


### PR DESCRIPTION
Adds the cadence Triple Timer Counter (TTC) based timer driver for zcu102 board.

Also: fixes star64's jh7110 to support timeouts requiring more than UINT32_MAX counter ticks.


Caveats:
- Fixed - now does multiple timeouts (up to UINT64_MAX ticks).~max timeout allowed: ~2min 51.799s (can be extended sacrificing resolution, atm uses 25MHz clock)~
- Clock source not touched, by default uses LSBUS clock, which is downscaled from IOPLL clock (which in turn is upscaled from main source clock) - will need to be changed when clock driver introduced/any clock modifications will be done.

Draft because of the following:
- [x] TODO: update the drivers.md doc: https://github.com/au-ts/sddf/blob/main/docs/drivers.md
- [ ] race condition on delivering overflow IRQ when happened during timeout IRQ (see comments) (Separate to #403)
- [x] TODO: rename `ZCU102_` defines to begin with `ZYNQMP_` (SoC specific rather than dev board specific)
- [x] Done, for now assumes the IOPLL clock is untouched after boot and set to 1.5GHz, and used as source downscaled by factor of 15 for the TTC counters ~~need to ensure Clock used for the counter is always set to 100MHz/use a different one~~
- [x] Done, downscaled freq to 25MHz (now max timeout is larger and overflowing happens every ~2min 52s) ~~add clock frequency downscaling (for lower resolution but rarer interrupts for 32-bit timer overflow, currently every ~42s)~~
- [x] Done ~~clean up serial driver skeleton code~~