### PR TITLE
Handle tx IRQs before rx IRQs in ethernet drivers

### DIFF
--- a/drivers/network/dwmac-5.10a/ethernet.c
+++ b/drivers/network/dwmac-5.10a/ethernet.c
@@ -215,12 +215,12 @@ static void handle_irq()
     *DMA_REG(DMA_CH0_STATUS) &= e;
 
     while (e & DMA_INTR_MASK) {
-        if (e & DMA_CH0_INTERRUPT_EN_RIE) {
-            rx_return();
-        }
         if (e & DMA_CH0_INTERRUPT_EN_TIE) {
             tx_return();
             tx_provide();
+        }
+        if (e & DMA_CH0_INTERRUPT_EN_RIE) {
+            rx_return();
         }
         if (e & DMA_INTR_ABNORMAL) {
             if (e & DMA_CH0_INTERRUPT_EN_FBEE) {

--- a/drivers/network/meson/ethernet.c
+++ b/drivers/network/meson/ethernet.c
@@ -207,12 +207,12 @@ static void handle_irq()
     eth_dma->status &= e;
 
     while (e & DMA_INTR_MASK) {
-        if (e & DMA_INTR_RXF) {
-            rx_return();
-        }
         if (e & DMA_INTR_TXF) {
             tx_return();
             tx_provide();
+        }
+        if (e & DMA_INTR_RXF) {
+            rx_return();
         }
         if (e & DMA_INTR_ABNORMAL) {
             if (e & DMA_INTR_FBE) {

--- a/drivers/network/virtio/ethernet.c
+++ b/drivers/network/virtio/ethernet.c
@@ -293,9 +293,9 @@ static void handle_irq()
     if (irq_status & VIRTIO_MMIO_IRQ_VQUEUE) {
         // We don't know whether the IRQ is related to a change to the RX queue
         // or TX queue, so we check both.
-        rx_return();
         tx_return();
         tx_provide();
+        rx_return();
         // We have handled the used buffer notification
         regs->InterruptACK = VIRTIO_MMIO_IRQ_VQUEUE;
     }


### PR DESCRIPTION
Handling transmit interrupts should be prioritised over receive interrupts to reduce RTT amongst other reasons. 