### PR TITLE
.gitignore: ignore Vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ zig-out/
 .zig-cache/
 venv/
 __pycache__
+.*.sw*


### PR DESCRIPTION
The pattern is .\*.sw\*, as they are hidden and generated in order of .swp, .swo, etc