### PR TITLE
ns16550a: variety of bugfixes

### DIFF
--- a/ci/matrix.py
+++ b/ci/matrix.py
@@ -79,8 +79,7 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
             "odroidc4",
             "qemu_virt_aarch64",
             "qemu_virt_riscv64",
-            # TODO: This driver has garbled output that breaks the tests.
-            # "star64",
+            "star64",
         ],
     },
     "timer": {

--- a/drivers/serial/ns16550a/include/uart.h
+++ b/drivers/serial/ns16550a/include/uart.h
@@ -67,10 +67,12 @@
 
 /* UART Interrupt Identity Register (R) */
 #define UART_IIR 0x02
-/* Transmit Holding Register Empty */
-#define UART_IIR_THR_EMPTY BIT(1)
-/* Received Data Available */
-#define UART_IIR_RX BIT(2)
+/* Interrupt ID Mask */
+#define UART_IIR_IID_MASK (0b1111)
+/* Interrupt ID = Transmit Holding Register Empty */
+#define UART_IIR_IID_THRE (0b0010)
+/* Interrupt Id = Received Data Available */
+#define UART_IIR_IID_DR (0b0100)
 
 /* UART FIFO Control Register (W) */
 #define UART_FCR 0x02

--- a/drivers/serial/ns16550a/include/uart.h
+++ b/drivers/serial/ns16550a/include/uart.h
@@ -60,19 +60,34 @@
 
 /* UART Interrupt Enable Register (R/W) */
 #define UART_IER 0x01
-/* Enable Received Data Available Interrupt */
+/* Enable Received Data Available Interrupt, if FIFOs are enabled, the
+ * Character Timeout Interrupt. */
 #define UART_IER_ERBFI BIT(0)
 /* Enable Transmit Holding Register Empty Interrupt */
 #define UART_IER_ETBEI BIT(1)
 
 /* UART Interrupt Identity Register (R) */
 #define UART_IIR 0x02
-/* Interrupt ID Mask */
-#define UART_IIR_IID_MASK (0b1111)
-/* Interrupt ID = Transmit Holding Register Empty */
-#define UART_IIR_IID_THRE (0b0010)
-/* Interrupt Id = Received Data Available */
-#define UART_IIR_IID_DR (0b0100)
+/* Interrupt ID Mask.
+ * According to the DW_APB_UART manual, this is bits 3:0, i.e. should be 0b1111
+ * The UART_IER_ERBFI (received data available interrupt) also enables the
+ * character timeout interrupt, i.e. 0b1100 for the IID.
+ * Furthermore, the manual specifies that the priorities put the received data
+ * interrupt *above* the character timeout interrupt.
+ *
+ * However, QEMU seems to disagree, and places the timeout interrupt above the
+ * received data interrupt.
+ *
+ * It appears that Zephyr just ignores it, which seems suspicious. But so does
+ * Linux.
+ *
+ * ??
+ */
+#define UART_IIR_IID_MASK (0b0111)
+/* Interrupt ID = Transmit Holding Register Indicator */
+#define UART_IIR_IID_THRI (0b0010)
+/* Interrupt ID = Received Data Available */
+#define UART_IIR_IID_RDI (0b0100)
 
 /* UART FIFO Control Register (W) */
 #define UART_FCR 0x02

--- a/drivers/serial/ns16550a/include/uart.h
+++ b/drivers/serial/ns16550a/include/uart.h
@@ -35,6 +35,7 @@
  * https://github.com/qemu/qemu/blob/56c6e249b6988c1b6edc2dd34ebb0f1e570a1365/hw/riscv/virt.c#L966
  */
 #define UART_CLK 3686400
+#define UART_DW_APB_SHADOW_REGISTERS 0
 #else
 #error "unknown UART clock"
 #endif
@@ -56,69 +57,70 @@
 
 /* UART Divisor High Latch Register (R/W) */
 #define UART_DLH 0x01
-/* Divisor Latch Mask */
-#define DL_MASK 0xff
 
 /* UART Interrupt Enable Register (R/W) */
 #define UART_IER 0x01
 /* Enable Received Data Available Interrupt */
-#define UART_IER_ERBFI 0x1
+#define UART_IER_ERBFI BIT(0)
 /* Enable Transmit Holding Register Empty Interrupt */
-#define UART_IER_ETBEI 0x2
+#define UART_IER_ETBEI BIT(1)
 
 /* UART Interrupt Identity Register (R) */
 #define UART_IIR 0x02
 /* Transmit Holding Register Empty */
-#define UART_IIR_THR_EMPTY 0x2
+#define UART_IIR_THR_EMPTY BIT(1)
 /* Received Data Available */
-#define UART_IIR_RX 0x4
+#define UART_IIR_RX BIT(2)
 
 /* UART FIFO Control Register (W) */
 #define UART_FCR 0x02
-/* Transmit FIFO Reset */
-#define UART_FCR_XFIFOR (1 << 2)
-/* Receive FIFO Reset */
-#define UART_FCR_RFIFOR (1 << 1)
 /* FIFO Enable */
-#define UART_FCR_FIFOE (1 << 0)
-/* FIFO Clear and Enable */
-#define UART_FCR_CE (UART_FCR_XFIFOR | UART_FCR_RFIFOR | UART_FCR_FIFOE)
+#define UART_FCR_FIFOE BIT(0)
+/* Receive FIFO Reset */
+#define UART_FCR_RFIFOR BIT(1)
+/* Transmit FIFO Reset */
+#define UART_FCR_XFIFOR BIT(2)
 
-/* UART Line Control Register */
+/* UART Line Control Register (RW) */
 #define UART_LCR 0x03
-/* Default for LCR. 8 bit data length and 2 stop bits*/
-#define UART_LCR_DEFAULT 0x03
 /* Divisor Latch Access Bit */
-#define UART_LCR_DLAB (1 << 7)
+#define UART_LCR_DLAB BIT(7)
 
-/* UART Modem Control Register */
+/* UART Modem Control Register (RW) */
 #define UART_MCR 0x4
 /* Data Terminal Ready */
-#define UART_MCR_DTR (1 << 0)
+#define UART_MCR_DTR BIT(0)
 /* Request to Send */
-#define UART_MCR_RTS (1 << 1)
+#define UART_MCR_RTS BIT(1)
 
 /* UART Line Status Register (R) */
 #define UART_LSR 0x05
 /* Data Ready */
-#define UART_LSR_DR 0x1
-/* Transmit Holding Register Empty */
-#define UART_LSR_THRE 0x20
+#define UART_LSR_DR BIT(0)
 /* Parity Error Bit */
-#define UART_LSR_PE (1 << 2)
+#define UART_LSR_PE BIT(2)
 /* Framing Error Bit */
-#define UART_LSR_FE (1 << 3)
+#define UART_LSR_FE BIT(3)
+/* Transmit Holding Register Empty */
+#define UART_LSR_THRE BIT(5)
+/* Transmit FIFO and Transmit Shift register Empty */
+#define UART_LSR_TEMT BIT(6)
 /* Recv FIFO Error Bit */
-#define UART_LSR_RFE (1 << 7)
-/* Abnormal Status */
-#define UART_ABNORMAL (UART_LSR_PE | UART_LSR_FE | UART_LSR_RFE)
+#define UART_LSR_RFE BIT(7)
 
 /*
  * These registers are special to the DW APB UART implementation.
  */
-#if defined(UART_DW_APB_SHADOW_REGISTERS)
+#if UART_DW_APB_SHADOW_REGISTERS
 /* UART Software Reset Register */
 #define UART_SSR 0x22
 /* UART Reset */
-#define UART_SSR_UR (1 << 0)
+#define UART_SSR_UR BIT(0)
+
+/* UART Status Register (0x7C >> 2 = 0x1f) */
+#define UART_USR 0x1f
+/* UART BUSY */
+#define UART_USR_BUSY BIT(0)
+/* Transmit FIFO Not Full */
+#define UART_USR_TFNF BIT(1)
 #endif

--- a/drivers/serial/ns16550a/uart.c
+++ b/drivers/serial/ns16550a/uart.c
@@ -67,9 +67,6 @@ static inline bool tx_fifo_not_full(void)
      * context" like Linux does [6], where it wants for the THR to empty both
      * before *and* after emitting a character. However, this is not the case.
      *
-     * @todo in release mode, openSBI's print output is never used by the kernel
-     *       at runtime, and so we could emit the whole FIFO-size at once.
-     *
      * Hence, on standard ns16550a we are likely to see interleaved serial output
      * because of how slow waiting for an interrupt for *every* output character
      * is.
@@ -230,8 +227,9 @@ void init(void)
 
 #if UART_DW_APB_SHADOW_REGISTERS
     /* Clear the USR busy bit
-        https://github.com/torvalds/linux/blob/v6.14/drivers/tty/serial/8250/8250_dw.c#L304-L306
-    */
+     * This must be done after enabling IRQs
+     * https://github.com/torvalds/linux/blob/v6.14/drivers/tty/serial/8250/8250_dw.c#L304-L306
+     */
     (void)*REG_PTR(UART_USR);
 #endif
 }

--- a/drivers/serial/ns16550a/uart.c
+++ b/drivers/serial/ns16550a/uart.c
@@ -178,9 +178,9 @@ static void handle_irq(void)
 
     /* IRQ ID is a priority-based *single* indication, not a bitvector */
     uint8_t irq_id = *REG_PTR(UART_IIR) & UART_IIR_IID_MASK;
-    if (config.rx_enabled && irq_id == UART_IIR_IID_DR) {
+    if (config.rx_enabled && irq_id == UART_IIR_IID_RDI) {
         rx_return();
-    } else if (irq_id == UART_IIR_IID_THRE) {
+    } else if (irq_id == UART_IIR_IID_THRI) {
         tx_provide();
     }
 }
@@ -215,7 +215,7 @@ void init(void)
        no parity, no break control. */
     *REG_PTR(UART_LCR) = 0b00000011;
 
-    // /* Set the baud rate */
+    /* Set the baud rate */
     set_baud(config.default_baud);
 
     if (config.rx_enabled) {

--- a/drivers/serial/ns16550a/uart.c
+++ b/drivers/serial/ns16550a/uart.c
@@ -142,13 +142,9 @@ void init(void)
 
     uart_base = (uintptr_t)device_resources.regions[0].region.vaddr;
 
-    /* Ensure that the FIFO's are empty */
-    while (!(*REG_PTR(UART_LSR) & UART_LSR_THRE));
 
-#if UART_DW_APB_SHADOW_REGISTERS
-    /* Reset the UART device - this disables RX and TX */
-    *REG_PTR(UART_SSR) |= UART_SSR_UR;
-#endif
+    /* Ensure that the FIFO's are empty */
+    while (!(*REG_PTR(UART_LSR) & (UART_LSR_THRE | UART_LSR_TEMT)));
 
     /* Setup the Modem Control Register */
     *REG_PTR(UART_MCR) |= (UART_MCR_DTR | UART_MCR_RTS);

--- a/examples/serial/serial.mk
+++ b/examples/serial/serial.mk
@@ -128,7 +128,7 @@ $(IMAGE_FILE) $(REPORT_FILE): $(IMAGES) $(SYSTEM_FILE)
 	MICROKIT_SDK=${MICROKIT_SDK} $(MICROKIT_TOOL) $(SYSTEM_FILE) --search-path $(BUILD_DIR) --board $(MICROKIT_BOARD) --config $(MICROKIT_CONFIG) -o $(IMAGE_FILE) -r $(REPORT_FILE)
 
 qemu: ${IMAGE_FILE}
-	$(QEMU) -m size=2G -nographic -d guest_errors $(QEMU_ARCH_ARGS)
+	$(QEMU) -m size=2G -nographic -serial mon:stdio -d guest_errors $(QEMU_ARCH_ARGS)
 
 clean::
 	${RM} -f *.elf


### PR DESCRIPTION
Fixes #411.

- Fixed corruption from the DW APB shadow reset that wasn't useful
- Fixed interleaving due to not using the FIFO
- Fixed usage of a bunch of read-clear and write-clear registers