### PR TITLE
ci: don't pin to unstable nix

### DIFF
--- a/.github/workflows/design_doc.yaml
+++ b/.github/workflows/design_doc.yaml
@@ -21,9 +21,9 @@ jobs:
           path: docs/design/
           key: design-doc-${{ hashFiles('docs/design/**') }}
       - name: Setup Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          nix_path: nixpkgs=channel:nixos-25.05
       - name: Compile document
         run: |
           cd docs/design


### PR DESCRIPTION
Probably should just use the flake as a different shell for manual stuff but I don't have time for that right now.