### PR TITLE
Use compiler builtins where possible

### DIFF
--- a/include/sddf/util/custom_libc/string.h
+++ b/include/sddf/util/custom_libc/string.h
@@ -5,12 +5,60 @@
 
 #include <stddef.h>
 
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin_memset)
+#define memset __builtin_memset
+#else
 void *memset(void *s, int c, size_t n);
+#endif
+
+#if __has_builtin(__builtin_memcmp)
+#define memcmp __builtin_memcmp
+#else
 int memcmp(const void *a, const void *b, size_t n);
+#endif
+
+#if __has_builtin(__builtin_memcpy)
+#define memcpy __builtin_memcpy
+#else
 void *memcpy(void *dest, const void *src, size_t n);
+#endif
+
+#if __has_builtin(__builtin_memmove)
+#define memmove __builtin_memmove
+#else
 void *memmove(void *dest, const void *src, size_t n);
+#endif
+
+#if __has_builtin(__builtin_strcat)
+#define strcat __builtin_strcat
+#else
 char *strcat(char *restrict dest, const char *restrict src);
+#endif
+
+#if __has_builtin(__builtin_strcmp)
+#define strcmp __builtin_strcmp
+#else
 int strcmp(const char *a, const char *b);
+#endif
+
+#if __has_builtin(__builtin_strncmp)
+#define strncmp __builtin_strncmp
+#else
 int strncmp(const char *a, const char *b, size_t n);
+#endif
+
+#if __has_builtin(__builtin_strcpy)
+#define strcpy __builtin_strcpy
+#else
 char *strcpy(char *restrict dest, const char *restrict src);
+#endif
+
+#if __has_builtin(__builtin_strlen)
+#define strlen __builtin_strlen
+#else
 size_t strlen(const char *s);
+#endif

--- a/util/custom_libc/libc.c
+++ b/util/custom_libc/libc.c
@@ -11,6 +11,7 @@ int atoi(const char *str)
     return sddf_atoi(str);
 }
 
+#undef strcat
 char *strcat(char *restrict dest, const char *restrict src)
 {
     char *to = dest;

--- a/util/custom_libc/riscv64/memcmp.c
+++ b/util/custom_libc/riscv64/memcmp.c
@@ -37,6 +37,7 @@ QUICKREF
 #include <string.h>
 #include "local.h"
 
+#undef memcmp
 int
 memcmp (const void *m1,
 	const void *m2,

--- a/util/custom_libc/riscv64/memcpy.c
+++ b/util/custom_libc/riscv64/memcpy.c
@@ -60,6 +60,7 @@ __libc_load_xlen (const void *src)
 }
 #endif
 
+#undef memcpy
 void *
 __inhibit_loop_to_libcall
 memcpy (void *__restrict aa, const void *__restrict bb, size_t n)

--- a/util/custom_libc/riscv64/memmove.c
+++ b/util/custom_libc/riscv64/memmove.c
@@ -92,6 +92,7 @@ __libc_memmove_bytewise_forward_copy (unsigned char *dst,
     }
 }
 
+#undef memmove
 void *__inhibit_loop_to_libcall
 memmove (void *dst_void, const void *src_void, size_t length)
 {

--- a/util/custom_libc/riscv64/strlen.c
+++ b/util/custom_libc/riscv64/strlen.c
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include "rv_string.h"
 
+#undef strlen
 size_t strlen(const char *str)
 {
   const char *start = str;

--- a/util/custom_libc/riscv64/strncmp.c
+++ b/util/custom_libc/riscv64/strncmp.c
@@ -38,6 +38,7 @@ QUICKREF
 #include <limits.h>
 #include "local.h"
 
+#undef strncmp
 int
 strncmp (const char *s1,
 	const char *s2,


### PR DESCRIPTION
For background, this is my understanding:
- We compile with `-ffreestanding` which implies `-fno-builtin`. Therefore the compiler will not substitute library calls with its builtin implementations
- With the `__builtin_` prefix we can attempt to invoke the builtin implementation directly, and if it can't be used the compiler will emit a library call anyway

This PR uses the preprocessor to replace library calls with the corresponding builtin (in a SDDF_CUSTOM_LIBC setting).

(Minor) issue: our vendored library code for RISC-V has some C implementations which include `string.h`, so we need to undefine the relevant macro to avoid a compiler error from trying to define a builtin function.