### PR TITLE
blk: add blk_storage_set_ready

### DIFF
--- a/blk/components/partitioning.c
+++ b/blk/components/partitioning.c
@@ -99,7 +99,7 @@ static bool gpt_partitions_init()
         client_storage_info->sector_size = driver_storage_info->sector_size;
         client_storage_info->capacity = clients[i].sectors / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE);
         client_storage_info->read_only = driver_storage_info->read_only;
-        __atomic_store_n(&client_storage_info->ready, true, __ATOMIC_RELEASE);
+        blk_storage_set_ready(client_storage_info, true);
     }
 
     return true;
@@ -274,7 +274,7 @@ static bool mbr_partitions_init(void)
         client_storage_info->sector_size = driver_storage_info->sector_size;
         client_storage_info->capacity = clients[i].sectors / (BLK_TRANSFER_SIZE / MSDOS_MBR_SECTOR_SIZE);
         client_storage_info->read_only = driver_storage_info->read_only;
-        __atomic_store_n(&client_storage_info->ready, true, __ATOMIC_RELEASE);
+        blk_storage_set_ready(client_storage_info, true);
     }
     return true;
 }

--- a/drivers/blk/mmc/imx/usdhc.c
+++ b/drivers/blk/mmc/imx/usdhc.c
@@ -1060,7 +1060,7 @@ void setup_blk_storage_info()
 
     LOG_DRIVER("Card size (blocks): %lu\n", storage_info->capacity);
 
-    __atomic_store_n(&storage_info->ready, true, __ATOMIC_RELEASE);
+    blk_storage_set_ready(storage_info, true);
     LOG_DRIVER("Driver initialisation complete\n");
 }
 

--- a/drivers/blk/virtio/block.c
+++ b/drivers/blk/virtio/block.c
@@ -319,7 +319,7 @@ void virtio_blk_init(void)
     storage_info->sector_size = VIRTIO_BLK_SECTOR_SIZE;
 
     /* Finished populating configuration */
-    __atomic_store_n(&storage_info->ready, true, __ATOMIC_RELEASE);
+    blk_storage_set_ready(storage_info, true);
 
 #ifdef DEBUG_DRIVER
     uint32_t features_low = regs->DeviceFeatures;

--- a/include/sddf/blk/storage_info.h
+++ b/include/sddf/blk/storage_info.h
@@ -45,3 +45,12 @@ static inline bool blk_storage_is_ready(blk_storage_info_t *storage_info)
 {
     return __atomic_load_n(&storage_info->ready, __ATOMIC_ACQUIRE);
 }
+
+/**
+ * Set shared memory whether the block storage device is ready.
+ * This does an atomic release operation.
+ */
+static inline void blk_storage_set_ready(blk_storage_info_t *storage_info, bool ready)
+{
+    __atomic_store_n(&storage_info->ready, ready, __ATOMIC_RELEASE);
+}


### PR DESCRIPTION
I can see the particular atomic operation being mixed up sometimes accidentally so better to put abstract this bit like we do for reading the ready field.