### PR TITLE
cache.c: add case for x86_64

### DIFF
--- a/util/cache.c
+++ b/util/cache.c
@@ -44,9 +44,10 @@ void cache_clean_and_invalidate(unsigned long start, unsigned long end)
         asm volatile("dc civac, %0" : : "r"(vaddr));
     }
     asm volatile("dsb sy" ::: "memory");
-#elif defined(CONFIG_ARCH_RISCV)
+#elif defined(CONFIG_ARCH_RISCV) || defined(CONFIG_ARCH_X86_64)
     /* While not all RISC-V platforms are DMA cache-cohernet,
      * we assume we are targeting one that is and so there is nothing to do. */
+    /* x86 is DMA coherent so nothing to do. */
 #else
 #error "Unknown architecture for cache_clean_and_invalidate"
 #endif
@@ -69,9 +70,10 @@ void cache_clean(unsigned long start, unsigned long end)
         asm volatile("dc cvac, %0" : : "r"(vaddr));
     }
     asm volatile("dmb sy" ::: "memory");
-#elif defined(CONFIG_ARCH_RISCV)
+#elif defined(CONFIG_ARCH_RISCV) || defined(CONFIG_ARCH_X86_64)
     /* While not all RISC-V platforms are DMA cache-cohernet,
      * we assume we are targeting one that is and so there is nothing to do. */
+    /* x86 is DMA coherent so nothing to do. */
 #else
 #error "Unknown architecture for cache_clean"
 #endif


### PR DESCRIPTION
Most of our x86_64 patches are too in-progress to upstream but this one would make it easier for me to port libvmm since it's the only sDDF change I need to get the initial port done.