### PR TITLE
Fix serial deadlock

### DIFF
--- a/drivers/serial/arm/uart.c
+++ b/drivers/serial/arm/uart.c
@@ -48,8 +48,8 @@ static void tx_provide(void)
         transferred = true;
     }
 
-    /* If transmit fifo is full and there is data remaining to be sent, enable interrupt when fifo is no longer full */
-    if (uart_regs->fr & PL011_FR_TXFF && !serial_queue_empty(&tx_queue_handle, tx_queue_handle.queue->head)) {
+    /* If there is data remaining to be sent, enable interrupt when fifo is no longer full */
+    if (!serial_queue_empty(&tx_queue_handle, tx_queue_handle.queue->head)) {
         uart_regs->imsc |= PL011_IMSC_TX_INT;
     } else {
         uart_regs->imsc &= ~PL011_IMSC_TX_INT;

--- a/drivers/serial/imx/uart.c
+++ b/drivers/serial/imx/uart.c
@@ -49,8 +49,8 @@ static void tx_provide(void)
         transferred = true;
     }
 
-    /* If transmit fifo is full and there is data remaining to be sent, enable interrupt when fifo is no longer full */
-    if (uart_regs->ts & UART_TST_TX_FIFO_FULL && !serial_queue_empty(&tx_queue_handle, tx_queue_handle.queue->head)) {
+    /* If there is data remaining to be sent, enable interrupt when fifo is no longer full */
+    if (!serial_queue_empty(&tx_queue_handle, tx_queue_handle.queue->head)) {
         uart_regs->cr1 |= UART_CR1_TX_READY_INT;
     } else {
         uart_regs->cr1 &= ~UART_CR1_TX_READY_INT;

--- a/drivers/serial/meson/uart.c
+++ b/drivers/serial/meson/uart.c
@@ -80,8 +80,8 @@ static void tx_provide(void)
         transferred = true;
     }
 
-    /* If transmit fifo is full and there is data remaining to be sent, enable interrupt when fifo is no longer full */
-    if (uart_regs->sr & AML_UART_TX_FULL && !serial_queue_empty(&tx_queue_handle, tx_queue_handle.queue->head)) {
+    /* If there is data remaining to be sent, enable interrupt when fifo is no longer full */
+    if (!serial_queue_empty(&tx_queue_handle, tx_queue_handle.queue->head)) {
         uart_regs->cr |= AML_UART_TX_INT_EN;
     } else {
         uart_regs->cr &= ~AML_UART_TX_INT_EN;

--- a/drivers/serial/zynqmp/uart.c
+++ b/drivers/serial/zynqmp/uart.c
@@ -57,13 +57,10 @@ static void tx_provide(void)
         *REG_PTR(ZYNQMP_UART_ISR) = ZYNQMP_UART_IXR_TXEMPTY;
     }
 
-    /* If the TX FIFO becomes full... */
-    if (*REG_PTR(ZYNQMP_UART_SR) & ZYNQMP_UART_CHANNEL_STS_TXNFULL) {
-        /* ...and there is more work to be done, raise a TX FIFO empty interrupt */
-        if (!serial_queue_empty(&tx_queue_handle, tx_queue_handle.queue->head)) {
-            *REG_PTR(ZYNQMP_UART_IER) = ZYNQMP_UART_IXR_TXEMPTY;
-            waiting_for_tx_to_finish = true;
-        }
+    /* If there is more work to be done, raise a TX FIFO empty interrupt */
+    if (!serial_queue_empty(&tx_queue_handle, tx_queue_handle.queue->head)) {
+        *REG_PTR(ZYNQMP_UART_IER) = ZYNQMP_UART_IXR_TXEMPTY;
+        waiting_for_tx_to_finish = true;
     }
 
     if (transferred && serial_require_consumer_signal(&tx_queue_handle)) {

--- a/serial/components/virt_tx.c
+++ b/serial/components/virt_tx.c
@@ -92,10 +92,13 @@ bool process_tx_queue(uint32_t client)
 
     /* Not enough space to transmit string to virtualiser. Continue later */
     if (length > serial_queue_free(&tx_queue_handle_drv)) {
-        tx_pending_push(client);
-
         /* Request signal from the driver when data has been consumed */
         serial_request_consumer_signal(&tx_queue_handle_drv);
+    }
+
+    /* Re-check free space in case signal was missed */
+    if (length > serial_queue_free(&tx_queue_handle_drv)) {
+        tx_pending_push(client);
         return false;
     }
 


### PR DESCRIPTION
It was discovered under certain conditions (very fast printing for a long period of time) the serial Tx subsystem can deadlock.

This was due to a failure to handle a race condition with the setting of the `producer_signalled` flag in the serial Tx virtualiser. Although the virtualiser sets the flag, it fails to double check whether the driver has done work in the meantime and possibly failed to observe the change in value of the flag.

This PR fixes this issue by adding a line of code to the virtualiser to check if the driver queue becomes free after setting the flag - thus eliminating the possible deadlock that may occur if the driver frees the queue after the initial free check but before the flag value has been updated.

While investigating this deadlock I also noticed a potential issue with the uart drivers. Previously we only registered for TX FIFO available interrupts if there was data pending to send AND if the FIFO is full. The FIFO full check in unnecessary and may also potentially cause a deadlock if the FIFO becomes non-full in-between filling it and checking it. This PR also removes this check and ensures IRQs are always enabled if there is data pending to be sent.