### PR TITLE
ci: add close() to _TeeOut to remove ignored exception when python exits

### DIFF
--- a/ci/lib/backends/common.py
+++ b/ci/lib/backends/common.py
@@ -49,6 +49,7 @@ class _TeeOut:
             self.fileio.write(s)
 
     # fmt: off
+    def close(self): return self.stdout.close()
     def flush(self): ...
     def readable(self): return False
     def writable(self): return True


### PR DESCRIPTION
It would print out the following in *some* versions of Python.

    Exception ignored in: <_io.TextIOWrapper encoding='UTF-8'>
    AttributeError: '_TeeOut' object has no attribute 'close'

This is because we replace sys.stdout with our _TeeOut object and so then sys.stdout.close() called by python as it shuts down will fail.