### PR TITLE
examples/echo_server: use the dwmac ethernet for the imx8mp (iotgate)

### DIFF
--- a/examples/echo_server/echo.mk
+++ b/examples/echo_server/echo.mk
@@ -62,8 +62,13 @@ else ifeq ($(strip $(MICROKIT_BOARD)), odroidc2)
 	SERIAL_DRIV_DIR := meson
 	TIMER_DRV_DIR := meson
 	CPU := cortex-a53
-else ifneq ($(filter $(strip $(MICROKIT_BOARD)),imx8mm_evk imx8mp_evk imx8mq_evk maaxboard),)
+else ifneq ($(filter $(strip $(MICROKIT_BOARD)),imx8mm_evk imx8mq_evk maaxboard),)
 	DRIV_DIR := imx
+	SERIAL_DRIV_DIR := imx
+	TIMER_DRV_DIR := imx
+	CPU := cortex-a53
+else ifeq ($(strip $(MICROKIT_BOARD)), imx8mp_evk)
+	DRIV_DIR := dwmac-5.10a
 	SERIAL_DRIV_DIR := imx
 	TIMER_DRV_DIR := imx
 	CPU := cortex-a53

--- a/examples/echo_server/meta.py
+++ b/examples/echo_server/meta.py
@@ -81,7 +81,7 @@ BOARDS: List[Board] = [
         paddr_top=0x70000000,
         serial="soc@0/bus@30800000/spba-bus@30800000/serial@30890000",
         timer="soc@0/bus@30000000/timer@302d0000",
-        ethernet="soc@0/bus@30800000/ethernet@30be0000",
+        ethernet="soc@0/bus@30800000/ethernet@30bf0000",
     ),
     Board(
         name="imx8mq_evk",


### PR DESCRIPTION
We recently(ish) changed our hardware setup so that the dwmac port is the one that can do DHCP.

If I do a `./ci/build.py $MICROKIT_SDK $(nproc) --examples echo_server` and then `/ci/examples/echo_server.py --boards imx8mp_evk --configs benchmark` this now runs successfully.

Fixes #452.