### PR TITLE
serial: cleanup in virt_tx.c

### DIFF
--- a/serial/components/virt_tx.c
+++ b/serial/components/virt_tx.c
@@ -121,11 +121,7 @@ void tx_return(void)
     }
 
     uint32_t client;
-    // TODO: `= {false};` gets optimised into memset
-    bool notify_client[SDDF_SERIAL_MAX_CLIENTS];
-    for (int i = 0; i < SDDF_SERIAL_MAX_CLIENTS; i++) {
-        notify_client[i] = false;
-    }
+    bool notify_client[SDDF_SERIAL_MAX_CLIENTS] = { false };
     bool transferred = false;
     for (uint32_t req = 0; req < num_pending_tx; req++) {
         tx_pending_pop(&client);


### PR DESCRIPTION
Since ff996d3a886c31019e60af13798c3038d8688eb8 we no longer have to worry about memset not existing.