### PR TITLE
virtio: ack interrupts *before* handling responses

### DIFF
--- a/drivers/blk/virtio/block.c
+++ b/drivers/blk/virtio/block.c
@@ -255,8 +255,8 @@ void handle_irq(void)
 {
     uint32_t irq_status = regs->InterruptStatus;
     if (irq_status & VIRTIO_MMIO_IRQ_VQUEUE) {
-        handle_response();
         regs->InterruptACK = VIRTIO_MMIO_IRQ_VQUEUE;
+        handle_response();
     }
 
     if (irq_status & VIRTIO_MMIO_IRQ_CONFIG) {

--- a/drivers/gpu/virtio/gpu.c
+++ b/drivers/gpu/virtio/gpu.c
@@ -784,8 +784,9 @@ static void handle_irq()
     uint32_t irq_status = regs->InterruptStatus;
     if (irq_status & VIRTIO_MMIO_IRQ_VQUEUE) {
         LOG_GPU_VIRTIO_DRIVER("Received virtqueue used buffer notification\n");
-        notify = handle_response();
+        // ACK before handling responses
         regs->InterruptACK = VIRTIO_MMIO_IRQ_VQUEUE;
+        notify = handle_response();
         /* Now that there are (maybe) some free descriptors, we want to handle any remaining
          * requests that we may have left in the queue before due to being
          * out of free descriptors.

--- a/drivers/network/virtio/ethernet.c
+++ b/drivers/network/virtio/ethernet.c
@@ -291,13 +291,14 @@ static void handle_irq()
 {
     uint32_t irq_status = regs->InterruptStatus;
     if (irq_status & VIRTIO_MMIO_IRQ_VQUEUE) {
+        // ACK the interrupt first before handling responses
+        regs->InterruptACK = VIRTIO_MMIO_IRQ_VQUEUE;
+
         // We don't know whether the IRQ is related to a change to the RX queue
         // or TX queue, so we check both.
         tx_return();
         tx_provide();
         rx_return();
-        // We have handled the used buffer notification
-        regs->InterruptACK = VIRTIO_MMIO_IRQ_VQUEUE;
     }
 
     if (irq_status & VIRTIO_MMIO_IRQ_CONFIG) {

--- a/drivers/serial/virtio/console.c
+++ b/drivers/serial/virtio/console.c
@@ -368,6 +368,9 @@ static void handle_irq()
 {
     uint32_t irq_status = uart_regs->InterruptStatus;
     if (irq_status & VIRTIO_MMIO_IRQ_VQUEUE) {
+        // ACK the interrupt first before handling responses
+        uart_regs->InterruptACK = VIRTIO_MMIO_IRQ_VQUEUE;
+
         // We don't know whether the IRQ is related to a change to the RX queue
         // or TX queue, so we check both.
         if (config.rx_enabled) {
@@ -376,8 +379,6 @@ static void handle_irq()
         }
         tx_return();
         tx_provide();
-        // We have handled the used buffer notification
-        uart_regs->InterruptACK = VIRTIO_MMIO_IRQ_VQUEUE;
     }
 
     if (irq_status & VIRTIO_MMIO_IRQ_CONFIG) {


### PR DESCRIPTION
If we handle the responses before ACKing, we run the chance of having responses appear after we (think) have processed all the responses; but then because we have ACK'd the interrupt we will have missed them and then hang.

Linux: https://elixir.bootlin.com/linux/v6.14.6/source/drivers/virtio/virtio_mmio.c#L299-L325