### PR TITLE
build.zig: fixes and improvements

### DIFF
--- a/examples/serial/build.zig
+++ b/examples/serial/build.zig
@@ -148,44 +148,35 @@ pub fn build(b: *std.Build) !void {
     const default_python = if (std.posix.getenv("PYTHON")) |p| p else "python3";
     const python = b.option([]const u8, "python", "Path to Python to use") orelse default_python;
 
-    // Getting the path to the Microkit SDK before doing anything else
-    const microkit_sdk_arg = b.option([]const u8, "sdk", "Path to Microkit SDK");
-    if (microkit_sdk_arg == null) {
-        std.log.err("Missing -Dsdk=/path/to/sdk argument being passed\n", .{});
-        std.posix.exit(1);
-    }
-    const microkit_sdk = microkit_sdk_arg.?;
+    const microkit_sdk = b.option(LazyPath, "sdk", "Path to Microkit SDK") orelse {
+        std.log.err("Missing -Dsdk=<sdk> argument", .{});
+        return error.MissingSdkPath;
+    };
 
-    const microkit_config_option = b.option(ConfigOptions, "config", "Microkit config to build for") orelse ConfigOptions.debug;
+    const microkit_config_option = b.option(ConfigOptions, "config", "Microkit config to build for") orelse .debug;
     const microkit_config = @tagName(microkit_config_option);
 
-    // Get the Microkit SDK board we want to target
-    const microkit_board_option = b.option(MicrokitBoard, "board", "Microkit board to target");
+    const microkit_board_option = b.option(MicrokitBoard, "board", "Microkit board to target") orelse {
+        std.log.err("Missing -Dboard=<board> argument", .{});
+        return error.MissingBoard;
+    };
 
-    if (microkit_board_option == null) {
-        std.log.err("Missing -Dboard=<BOARD> argument being passed\n", .{});
-        std.posix.exit(1);
-    }
-    const target = b.resolveTargetQuery(findTarget(microkit_board_option.?));
-    const microkit_board = @tagName(microkit_board_option.?);
+    const target = b.resolveTargetQuery(findTarget(microkit_board_option));
+    const microkit_board = @tagName(microkit_board_option);
 
-    // Since we are relying on Zig to produce the final ELF, it needs to do the
-    // linking step as well.
-    const microkit_board_dir = b.fmt("{s}/board/{s}/{s}", .{ microkit_sdk, microkit_board, microkit_config });
-    const microkit_tool = b.fmt("{s}/bin/microkit", .{microkit_sdk});
-    const libmicrokit = b.fmt("{s}/lib/libmicrokit.a", .{microkit_board_dir});
-    const libmicrokit_include = b.fmt("{s}/include", .{microkit_board_dir});
-    const libmicrokit_linker_script = b.fmt("{s}/lib/microkit.ld", .{microkit_board_dir});
+    const microkit_board_dir = microkit_sdk.path(b, "board").path(b, microkit_board).path(b, microkit_config);
+    const microkit_tool = microkit_sdk.path(b, "bin/microkit");
+    const libmicrokit = microkit_board_dir.path(b, "lib/libmicrokit.a");
+    const libmicrokit_include = microkit_board_dir.path(b, "include");
+    const libmicrokit_linker_script = microkit_board_dir.path(b, "lib/microkit.ld");
 
     const sddf_dep = b.dependency("sddf", .{
         .target = target,
         .optimize = optimize,
-        .libmicrokit = @as([]const u8, libmicrokit),
-        .libmicrokit_include = @as([]const u8, libmicrokit_include),
-        .libmicrokit_linker_script = @as([]const u8, libmicrokit_linker_script),
+        .microkit_board_dir = microkit_board_dir,
     });
 
-    const driver_class = switch (microkit_board_option.?) {
+    const driver_class = switch (microkit_board_option) {
         .qemu_virt_aarch64 => "arm",
         .odroidc2, .odroidc4 => "meson",
         .maaxboard, .imx8mm_evk, .imx8mp_evk, .imx8mq_evk => "imx",
@@ -218,9 +209,9 @@ pub fn build(b: *std.Build) !void {
     client.linkLibrary(sddf_dep.artifact("util"));
     client.linkLibrary(sddf_dep.artifact("util_putchar_serial"));
 
-    client.addIncludePath(.{ .cwd_relative = libmicrokit_include });
-    client.addObjectFile(.{ .cwd_relative = libmicrokit });
-    client.setLinkerScript(.{ .cwd_relative = libmicrokit_linker_script });
+    client.addIncludePath(libmicrokit_include);
+    client.addObjectFile(libmicrokit);
+    client.setLinkerScript(libmicrokit_linker_script);
 
     b.installArtifact(client);
 
@@ -267,8 +258,9 @@ pub fn build(b: *std.Build) !void {
     const objcopys = &.{ client1_objcopy, client2_objcopy, virt_rx_objcopy, virt_tx_objcopy, driver_resources_objcopy, driver_config_objcopy };
 
     const final_image_dest = b.getInstallPath(.bin, "./loader.img");
-    const microkit_tool_cmd = b.addSystemCommand(&[_][]const u8{
-        microkit_tool,
+    const microkit_tool_cmd = Step.Run.create(b, "run microkit tool");
+    microkit_tool_cmd.addFileArg(microkit_tool);
+    microkit_tool_cmd.addArgs(&[_][]const u8{
         b.getInstallPath(.{ .custom = "meta_output" }, "serial.system"),
         "--search-path", b.getInstallPath(.bin, ""),
         "--board", microkit_board,
@@ -281,7 +273,7 @@ pub fn build(b: *std.Build) !void {
     }
     microkit_tool_cmd.step.dependOn(&meta_output_install.step);
     microkit_tool_cmd.step.dependOn(b.getInstallStep());
-    microkit_tool_cmd.setEnvironmentVariable("MICROKIT_SDK", microkit_sdk);
+    microkit_tool_cmd.setEnvironmentVariable("MICROKIT_SDK", microkit_sdk.getPath3(b, null).toString(b.allocator) catch @panic("OOM"));
     // Add the "microkit" step, and make it the default step when we execute `zig build`>
     const microkit_step = b.step("microkit", "Compile and build the final bootable image");
     microkit_step.dependOn(&microkit_tool_cmd.step);
@@ -290,7 +282,7 @@ pub fn build(b: *std.Build) !void {
     // This is setting up a `qemu` command for running the system using QEMU,
     // which we only want to do when we have a board that we can actually simulate.
     var qemu_cmd: ?*Step.Run = null;
-    if (microkit_board_option.? == .qemu_virt_aarch64) {
+    if (microkit_board_option == .qemu_virt_aarch64) {
         const loader_arg = b.fmt("loader,file={s},addr=0x70000000,cpu-num=0", .{final_image_dest});
         qemu_cmd = b.addSystemCommand(&[_][]const u8{
             "qemu-system-aarch64",
@@ -306,7 +298,7 @@ pub fn build(b: *std.Build) !void {
             "2G",
             "-nographic",
         });
-    } else if (microkit_board_option.? == .qemu_virt_riscv64) {
+    } else if (microkit_board_option == .qemu_virt_riscv64) {
         qemu_cmd = b.addSystemCommand(&[_][]const u8{
             "qemu-system-riscv64",
             "-machine",

--- a/examples/timer/build.zig
+++ b/examples/timer/build.zig
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 const std = @import("std");
+const LazyPath = std.Build.LazyPath;
 const Step = std.Build.Step;
 
 const MicrokitBoard = enum {
@@ -157,41 +158,35 @@ pub fn build(b: *std.Build) !void {
     const default_python = if (std.posix.getenv("PYTHON")) |p| p else "python3";
     const python = b.option([]const u8, "python", "Path to Python to use") orelse default_python;
 
-    const microkit_sdk_arg = b.option([]const u8, "sdk", "Path to Microkit SDK");
-    if (microkit_sdk_arg == null) {
-        std.log.err("Missing -Dsdk=/path/to/sdk argument being passed\n", .{});
-        std.posix.exit(1);
-    }
-    const microkit_sdk = microkit_sdk_arg.?;
+    const microkit_sdk = b.option(LazyPath, "sdk", "Path to Microkit SDK") orelse {
+        std.log.err("Missing -Dsdk=<sdk> argument", .{});
+        return error.MissingSdkPath;
+    };
 
-    const microkit_config_option = b.option(ConfigOptions, "config", "Microkit config to build for") orelse ConfigOptions.debug;
+    const microkit_config_option = b.option(ConfigOptions, "config", "Microkit config to build for") orelse .debug;
     const microkit_config = @tagName(microkit_config_option);
 
-    // Get the Microkit SDK board we want to target
-    const microkit_board_option = b.option(MicrokitBoard, "board", "Microkit board to target");
+    const microkit_board_option = b.option(MicrokitBoard, "board", "Microkit board to target") orelse {
+        std.log.err("Missing -Dboard=<board> argument", .{});
+        return error.MissingBoard;
+    };
 
-    if (microkit_board_option == null) {
-        std.log.err("Missing -Dboard=<BOARD> argument being passed\n", .{});
-        std.posix.exit(1);
-    }
-    const target = b.resolveTargetQuery(findTarget(microkit_board_option.?));
-    const microkit_board = @tagName(microkit_board_option.?);
+    const target = b.resolveTargetQuery(findTarget(microkit_board_option));
+    const microkit_board = @tagName(microkit_board_option);
 
-    const microkit_board_dir = b.fmt("{s}/board/{s}/{s}", .{ microkit_sdk, microkit_board, microkit_config });
-    const microkit_tool = b.fmt("{s}/bin/microkit", .{microkit_sdk});
-    const libmicrokit = b.fmt("{s}/lib/libmicrokit.a", .{microkit_board_dir});
-    const libmicrokit_include = b.fmt("{s}/include", .{microkit_board_dir});
-    const libmicrokit_linker_script = b.fmt("{s}/lib/microkit.ld", .{microkit_board_dir});
+    const microkit_board_dir = microkit_sdk.path(b, "board").path(b, microkit_board).path(b, microkit_config);
+    const microkit_tool = microkit_sdk.path(b, "bin/microkit");
+    const libmicrokit = microkit_board_dir.path(b, "lib/libmicrokit.a");
+    const libmicrokit_include = microkit_board_dir.path(b, "include");
+    const libmicrokit_linker_script = microkit_board_dir.path(b, "lib/microkit.ld");
 
     const sddf_dep = b.dependency("sddf", .{
         .target = target,
         .optimize = optimize,
-        .libmicrokit = @as([]const u8, libmicrokit),
-        .libmicrokit_include = @as([]const u8, libmicrokit_include),
-        .libmicrokit_linker_script = @as([]const u8, libmicrokit_linker_script),
+        .microkit_board_dir = microkit_board_dir,
     });
 
-    const driver_class = switch (microkit_board_option.?) {
+    const driver_class = switch (microkit_board_option) {
         .qemu_virt_aarch64 => "arm",
         .qemu_virt_riscv64 => "goldfish",
         .odroidc2, .odroidc4 => "meson",
@@ -217,9 +212,9 @@ pub fn build(b: *std.Build) !void {
     client.linkLibrary(sddf_dep.artifact("util"));
     client.linkLibrary(sddf_dep.artifact("util_putchar_debug"));
 
-    client.addIncludePath(.{ .cwd_relative = libmicrokit_include });
-    client.addObjectFile(.{ .cwd_relative = libmicrokit });
-    client.setLinkerScript(.{ .cwd_relative = libmicrokit_linker_script });
+    client.addIncludePath(libmicrokit_include);
+    client.addObjectFile(libmicrokit);
+    client.setLinkerScript(libmicrokit_linker_script);
 
     b.installArtifact(client);
 
@@ -259,8 +254,9 @@ pub fn build(b: *std.Build) !void {
     const objcopys = &.{ client_objcopy, driver_objcopy };
 
     const final_image_dest = b.getInstallPath(.bin, "./loader.img");
-    const microkit_tool_cmd = b.addSystemCommand(&[_][]const u8{
-        microkit_tool,
+    const microkit_tool_cmd = Step.Run.create(b, "run microkit tool");
+    microkit_tool_cmd.addFileArg(microkit_tool);
+    microkit_tool_cmd.addArgs(&[_][]const u8{
         b.getInstallPath(.{ .custom = "meta_output" }, "timer.system"),
         "--search-path", b.getInstallPath(.bin, ""),
         "--board", microkit_board,
@@ -273,7 +269,8 @@ pub fn build(b: *std.Build) !void {
     }
     microkit_tool_cmd.step.dependOn(&meta_output_install.step);
     microkit_tool_cmd.step.dependOn(b.getInstallStep());
-    microkit_tool_cmd.setEnvironmentVariable("MICROKIT_SDK", microkit_sdk);
+    microkit_tool_cmd.setEnvironmentVariable("MICROKIT_SDK", microkit_sdk.getPath3(b, null).toString(b.allocator) catch @panic("OOM"));
+
     const microkit_step = b.step("microkit", "Compile and build the final bootable image");
     microkit_step.dependOn(&microkit_tool_cmd.step);
     b.default_step = microkit_step;
@@ -281,7 +278,7 @@ pub fn build(b: *std.Build) !void {
     // This is setting up a `qemu` command for running the system using QEMU,
     // which we only want to do when we have a board that we can actually simulate.
     var qemu_cmd: ?*Step.Run = null;
-    if (std.mem.eql(u8, microkit_board, "qemu_virt_aarch64")) {
+    if (microkit_board_option == .qemu_virt_aarch64) {
         const loader_arg = b.fmt("loader,file={s},addr=0x70000000,cpu-num=0", .{final_image_dest});
         qemu_cmd = b.addSystemCommand(&[_][]const u8{
             "qemu-system-aarch64",
@@ -297,7 +294,7 @@ pub fn build(b: *std.Build) !void {
             "2G",
             "-nographic",
         });
-    }  else if (microkit_board_option.? == .qemu_virt_riscv64) {
+    }  else if (microkit_board_option == .qemu_virt_riscv64) {
         qemu_cmd = b.addSystemCommand(&[_][]const u8{
             "qemu-system-riscv64",
             "-machine",


### PR DESCRIPTION
Doing `zig build` in the root of the repository no longer gives random errors. The main reason I'm making these changes is:
1. Using LazyPaths means handing relative paths (e.g SDK path) should be more reliable.
2. sDDF can be consumed as a package (I need this for sdfgen work)