### PR TITLE
Add alternative names for ethernet driver elf files for systems that require more than one ethernet driver

### DIFF
--- a/drivers/network/dwmac-5.10a/eth_driver.mk
+++ b/drivers/network/dwmac-5.10a/eth_driver.mk
@@ -7,7 +7,7 @@
 # the Synopsys dwmac 5.10a NIC driver
 #
 # NOTES:
-#   Generates eth_driver.elf
+#   Generates eth_driver.elf (alternative unique name eth_driver_dwmac-5.10a.elf)
 #   Assumes libsddf_util_debug.a is in LIBS
 
 ETHERNET_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
@@ -18,11 +18,11 @@ ${CHECK_NETDRV_FLAGS_MD5}:
 	-rm -f .netdrv_cflags-*
 	touch $@
 
-eth_driver.elf: network/starfive/ethernet.o
+eth_driver.elf eth_driver_dwmac-5.10a.elf: network/dwmac-5.10a/ethernet.o
 	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
 
-network/starfive/ethernet.o: ${ETHERNET_DRIVER_DIR}ethernet.c ${CHECK_NETDRV_FLAGS}
-	mkdir -p network/starfive
+network/dwmac-5.10a/ethernet.o: ${ETHERNET_DRIVER_DIR}ethernet.c ${CHECK_NETDRV_FLAGS}
+	mkdir -p network/dwmac-5.10a
 	${CC} -c ${CFLAGS} ${CFLAGS_network} -I ${ETHERNET_DRIVER_DIR} -o $@ $<
 
--include starfive/ethernet.d
+-include dwmac-5.10a/ethernet.d

--- a/drivers/network/imx/eth_driver.mk
+++ b/drivers/network/imx/eth_driver.mk
@@ -7,7 +7,7 @@
 # the IMX8 NIC driver
 #
 # NOTES
-#  Generates eth_driver.elf
+#  Generates eth_driver.elf (alternative unique name eth_driver_imx.elf)
 #  Expects libsddf_util_debug.a to be in LIBS
 
 ETHERNET_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
@@ -17,7 +17,7 @@ ${CHECK_NETDRV_FLAGS_MD5}:
 	-rm -f .netdrv_cflags-*
 	touch $@
 
-eth_driver.elf: network/imx/ethernet.o
+eth_driver.elf eth_driver_imx.elf: network/imx/ethernet.o
 	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
 
 network/imx/ethernet.o: ${ETHERNET_DRIVER_DIR}/ethernet.c ${CHECK_NETDRV_FLAGS_MD5}

--- a/drivers/network/meson/eth_driver.mk
+++ b/drivers/network/meson/eth_driver.mk
@@ -7,7 +7,7 @@
 # the Amlogic NIC driver
 #
 # NOTES:
-#   Generates eth_driver.elf
+#  Generates eth_driver.elf (alternative unique name eth_driver_meson.elf)
 #   Assumes libsddf_util_debug.a is in LIBS
 
 ETHERNET_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
@@ -18,7 +18,7 @@ ${CHECK_NETDRV_FLAGS_MD5}:
 	-rm -f .netdrv_cflags-*
 	touch $@
 
-eth_driver.elf: network/meson/ethernet.o
+eth_driver.elf eth_driver_meson.elf: network/meson/ethernet.o
 	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
 
 network/meson/ethernet.o: ${ETHERNET_DRIVER_DIR}/ethernet.c ${CHECK_NETDRV_FLAGS_MD5}

--- a/drivers/network/virtio/eth_driver.mk
+++ b/drivers/network/virtio/eth_driver.mk
@@ -7,7 +7,7 @@
 # the VirtIO driver
 #
 # NOTES:
-#   Generates eth_driver.elf
+#  Generates eth_driver.elf (alternative unique name eth_driver_virtio.elf)
 #   Assumes libsddf_util_debug.a is in LIBS
 
 ETHERNET_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
@@ -18,7 +18,7 @@ ${CHECK_NETDRV_FLAGS_MD5}:
 	-rm -f .netdrv_cflags-*
 	touch $@
 
-eth_driver.elf: network/virtio/ethernet.o
+eth_driver.elf eth_driver_virtio.elf: network/virtio/ethernet.o
 	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
 
 network/virtio/ethernet.o: ${ETHERNET_DRIVER_DIR}/ethernet.c ${CHECK_NETDRV_FLAGS}


### PR DESCRIPTION
As in title. This is needed for the LionsOS Firewall system. If there is a more optimal way to achieve this, other solutions are welcomed.