### PR TITLE
Remove export override directives

### DIFF
--- a/examples/blk/Makefile
+++ b/examples/blk/Makefile
@@ -12,7 +12,8 @@ ifeq ($(strip $(MICROKIT_BOARD)),)
 $(error MICROKIT_BOARD must be specified)
 endif
 BUILD_DIR ?= build
-export BUILD_DIR := $(abspath ${BUILD_DIR})
+override BUILD_DIR := $(abspath ${BUILD_DIR})
+export BUILD_DIR
 export SDDF := $(abspath ../..)
 override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 

--- a/examples/blk/Makefile
+++ b/examples/blk/Makefile
@@ -13,7 +13,7 @@ $(error MICROKIT_BOARD must be specified)
 endif
 BUILD_DIR ?= build
 export BUILD_DIR := $(abspath ${BUILD_DIR})
-export SDDF = $(abspath ../..)
+export SDDF := $(abspath ../..)
 override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 
 IMAGE_FILE := ${BUILD_DIR}/loader.img

--- a/examples/blk/Makefile
+++ b/examples/blk/Makefile
@@ -11,14 +11,13 @@ endif
 ifeq ($(strip $(MICROKIT_BOARD)),)
 $(error MICROKIT_BOARD must be specified)
 endif
-export MICROKIT_BOARD
 BUILD_DIR ?= build
-export SDDF=$(abspath ../..)
-export BUILD_DIR:=$(abspath ${BUILD_DIR})
-export override MICROKIT_SDK:=$(abspath ${MICROKIT_SDK})
+export BUILD_DIR := $(abspath ${BUILD_DIR})
+export SDDF = $(abspath ../..)
+override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 
-IMAGE_FILE:= ${BUILD_DIR}/loader.img
-REPORT_FILE:= ${BUILD_DIR}/report.txt
+IMAGE_FILE := ${BUILD_DIR}/loader.img
+REPORT_FILE := ${BUILD_DIR}/report.txt
 
 all: ${IMAGE_FILE}
 

--- a/examples/blk/blk.mk
+++ b/examples/blk/blk.mk
@@ -101,7 +101,7 @@ DTS := $(SDDF)/dts/$(MICROKIT_BOARD).dts
 DTB := $(MICROKIT_BOARD).dtb
 METAPROGRAM := $(TOP)/meta.py
 
-BLK_DRIVER := ${SDDF}/drivers/blk/${BLK_DRIVER_DIR}
+BLK_DRIVER := $(SDDF)/drivers/blk/${BLK_DRIVER_DIR}
 SERIAL_DRIVER := $(SDDF)/drivers/serial/${SERIAL_DRIVER_DIR}
 
 all: $(IMAGE_FILE)

--- a/examples/echo_server/Makefile
+++ b/examples/echo_server/Makefile
@@ -12,7 +12,8 @@ ifeq ($(strip $(MICROKIT_BOARD)),)
 $(error MICROKIT_BOARD must be specified)
 endif
 BUILD_DIR ?= build
-export BUILD_DIR := $(abspath ${BUILD_DIR})
+override BUILD_DIR := $(abspath ${BUILD_DIR})
+export BUILD_DIR
 export SDDF := $(abspath ../..)
 override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 

--- a/examples/echo_server/Makefile
+++ b/examples/echo_server/Makefile
@@ -13,7 +13,7 @@ $(error MICROKIT_BOARD must be specified)
 endif
 BUILD_DIR ?= build
 export BUILD_DIR := $(abspath ${BUILD_DIR})
-export SDDF = $(abspath ../..)
+export SDDF := $(abspath ../..)
 override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 
 IMAGE_FILE := $(BUILD_DIR)/loader.img

--- a/examples/echo_server/Makefile
+++ b/examples/echo_server/Makefile
@@ -11,16 +11,15 @@ endif
 ifeq ($(strip $(MICROKIT_BOARD)),)
 $(error MICROKIT_BOARD must be specified)
 endif
-export MICROKIT_BOARD
 BUILD_DIR ?= build
-export SDDF=$(abspath ../..)
-export BUILD_DIR:=$(abspath ${BUILD_DIR})
-export override MICROKIT_SDK:=$(abspath ${MICROKIT_SDK})
+export BUILD_DIR := $(abspath ${BUILD_DIR})
+export SDDF = $(abspath ../..)
+override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 
 IMAGE_FILE := $(BUILD_DIR)/loader.img
 REPORT_FILE := $(BUILD_DIR)/report.txt
 
-export ECHO_INCLUDE:=$(abspath .)/include
+export ECHO_INCLUDE := $(abspath .)/include
 
 all: ${IMAGE_FILE}
 

--- a/examples/echo_server/echo.mk
+++ b/examples/echo_server/echo.mk
@@ -53,39 +53,39 @@ PYTHON ?= python3
 MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
 
 ifeq ($(strip $(MICROKIT_BOARD)), odroidc4)
-	export DRIV_DIR := meson
-	export SERIAL_DRIV_DIR := meson
-	export TIMER_DRV_DIR := meson
-	export CPU := cortex-a55
+	DRIV_DIR := meson
+	SERIAL_DRIV_DIR := meson
+	TIMER_DRV_DIR := meson
+	CPU := cortex-a55
 else ifeq ($(strip $(MICROKIT_BOARD)), odroidc2)
-	export DRIV_DIR := meson
-	export SERIAL_DRIV_DIR := meson
-	export TIMER_DRV_DIR := meson
-	export CPU := cortex-a53
+	DRIV_DIR := meson
+	SERIAL_DRIV_DIR := meson
+	TIMER_DRV_DIR := meson
+	CPU := cortex-a53
 else ifneq ($(filter $(strip $(MICROKIT_BOARD)),imx8mm_evk imx8mp_evk imx8mq_evk maaxboard),)
-	export DRIV_DIR := imx
-	export SERIAL_DRIV_DIR := imx
-	export TIMER_DRV_DIR := imx
-	export CPU := cortex-a53
+	DRIV_DIR := imx
+	SERIAL_DRIV_DIR := imx
+	TIMER_DRV_DIR := imx
+	CPU := cortex-a53
 else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_aarch64)
-	export DRIV_DIR := virtio
-	export SERIAL_DRIV_DIR := arm
-	export TIMER_DRV_DIR := arm
-	export CPU := cortex-a53
-	export QEMU := qemu-system-aarch64
-	export QEMU_ARCH_ARGS := -machine virt,virtualization=on -cpu cortex-a53 \
-						-device loader,file=$(IMAGE_FILE),addr=0x70000000,cpu-num=0 \
-						-serial mon:stdio
+	DRIV_DIR := virtio
+	SERIAL_DRIV_DIR := arm
+	TIMER_DRV_DIR := arm
+	CPU := cortex-a53
+	QEMU := qemu-system-aarch64
+	QEMU_ARCH_ARGS := -machine virt,virtualization=on -cpu cortex-a53 \
+					  -device loader,file=$(IMAGE_FILE),addr=0x70000000,cpu-num=0 \
+					  -serial mon:stdio
 else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_riscv64)
-	export DRIV_DIR := virtio
-	export SERIAL_DRIV_DIR := ns16550a
-	export TIMER_DRV_DIR := goldfish
-	export QEMU := qemu-system-riscv64
-	export QEMU_ARCH_ARGS := -machine virt -kernel $(IMAGE_FILE) -serial mon:stdio
+	DRIV_DIR := virtio
+	SERIAL_DRIV_DIR := ns16550a
+	TIMER_DRV_DIR := goldfish
+	QEMU := qemu-system-riscv64
+	QEMU_ARCH_ARGS := -machine virt -kernel $(IMAGE_FILE) -serial mon:stdio
 else ifeq ($(strip $(MICROKIT_BOARD)), star64)
-	export DRIV_DIR := dwmac-5.10a
-	export SERIAL_DRIV_DIR := ns16550a
-	export TIMER_DRV_DIR := jh7110
+	DRIV_DIR := dwmac-5.10a
+	SERIAL_DRIV_DIR := ns16550a
+	TIMER_DRV_DIR := jh7110
 else
 $(error Unsupported MICROKIT_BOARD given)
 endif
@@ -94,15 +94,15 @@ endif
 TOP := ${SDDF}/examples/echo_server
 METAPROGRAM := $(TOP)/meta.py
 
-ECHO_SERVER:=${SDDF}/examples/echo_server
-LWIPDIR:=network/ipstacks/lwip/src
-BENCHMARK:=$(SDDF)/benchmark
-UTIL:=$(SDDF)/util
-ETHERNET_DRIVER:=$(SDDF)/drivers/network/$(DRIV_DIR)
+ECHO_SERVER := ${SDDF}/examples/echo_server
+LWIPDIR := network/ipstacks/lwip/src
+BENCHMARK := $(SDDF)/benchmark
+UTIL := $(SDDF)/util
+ETHERNET_DRIVER := $(SDDF)/drivers/network/$(DRIV_DIR)
 SERIAL_COMPONENTS := $(SDDF)/serial/components
 SERIAL_DRIVER := $(SDDF)/drivers/serial/$(SERIAL_DRIV_DIR)
-TIMER_DRIVER:=$(SDDF)/drivers/timer/$(TIMER_DRV_DIR)
-NETWORK_COMPONENTS:=$(SDDF)/network/components
+TIMER_DRIVER := $(SDDF)/drivers/timer/$(TIMER_DRV_DIR)
+NETWORK_COMPONENTS := $(SDDF)/network/components
 SYSTEM_FILE := echo_server.system
 DTS := $(SDDF)/dts/$(MICROKIT_BOARD).dts
 DTB := $(MICROKIT_BOARD).dtb

--- a/examples/gpu/Makefile
+++ b/examples/gpu/Makefile
@@ -11,7 +11,8 @@ endif
 export FB_IMG ?= fb_img.jpeg
 export BLOB ?= 0
 BUILD_DIR ?= build
-export BUILD_DIR := $(abspath ${BUILD_DIR})
+override BUILD_DIR := $(abspath ${BUILD_DIR})
+export BUILD_DIR
 export MICROKIT_BOARD ?= qemu_virt_aarch64
 export MICROKIT_CONFIG ?= debug
 export SDDF := $(abspath ../..)

--- a/examples/gpu/Makefile
+++ b/examples/gpu/Makefile
@@ -18,7 +18,6 @@ export MICROKIT_CONFIG ?= debug
 export SDDF := $(abspath ../..)
 
 override FB_IMG := $(abspath ${FB_IMG})
-override BUILD_DIR := $(abspath ${BUILD_DIR})
 override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 
 IMAGE_FILE := ${BUILD_DIR}/loader.img

--- a/examples/gpu/Makefile
+++ b/examples/gpu/Makefile
@@ -10,8 +10,8 @@ endif
 
 export FB_IMG ?= fb_img.jpeg
 export BLOB ?= 0
-export BUILD_DIR ?= build
-export MICROKIT_SDK
+BUILD_DIR ?= build
+export BUILD_DIR := $(abspath ${BUILD_DIR})
 export MICROKIT_BOARD ?= qemu_virt_aarch64
 export MICROKIT_CONFIG ?= debug
 export SDDF := $(abspath ../..)
@@ -20,8 +20,8 @@ override FB_IMG := $(abspath ${FB_IMG})
 override BUILD_DIR := $(abspath ${BUILD_DIR})
 override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 
-IMAGE_FILE:= ${BUILD_DIR}/loader.img
-REPORT_FILE:= ${BUILD_DIR}/report.txt
+IMAGE_FILE := ${BUILD_DIR}/loader.img
+REPORT_FILE := ${BUILD_DIR}/report.txt
 
 all: ${IMAGE_FILE}
 

--- a/examples/gpu/gpu.mk
+++ b/examples/gpu/gpu.mk
@@ -87,11 +87,11 @@ endif
 LDFLAGS := -L${BOARD_DIR}/lib
 LIBS := --start-group -lmicrokit -Tmicrokit.ld libsddf_util_debug.a --end-group
 
-IMAGE_FILE   := loader.img
-REPORT_FILE  := report.txt
-SYSTEM_FILE  := ${TOP}/board/${MICROKIT_BOARD}/gpu.system
+IMAGE_FILE := loader.img
+REPORT_FILE := report.txt
+SYSTEM_FILE := ${TOP}/board/${MICROKIT_BOARD}/gpu.system
 
-GPU_DRIVER   := ${SDDF}/drivers/gpu/${GPU_DRIVER_DIR}
+GPU_DRIVER := ${SDDF}/drivers/gpu/${GPU_DRIVER_DIR}
 GPU_COMPONENTS := ${SDDF}/gpu/components
 TIMER_DRIVER := ${SDDF}/drivers/timer/${TIMER_DRIVER_DIR}
 
@@ -122,7 +122,7 @@ include ${TIMER_DRIVER}/timer_driver.mk
 
 ${IMAGES}: libsddf_util_debug.a
 
-CHECK_GPU_CLI_FLAGS_MD5:=.gpu_cli_cflags-$(shell echo -- ${CFLAGS} ${CFLAGS_gpu} | shasum | sed 's/ *-//')
+CHECK_GPU_CLI_FLAGS_MD5 := .gpu_cli_cflags-$(shell echo -- ${CFLAGS} ${CFLAGS_gpu} | shasum | sed 's/ *-//')
 
 ${CHECK_GPU_CLI_FLAGS_MD5}:
 	-rm -f .gpu_cli_cflags-*

--- a/examples/i2c/Makefile
+++ b/examples/i2c/Makefile
@@ -10,7 +10,8 @@ endif
 override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 
 BUILD_DIR ?= build
-export BUILD_DIR := $(abspath ${BUILD_DIR})
+override BUILD_DIR := $(abspath ${BUILD_DIR})
+export BUILD_DIR
 export MICROKIT_CONFIG ?= debug
 export MICROKIT_BOARD ?= odroidc4
 

--- a/examples/i2c/Makefile
+++ b/examples/i2c/Makefile
@@ -7,13 +7,14 @@
 ifeq ($(strip $(MICROKIT_SDK)),)
 $(error MICROKIT_SDK must be specified)
 endif
-override MICROKIT_SDK:=$(abspath ${MICROKIT_SDK})
+override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 
-export BUILD_DIR ?= build
+BUILD_DIR ?= build
+export BUILD_DIR := $(abspath ${BUILD_DIR})
 export MICROKIT_CONFIG ?= debug
 export MICROKIT_BOARD ?= odroidc4
 
-export I2C_BUS_NUM:=2
+export I2C_BUS_NUM := 2
 export SDDF := $(abspath ../../)
 
 IMAGE_FILE := $(BUILD_DIR)/loader.img

--- a/examples/i2c/i2c.mk
+++ b/examples/i2c/i2c.mk
@@ -68,13 +68,13 @@ CFLAGS += -I$(BOARD_DIR)/include \
 	-MD \
 	-MP
 
-CLIENT_PN532_OBJS :=  pn532.o client_pn532.o
+CLIENT_PN532_OBJS := pn532.o client_pn532.o
 DEPS_PN532 := $(CLIENT_PN532_OBJS:.o=.d)
 
-CLIENT_DS3231_OBJS :=  ds3231.o client_ds3231.o
+CLIENT_DS3231_OBJS := ds3231.o client_ds3231.o
 DEPS_DS3231 := $(CLIENT_DS3231_OBJS:.o=.d)
 
-VPATH:=${TOP}
+VPATH := ${TOP}
 all: $(IMAGE_FILE)
 
 client_pn532.elf: $(CLIENT_PN532_OBJS) libco.a libsddf_util.a

--- a/examples/serial/Makefile
+++ b/examples/serial/Makefile
@@ -12,7 +12,8 @@ ifeq ($(strip $(MICROKIT_BOARD)),)
 $(error MICROKIT_BOARD must be specified)
 endif
 BUILD_DIR ?= build
-export BUILD_DIR := $(abspath ${BUILD_DIR})
+override BUILD_DIR := $(abspath ${BUILD_DIR})
+export BUILD_DIR
 export SDDF := $(abspath ../..)
 override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 

--- a/examples/serial/Makefile
+++ b/examples/serial/Makefile
@@ -13,7 +13,7 @@ $(error MICROKIT_BOARD must be specified)
 endif
 BUILD_DIR ?= build
 export BUILD_DIR := $(abspath ${BUILD_DIR})
-export SDDF = $(abspath ../..)
+export SDDF := $(abspath ../..)
 override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 
 IMAGE_FILE := ${BUILD_DIR}/loader.img

--- a/examples/serial/Makefile
+++ b/examples/serial/Makefile
@@ -11,14 +11,13 @@ endif
 ifeq ($(strip $(MICROKIT_BOARD)),)
 $(error MICROKIT_BOARD must be specified)
 endif
-export MICROKIT_BOARD
 BUILD_DIR ?= build
-export SDDF=$(abspath ../..)
-export BUILD_DIR:=$(abspath ${BUILD_DIR})
-export override MICROKIT_SDK:=$(abspath ${MICROKIT_SDK})
+export BUILD_DIR := $(abspath ${BUILD_DIR})
+export SDDF = $(abspath ../..)
+override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 
-IMAGE_FILE:= ${BUILD_DIR}/loader.img
-REPORT_FILE:= ${BUILD_DIR}/report.txt
+IMAGE_FILE := ${BUILD_DIR}/loader.img
+REPORT_FILE := ${BUILD_DIR}/report.txt
 
 all: ${IMAGE_FILE}
 

--- a/examples/serial/serial.mk
+++ b/examples/serial/serial.mk
@@ -91,7 +91,7 @@ CFLAGS += -I$(BOARD_DIR)/include \
 	-I${SDDF}/include/microkit \
 	$(CFLAGS_ARCH)
 
-CHECK_FLAGS_BOARD_MD5:=.board_cflags-$(shell echo -- ${CFLAGS} ${MICROKIT_SDK} ${MICROKIT_BOARD} ${MICROKIT_CONFIG} | shasum | sed 's/ *-//')
+CHECK_FLAGS_BOARD_MD5 := .board_cflags-$(shell echo -- ${CFLAGS} ${MICROKIT_SDK} ${MICROKIT_BOARD} ${MICROKIT_CONFIG} | shasum | sed 's/ *-//')
 
 ${CHECK_FLAGS_BOARD_MD5}:
 	-rm -f .board_cflags-*

--- a/examples/timer/Makefile
+++ b/examples/timer/Makefile
@@ -12,7 +12,8 @@ ifeq ($(strip $(MICROKIT_BOARD)),)
 $(error MICROKIT_BOARD must be specified)
 endif
 BUILD_DIR ?= build
-export BUILD_DIR := $(abspath ${BUILD_DIR})
+override BUILD_DIR := $(abspath ${BUILD_DIR})
+export BUILD_DIR
 export SDDF := $(abspath ../..)
 override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 

--- a/examples/timer/Makefile
+++ b/examples/timer/Makefile
@@ -11,10 +11,9 @@ endif
 ifeq ($(strip $(MICROKIT_BOARD)),)
 $(error MICROKIT_BOARD must be specified)
 endif
-export MICROKIT_BOARD
 BUILD_DIR ?= build
-export SDDF := $(abspath ../..)
 export BUILD_DIR := $(abspath ${BUILD_DIR})
+export SDDF := $(abspath ../..)
 override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 
 IMAGE_FILE := $(BUILD_DIR)/loader.img

--- a/examples/timer/timer.mk
+++ b/examples/timer/timer.mk
@@ -41,25 +41,25 @@ PYTHON ?= python3
 MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
 
 ifeq ($(strip $(MICROKIT_BOARD)), odroidc4)
-	export TIMER_DRIVER_DIR := meson
-	export CPU := cortex-a55
+	TIMER_DRIVER_DIR := meson
+	CPU := cortex-a55
 else ifeq ($(strip $(MICROKIT_BOARD)), odroidc2)
-	export TIMER_DRIVER_DIR := meson
-	export CPU := cortex-a53
+	TIMER_DRIVER_DIR := meson
+	CPU := cortex-a53
 else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_aarch64)
-	export TIMER_DRIVER_DIR := arm
-	export CPU := cortex-a53
-	export QEMU := qemu-system-aarch64
-	export QEMU_ARCH_ARGS := -machine virt,virtualization=on -cpu cortex-a53 -device loader,file=$(IMAGE_FILE),addr=0x70000000,cpu-num=0
+	TIMER_DRIVER_DIR := arm
+	CPU := cortex-a53
+	QEMU := qemu-system-aarch64
+	QEMU_ARCH_ARGS := -machine virt,virtualization=on -cpu cortex-a53 -device loader,file=$(IMAGE_FILE),addr=0x70000000,cpu-num=0
 else ifeq ($(strip $(MICROKIT_BOARD)), qemu_virt_riscv64)
-	export TIMER_DRIVER_DIR := goldfish
-	export QEMU := qemu-system-riscv64
-	export QEMU_ARCH_ARGS := -machine virt -kernel $(IMAGE_FILE)
+	TIMER_DRIVER_DIR := goldfish
+	QEMU := qemu-system-riscv64
+	QEMU_ARCH_ARGS := -machine virt -kernel $(IMAGE_FILE)
 else ifeq ($(strip $(MICROKIT_BOARD)), star64)
-	export TIMER_DRIVER_DIR := jh7110
+	TIMER_DRIVER_DIR := jh7110
 else ifneq ($(filter $(strip $(MICROKIT_BOARD)),imx8mm_evk imx8mp_evk imx8mq_evk maaxboard),)
-	export TIMER_DRIVER_DIR := imx
-	export CPU := cortex-a53
+	TIMER_DRIVER_DIR := imx
+	CPU := cortex-a53
 else
 $(error Unsupported MICROKIT_BOARD given)
 endif


### PR DESCRIPTION
This PR removes all `export override` directives from our makefiles, as discussed here #337.

It was found that `export override` is not syntactically correct in older versions of GNU make, which happen to be the default for MacOS. Also, the variables which it was being applied to were mandatory environment or command line variables, therefore the `export` had no effect. 

This PR also removes a handful of `export` directives which were not necessary (on variables which were not used in submakes).