### PR TITLE
Add more features and configuration options to lib sDDF LWIP

### DIFF
--- a/examples/echo_server/echo.c
+++ b/examples/echo_server/echo.c
@@ -88,7 +88,7 @@ void transmit(void)
     while (reprocess) {
         while (head != NULL && !net_queue_empty_free(&net_tx_handle)) {
             net_sddf_err_t err = sddf_lwip_transmit_pbuf(head);
-            if (err == SDDF_LWIP_ERR_PBUF) {
+            if (err == SDDF_LWIP_ERR_LARGE_PBUF) {
                 sddf_dprintf("LWIP|ERROR: attempted to send a packet of size %u > BUFFER SIZE %u\n", head->tot_len,
                              NET_BUFFER_SIZE);
             } else if (err != SDDF_LWIP_ERR_OK) {
@@ -130,8 +130,8 @@ void init(void)
                    net_config.tx.num_buffers);
     net_buffers_init(&net_tx_handle, 0);
 
-    sddf_lwip_init(&lib_sddf_lwip_config, &net_config, &timer_config, net_rx_handle, net_tx_handle, NULL,
-                   netif_status_callback, enqueue_pbufs);
+    sddf_lwip_init(&lib_sddf_lwip_config, &net_config, &timer_config, net_rx_handle, net_tx_handle, NULL, 
+                   NULL, netif_status_callback, enqueue_pbufs, NULL, NULL);
     set_timeout();
 
     setup_udp_socket();

--- a/examples/echo_server/echo.c
+++ b/examples/echo_server/echo.c
@@ -130,8 +130,8 @@ void init(void)
                    net_config.tx.num_buffers);
     net_buffers_init(&net_tx_handle, 0);
 
-    sddf_lwip_init(&lib_sddf_lwip_config, &net_config, &timer_config, net_rx_handle, net_tx_handle, NULL, 
-                   NULL, netif_status_callback, enqueue_pbufs, NULL, NULL);
+    sddf_lwip_init(&lib_sddf_lwip_config, &net_config, &timer_config, net_rx_handle, net_tx_handle, NULL, NULL,
+                   netif_status_callback, enqueue_pbufs, NULL, NULL);
     set_timeout();
 
     setup_udp_socket();

--- a/include/sddf/network/lib_sddf_lwip.h
+++ b/include/sddf/network/lib_sddf_lwip.h
@@ -20,12 +20,12 @@ typedef enum {
     /* No error, everything OK. */
     SDDF_LWIP_ERR_OK = 0,
     /* Pbuf too large for sDDF buffer. */
-    SDDF_LWIP_ERR_PBUF = -1,
+    SDDF_LWIP_ERR_LARGE_PBUF = -1,
+    /* Pbuf is NULL or from the wrong memory pool. */
+    SDDF_LWIP_ERR_INVALID_PBUF = -2,
     /* No buffers available. */
-    SDDF_LWIP_ERR_NO_BUF = -2,
-    /* Pbuf successfully enqueued to be sent later. */
-    SDDF_LWIP_ERR_ENQUEUED = -3,
-    /* Could not resolve error. */
+    SDDF_LWIP_ERR_NO_BUF = -3,
+    /* Unknown LWIP error. */
     SDDF_LWIP_ERR_UNHANDLED = -4
 } net_sddf_err_t;
 
@@ -36,6 +36,13 @@ typedef struct lib_sddf_lwip_config {
     region_resource_t pbuf_pool;
     uint64_t num_pbufs;
 } lib_sddf_lwip_config_t;
+
+/* Wrapper over custom_pbuf structure to keep track of buffer's offset into data
+region. */
+typedef struct pbuf_custom_offset {
+    struct pbuf_custom custom;
+    uint64_t offset;
+} pbuf_custom_offset_t;
 
 /**
  * Function type for output of sDDF LWIP errors.
@@ -56,58 +63,124 @@ typedef void (*sddf_lwip_netif_status_callback_fn)(char *ip_addr);
 typedef net_sddf_err_t (*sddf_lwip_handle_empty_tx_free_fn)(struct pbuf *p);
 
 /**
+ * Function type for checking whether the transmission of a pbuf should be
+ * intercepted and handled by the provided TX handle intercept function.
+ */
+typedef bool (*sddf_lwip_tx_intercept_condition_fn)(struct pbuf *p);
+
+/**
+ * Function type for handling the transmission of pbufs which satisfy the
+ * provided TX intercept condition function.
+ */
+typedef net_sddf_err_t (*sddf_lwip_tx_handle_intercept_fn)(struct pbuf *p);
+
+/**
+ * Allocate a pbuf from lib sDDF LWIP static pbuf pool.
+ *
+ * @return pointer to allocated pbuf or NULL if out of memory.
+ */
+pbuf_custom_offset_t *pbuf_pool_alloc(void);
+
+/**
+ * Free a pbuf allocated from lib sDDF LWIP static pbuf pool. WARNING: This
+ * function only checks if p is a valid pbuf pointer from the memory pool, not
+ * if it is currently allocated. Freeing a pbuf that is already free will cause
+ * pbufs to be permanently lost.
+ *
+ * @param p pbuf to free.
+ *
+ * @return SDDF_LWIP_ERR_OK pbuf freed succesfully.
+ * @return SDDF_LWIP_ERR_INVALID_PBUF pbuf is not part of lib sDDF LWIP static
+ * pbuf pool.
+ */
+net_sddf_err_t pbuf_pool_free(pbuf_custom_offset_t *pbuf);
+
+/**
  * Checks LWIP system timeouts. Should be invoked after every LWIP tick.
  */
 void sddf_lwip_process_timeout(void);
 
 /**
- * Transmits the provided pbuf through the sddf network system.
+ * Transmits the provided pbuf through the sddf network system. If there are no
+ * free sDDF buffers available, handle_empty_tx_free will be called with the
+ * pbuf, and the return value will be returned.
  *
  * @param p pbuf to be transmitted.
  *
- * @return If the pbuf is sent successfully, SDDF_LWIP_ERR_OK is returned and the
- * pbuf can safely be freed. If the pbuf is too large, SDDF_LWIP_ERR_PBUF is
- * returned. If there are no free sDDF buffers available,
- * handle_empty_tx_free will be called with the pbuf, and the return value
- * will be returned.
+ * @return SDDF_LWIP_ERR_OK pbuf was sent successfully.
+ * @return SDDF_LWIP_ERR_LARGE_PBUF pbuf is larger than sDDF net buffer.
+ * @return SDDF_LWIP_ERR_NO_BUF no available sDDF buffers, or lib sDDF LWIP does
+   not have Tx enabled.
+ * @return SDDF_LWIP_ERR_UNHANDLED unhandled LWIP error occured.
  */
 net_sddf_err_t sddf_lwip_transmit_pbuf(struct pbuf *p);
 
 /**
  * Handles the passing of incoming packets in sDDF buffers to LWIP. Must be
- * called to process the sDDF RX queue each time a notification is received
- * from the network virtualiser.
+ * called to process the sDDF RX queue each time a notification is received from
+ * the network virtualiser. If client is TX only calling this function has no
+ * effect.
  */
 void sddf_lwip_process_rx(void);
 
 /**
+ * Input a user provided pbuf into LWIPs network stack. User is responsible for
+ * freeing the pbuf in the case of failure.
+ *
+ * @param p initialised pbuf to input.
+ *
+ * @return SDDF_LWIP_ERR_OK pbuf was input successfully.
+ * @return SDDF_LWIP_ERR_INVALID_PBUF invalid pbuf pointer.
+ * @return SDDF_LWIP_ERR_UNHANDLED unhandled LWIP error occured.
+ */
+net_sddf_err_t sddf_lwip_input_pbuf(struct pbuf *p);
+
+/**
  * Handles the sending of notifications to the network RX and TX virtualisers.
  * Must be invoked at the end of each event handling loop and initialisation
- * to ensure outgoing buffers are processed by the virtualisers.
+ * to ensure enqueued buffers are processed by the virtualisers.
  */
 void sddf_lwip_maybe_notify(void);
 
 /**
- * Initialisation function for the sDDF LWIP library. Must be called prior
- * to using any other library functions.
+ * Initialisation function for the sDDF LWIP library. Must be called prior to
+ * using any other sDDF LWIP library functions.
  *
  * @param lib_sddf_lwip_config config structure for this library
  * @param net_config sDDF-Net config resource structure
  * @param timer_config sDDF-Timer config resource structure
- * @param rx_queue RX net queue handle data structure. Must be initialised
- * prior to being passed to this function.
- * @param tx_queue TX net queue handle data structure. Must be initialised
- * prior to being passed to this function.
- * @param err_output function pointer to optional user provided error
- * output function. Provide NULL to use default sddf_printf_.
- * @param netif_callback function pointer to optional user provided netif
- * status callback function. Provide NULL to use err_output to print client
- * MAC address and obtained IP address.
+ * @param rx_queue RX net queue handle data structure. If client is TX only, set
+ * capacity to 0.
+ * @param tx_queue TX net queue handle data structure.  If client is RX only,
+ * set capacity to 0.
+ * @param ip_addr IP address of client as a string if IP is fixed. Set to NULL
+ * if DHCP is required to obtain IP address. WARNING: If provided, ip_addr
+ * string must be '\0' terminated.
+ * @param err_output function pointer to optional user provided error output
+ * function. Provide NULL to use default sddf_printf_.
+ * @param netif_callback function pointer to optional user provided netif status
+ * callback function. Provide NULL to use err_output to print client MAC address
+ * and obtained IP address.
  * @param handle_empty_tx_free function pointer to optional user provided
  * handling function for no available sDDF TX buffers during sending of LWIP
  * pbuf. Provide NULL to leave unhandled.
+ * @param tx_intercept_condition function pointer to optional user provided TX
+ * interception check function. Allows users to intercept LWIP transmissions
+ * before they are enqueued in sDDF net TX queue. Return true to invoke TX
+ * intercept handling function.
+ * @param tx_handle_intercept function pointer to optional user provided TX
+ * intercept handling function. If TX intercept condition function returns true
+ * for a pbuf, the TX intercept handle function will be invoked to handle the
+ * transmission of the pbuf.
  */
-void sddf_lwip_init(lib_sddf_lwip_config_t *lib_sddf_lwip_config, net_client_config_t *net_config,
-                    timer_client_config_t *timer_config, net_queue_handle_t rx_queue, net_queue_handle_t tx_queue,
-                    sddf_lwip_err_output_fn err_output, sddf_lwip_netif_status_callback_fn netif_callback,
-                    sddf_lwip_handle_empty_tx_free_fn handle_empty_tx_free);
+void sddf_lwip_init(lib_sddf_lwip_config_t *lib_sddf_lwip_config,
+                    net_client_config_t *net_config,
+                    timer_client_config_t *timer_config,
+                    net_queue_handle_t rx_queue,
+                    net_queue_handle_t tx_queue,
+                    char *ip_addr,
+                    sddf_lwip_err_output_fn err_output,
+                    sddf_lwip_netif_status_callback_fn netif_callback,
+                    sddf_lwip_handle_empty_tx_free_fn handle_empty_tx_free,
+                    sddf_lwip_tx_intercept_condition_fn tx_intercept_condition,
+                    sddf_lwip_tx_handle_intercept_fn tx_handle_intercept);

--- a/include/sddf/network/lib_sddf_lwip.h
+++ b/include/sddf/network/lib_sddf_lwip.h
@@ -75,6 +75,13 @@ typedef bool (*sddf_lwip_tx_intercept_condition_fn)(struct pbuf *p);
 typedef net_sddf_err_t (*sddf_lwip_tx_handle_intercept_fn)(struct pbuf *p);
 
 /**
+ * Check whether the pbuf pool is empty.
+ *
+ * @return true if pbuf pool is empty, false otherwise.
+ */
+bool pbuf_pool_empty(void);
+
+/**
  * Allocate a pbuf from lib sDDF LWIP static pbuf pool.
  *
  * @return pointer to allocated pbuf or NULL if out of memory.

--- a/include/sddf/network/lib_sddf_lwip.h
+++ b/include/sddf/network/lib_sddf_lwip.h
@@ -173,13 +173,9 @@ void sddf_lwip_maybe_notify(void);
  * for a pbuf, the TX intercept handle function will be invoked to handle the
  * transmission of the pbuf.
  */
-void sddf_lwip_init(lib_sddf_lwip_config_t *lib_sddf_lwip_config,
-                    net_client_config_t *net_config,
-                    timer_client_config_t *timer_config,
-                    net_queue_handle_t rx_queue,
-                    net_queue_handle_t tx_queue,
-                    char *ip_addr,
-                    sddf_lwip_err_output_fn err_output,
+void sddf_lwip_init(lib_sddf_lwip_config_t *lib_sddf_lwip_config, net_client_config_t *net_config,
+                    timer_client_config_t *timer_config, net_queue_handle_t rx_queue, net_queue_handle_t tx_queue,
+                    char *ip_addr, sddf_lwip_err_output_fn err_output,
                     sddf_lwip_netif_status_callback_fn netif_callback,
                     sddf_lwip_handle_empty_tx_free_fn handle_empty_tx_free,
                     sddf_lwip_tx_intercept_condition_fn tx_intercept_condition,

--- a/network/lib_sddf_lwip/lib_sddf_lwip.c
+++ b/network/lib_sddf_lwip/lib_sddf_lwip.c
@@ -84,9 +84,7 @@ lwip_state_t lwip_state;
 sddf_state_t sddf_state;
 pbuf_pool_t pbuf_pool;
 
-static void pbuf_pool_init(void *mem,
-                           size_t mem_size,
-                           size_t pbuf_count)
+static void pbuf_pool_init(void *mem, size_t mem_size, size_t pbuf_count)
 {
     assert(mem != NULL);
     assert(pbuf_count != 0);
@@ -115,10 +113,9 @@ pbuf_custom_offset_t *pbuf_pool_alloc(void)
 
 net_sddf_err_t pbuf_pool_free(pbuf_custom_offset_t *pbuf)
 {
-    if (pbuf == NULL ||
-        pbuf < (pbuf_custom_offset_t *)pbuf_pool.pbufs ||
-        pbuf > (pbuf_custom_offset_t *)&pbuf_pool.pbufs[pbuf_pool.capacity] ||
-        ((uintptr_t)pbuf - (uintptr_t)pbuf_pool.pbufs % sizeof(pbuf_custom_offset_t))) {
+    if (pbuf == NULL || pbuf < (pbuf_custom_offset_t *)pbuf_pool.pbufs
+        || pbuf > (pbuf_custom_offset_t *)&pbuf_pool.pbufs[pbuf_pool.capacity]
+        || ((uintptr_t)pbuf - (uintptr_t)pbuf_pool.pbufs % sizeof(pbuf_custom_offset_t))) {
         return SDDF_LWIP_ERR_INVALID_PBUF;
     }
 
@@ -271,8 +268,7 @@ static void interface_free_buffer(struct pbuf *p)
  *
  * @return the newly created pbuf. Can be cast to pbuf_custom.
  */
-static struct pbuf *create_interface_buffer(uint64_t offset,
-                                            size_t length)
+static struct pbuf *create_interface_buffer(uint64_t offset, size_t length)
 {
     /* Client must have RX enabled */
     if (!sddf_state.rx_queue.capacity) {
@@ -300,8 +296,7 @@ static struct pbuf *create_interface_buffer(uint64_t offset,
  * sddf buffers available, handle_empty_tx_free will be called with the pbuf,
  * and the equivalent lwip error will be returned.
  */
-static err_t lwip_eth_send(struct netif *netif,
-                           struct pbuf *p)
+static err_t lwip_eth_send(struct netif *netif, struct pbuf *p)
 {
     if (p->tot_len > NET_BUFFER_SIZE) {
         lwip_state.err_output("LWIP|ERROR: attempted to send a packet of size %u > BUFFER SIZE %u\n", p->tot_len,
@@ -427,13 +422,9 @@ static void netif_status_callback(struct netif *netif)
     }
 }
 
-void sddf_lwip_init(lib_sddf_lwip_config_t *lib_sddf_lwip_config,
-                    net_client_config_t *net_config,
-                    timer_client_config_t *timer_config,
-                    net_queue_handle_t rx_queue,
-                    net_queue_handle_t tx_queue,
-                    char *ip_string,
-                    sddf_lwip_err_output_fn err_output,
+void sddf_lwip_init(lib_sddf_lwip_config_t *lib_sddf_lwip_config, net_client_config_t *net_config,
+                    timer_client_config_t *timer_config, net_queue_handle_t rx_queue, net_queue_handle_t tx_queue,
+                    char *ip_string, sddf_lwip_err_output_fn err_output,
                     sddf_lwip_netif_status_callback_fn netif_callback,
                     sddf_lwip_handle_empty_tx_free_fn handle_empty_tx_free,
                     sddf_lwip_tx_intercept_condition_fn tx_intercept_condition,
@@ -469,8 +460,7 @@ void sddf_lwip_init(lib_sddf_lwip_config_t *lib_sddf_lwip_config,
                                                                      : handle_empty_tx_free;
     lwip_state.tx_intercept_condition = (tx_intercept_condition == NULL) ? tx_intercept_condition_default
                                                                          : tx_intercept_condition;
-    lwip_state.tx_handle_intercept = (tx_handle_intercept == NULL) ? tx_handle_intercept_default
-                                                                         : tx_handle_intercept;
+    lwip_state.tx_handle_intercept = (tx_handle_intercept == NULL) ? tx_handle_intercept_default : tx_handle_intercept;
 
     lwip_init();
 

--- a/network/lib_sddf_lwip/lib_sddf_lwip.c
+++ b/network/lib_sddf_lwip/lib_sddf_lwip.c
@@ -9,6 +9,7 @@
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
 #include <sddf/network/lib_sddf_lwip.h>
+#include <sddf/network/constants.h>
 #include <sddf/network/queue.h>
 #include <sddf/network/util.h>
 #include <sddf/timer/client.h>
@@ -23,19 +24,29 @@
 #include "lwip/timeouts.h"
 #include "lwip/dhcp.h"
 
+/* Number of characters needed to store string of longest IPV4 address */
+#define SDDF_LWIP_IPV4_ADDR_STRLEN 16
+
 static char SDDF_LIB_SDDF_LWIP_MAGIC[SDDF_LIB_SDDF_LWIP_MAGIC_LEN] = { 's', 'D', 'D', 'F', 0x8 };
 
 typedef struct lwip_state {
     /* LWIP network interface struct. */
     struct netif netif;
+    /* IP address of client as a string */
+    char ip_string[SDDF_LWIP_IPV4_ADDR_STRLEN];
     /* MAC address of client. */
-    uint8_t mac[6];
+    uint8_t mac[ETH_HWADDR_LEN];
     /* Output function used to print error messages. */
     sddf_lwip_err_output_fn err_output;
     /* Callback function to be invoked when ip address is obtained. */
     sddf_lwip_netif_status_callback_fn netif_callback;
     /* Function that optionally handles when no free tx buffers available. */
     sddf_lwip_handle_empty_tx_free_fn handle_empty_tx_free;
+    /* Optional function that checks if the transmission of a pbuf should be
+    handled using the custom intercept handling function */
+    sddf_lwip_tx_intercept_condition_fn tx_intercept_condition;
+    /* Optional TX handling function to handle the transmission of intercepted pbufs separately */
+    sddf_lwip_tx_handle_intercept_fn tx_handle_intercept;
 } lwip_state_t;
 
 typedef struct sddf_state {
@@ -59,12 +70,6 @@ typedef struct sddf_state {
     sddf_channel timer_ch;
 } sddf_state_t;
 
-/* Wrapper over custom_pbuf structure to keep track of buffer's offset into data region. */
-typedef struct pbuf_custom_offset {
-    struct pbuf_custom custom;
-    uint64_t offset;
-} pbuf_custom_offset_t;
-
 typedef struct pbuf_pool {
     union {
         pbuf_custom_offset_t pbuf;
@@ -79,49 +84,48 @@ lwip_state_t lwip_state;
 sddf_state_t sddf_state;
 pbuf_pool_t pbuf_pool;
 
-pbuf_pool_t pbuf_pool_init(void *mem, size_t mem_size, size_t pbuf_count)
+static void pbuf_pool_init(void *mem,
+                           size_t mem_size,
+                           size_t pbuf_count)
 {
     assert(mem != NULL);
     assert(pbuf_count != 0);
     assert(pbuf_count <= mem_size / sizeof(pbuf_custom_offset_t));
 
-    pbuf_pool_t pool = {
-        .pbufs = mem,
-        .first_free = 0,
-        .capacity = pbuf_count,
-    };
+    pbuf_pool.pbufs = mem;
+    pbuf_pool.first_free = 0;
+    pbuf_pool.capacity = pbuf_count;
 
     for (size_t i = 0; i < pbuf_count - 1; i++) {
-        pool.pbufs[i].next_free = i + 1;
+        pbuf_pool.pbufs[i].next_free = i + 1;
     }
-    pool.pbufs[pbuf_count - 1].next_free = SIZE_MAX;
-
-    return pool;
+    pbuf_pool.pbufs[pbuf_count - 1].next_free = SIZE_MAX;
 }
 
-pbuf_custom_offset_t *pbuf_pool_alloc(pbuf_pool_t *pool)
+pbuf_custom_offset_t *pbuf_pool_alloc(void)
 {
-    assert(pool != NULL);
-
-    if (pool->first_free == SIZE_MAX) {
+    if (pbuf_pool.first_free == SIZE_MAX) {
         return NULL;
     }
 
-    size_t first_free = pool->first_free;
-    pool->first_free = pool->pbufs[first_free].next_free;
-    return &pool->pbufs[first_free].pbuf;
+    size_t first_free = pbuf_pool.first_free;
+    pbuf_pool.first_free = pbuf_pool.pbufs[first_free].next_free;
+    return &pbuf_pool.pbufs[first_free].pbuf;
 }
 
-void pbuf_pool_free(pbuf_pool_t *pool, pbuf_custom_offset_t *pbuf)
+net_sddf_err_t pbuf_pool_free(pbuf_custom_offset_t *pbuf)
 {
-    assert(pool != NULL);
-    assert(pbuf != NULL);
-    assert((pbuf_custom_offset_t *)pool->pbufs <= pbuf);
-    assert(pbuf < (pbuf_custom_offset_t *)&pool->pbufs[pool->capacity]);
+    if (pbuf == NULL ||
+        pbuf < (pbuf_custom_offset_t *)pbuf_pool.pbufs ||
+        pbuf > (pbuf_custom_offset_t *)&pbuf_pool.pbufs[pbuf_pool.capacity] ||
+        ((uintptr_t)pbuf - (uintptr_t)pbuf_pool.pbufs % sizeof(pbuf_custom_offset_t))) {
+        return SDDF_LWIP_ERR_INVALID_PBUF;
+    }
 
-    size_t idx = pbuf - (pbuf_custom_offset_t *)pool->pbufs;
-    pool->pbufs[idx].next_free = pool->first_free;
-    pool->first_free = idx;
+    size_t idx = pbuf - (pbuf_custom_offset_t *)pbuf_pool.pbufs;
+    pbuf_pool.pbufs[idx].next_free = pbuf_pool.first_free;
+    pbuf_pool.first_free = idx;
+    return SDDF_LWIP_ERR_OK;
 }
 
 /**
@@ -136,16 +140,36 @@ static err_t sddf_err_to_lwip_err(net_sddf_err_t sddf_err)
     switch (sddf_err) {
     case SDDF_LWIP_ERR_OK:
         return ERR_OK;
-    case SDDF_LWIP_ERR_PBUF:
+    case SDDF_LWIP_ERR_LARGE_PBUF:
+        return ERR_BUF;
+    case SDDF_LWIP_ERR_INVALID_PBUF:
         return ERR_BUF;
     case SDDF_LWIP_ERR_NO_BUF:
         return ERR_MEM;
-    case SDDF_LWIP_ERR_ENQUEUED:
-        return ERR_OK;
     case SDDF_LWIP_ERR_UNHANDLED:
         return ERR_MEM;
     }
     return ERR_ARG;
+}
+
+/**
+ * Helper function to convert lwip errors to sddf errors.
+ *
+ * @param err lwip error.
+ *
+ * @return Equivalent sddf error.
+ */
+static net_sddf_err_t lwip_err_to_sddf_err(err_t err)
+{
+    switch (err) {
+    case ERR_OK:
+        return SDDF_LWIP_ERR_OK;
+    case ERR_BUF:
+        return SDDF_LWIP_ERR_LARGE_PBUF;
+    case ERR_MEM:
+        return SDDF_LWIP_ERR_NO_BUF;
+    }
+    return SDDF_LWIP_ERR_UNHANDLED;
 }
 
 /**
@@ -171,7 +195,32 @@ static void netif_status_callback_default(char *ip_addr)
  *
  * @return Simply returns the sddf error indicating nothing was done.
  */
-static net_sddf_err_t handle_empty_tx_free_default(struct pbuf *p)
+static inline net_sddf_err_t handle_empty_tx_free_default(struct pbuf *p)
+{
+    return SDDF_LWIP_ERR_UNHANDLED;
+}
+
+/**
+ * Default TX intercept condition checking function. Returns false for all pbufs
+ * indicating that all pbufs should be transmitted using sDDF net queues.
+ *
+ * @param p pbuf that could not be sent due to queue being empty.
+ *
+ * @return false.
+ */
+static inline bool tx_intercept_condition_default(struct pbuf *p)
+{
+    return false;
+}
+
+/**
+ * Default TX intercept handling function. Should not be invoked.
+ *
+ * @param p pbuf that could not be sent due to queue being empty.
+ *
+ * @return Simply returns the sddf error indicating nothing was done.
+ */
+static inline net_sddf_err_t tx_handle_intercept_default(struct pbuf *p)
 {
     return SDDF_LWIP_ERR_UNHANDLED;
 }
@@ -179,23 +228,29 @@ static net_sddf_err_t handle_empty_tx_free_default(struct pbuf *p)
 /**
  * Returns current time from the timer.
  */
-uint32_t sys_now(void)
+inline uint32_t sys_now(void)
 {
     return sddf_timer_time_now(sddf_state.timer_ch) / NS_IN_MS;
 }
 
-void sddf_lwip_process_timeout()
+void sddf_lwip_process_timeout(void)
 {
     sys_check_timeouts();
 }
 
 /**
- * Free a pbuf. This also returns the underlying sddf buffer to the receive free ring.
+ * Free a pbuf. This also returns the underlying sddf buffer to the receive free
+ * ring. No effect for TX only clients.
  *
  * @param p pbuf to free.
  */
 static void interface_free_buffer(struct pbuf *p)
 {
+    /* Client must have RX enabled */
+    if (!sddf_state.rx_queue.capacity) {
+        return;
+    }
+
     SYS_ARCH_DECL_PROTECT(old_level);
     pbuf_custom_offset_t *custom_pbuf_offset = (pbuf_custom_offset_t *)p;
     SYS_ARCH_PROTECT(old_level);
@@ -203,21 +258,28 @@ static void interface_free_buffer(struct pbuf *p)
     int err = net_enqueue_free(&(sddf_state.rx_queue), buffer);
     assert(!err);
     sddf_state.notify_rx = true;
-    pbuf_pool_free(&pbuf_pool, custom_pbuf_offset);
+    pbuf_pool_free(custom_pbuf_offset);
     SYS_ARCH_UNPROTECT(old_level);
 }
 
 /**
- * Create a pbuf structure to pass to the network interface.
+ * Create a pbuf structure to pass to the network interface. Always returns NULL
+ * for TX only clients.
  *
  * @param offset offset into the data region of the buffer to be passed.
  * @param length length of data.
  *
  * @return the newly created pbuf. Can be cast to pbuf_custom.
  */
-static struct pbuf *create_interface_buffer(uint64_t offset, size_t length)
+static struct pbuf *create_interface_buffer(uint64_t offset,
+                                            size_t length)
 {
-    pbuf_custom_offset_t *custom_pbuf_offset = (pbuf_custom_offset_t *)pbuf_pool_alloc(&pbuf_pool);
+    /* Client must have RX enabled */
+    if (!sddf_state.rx_queue.capacity) {
+        return NULL;
+    }
+
+    pbuf_custom_offset_t *custom_pbuf_offset = pbuf_pool_alloc();
     custom_pbuf_offset->offset = offset;
     custom_pbuf_offset->custom.custom_free_function = interface_free_buffer;
 
@@ -227,6 +289,8 @@ static struct pbuf *create_interface_buffer(uint64_t offset, size_t length)
 
 /**
  * Copy a pbuf into an sddf buffer and insert it into the transmit active queue.
+ * If client is RX only, and transmission is not intercepted, this function will
+ * always return the ERR_MEM error.
  *
  * @param netif lwip network interface state.
  * @param p pbuf to be transmitted.
@@ -236,11 +300,22 @@ static struct pbuf *create_interface_buffer(uint64_t offset, size_t length)
  * sddf buffers available, handle_empty_tx_free will be called with the pbuf,
  * and the equivalent lwip error will be returned.
  */
-static err_t lwip_eth_send(struct netif *netif, struct pbuf *p)
+static err_t lwip_eth_send(struct netif *netif,
+                           struct pbuf *p)
 {
     if (p->tot_len > NET_BUFFER_SIZE) {
         lwip_state.err_output("LWIP|ERROR: attempted to send a packet of size %u > BUFFER SIZE %u\n", p->tot_len,
                               NET_BUFFER_SIZE);
+        return ERR_BUF;
+    }
+
+    /* Allow user to intercept packets before transmission */
+    if (lwip_state.tx_intercept_condition(p)) {
+        return sddf_err_to_lwip_err(lwip_state.tx_handle_intercept(p));
+    }
+
+    /* Client must have TX enabled */
+    if (!sddf_state.tx_queue.capacity) {
         return ERR_MEM;
     }
 
@@ -270,24 +345,17 @@ static err_t lwip_eth_send(struct netif *netif, struct pbuf *p)
 
 net_sddf_err_t sddf_lwip_transmit_pbuf(struct pbuf *p)
 {
-    if (p->tot_len > NET_BUFFER_SIZE) {
-        lwip_state.err_output("LWIP|ERROR: attempted to send a packet of size %u > BUFFER SIZE %u\n", p->tot_len,
-                              NET_BUFFER_SIZE);
-        return SDDF_LWIP_ERR_PBUF;
-    }
 
-    if (net_queue_empty_free(&sddf_state.tx_queue)) {
-        return lwip_state.handle_empty_tx_free(p);
-    }
-
-    err_t err = lwip_eth_send(&lwip_state.netif, p);
-    assert(!err);
-
-    return SDDF_LWIP_ERR_OK;
+    return lwip_err_to_sddf_err(lwip_eth_send(&lwip_state.netif, p));
 }
 
 void sddf_lwip_process_rx(void)
 {
+    /* Client must have RX enabled */
+    if (!sddf_state.rx_queue.capacity) {
+        return;
+    }
+
     bool reprocess = true;
     while (reprocess) {
         while (!net_queue_empty_active(&sddf_state.rx_queue)) {
@@ -313,6 +381,20 @@ void sddf_lwip_process_rx(void)
     }
 }
 
+net_sddf_err_t sddf_lwip_input_pbuf(struct pbuf *p)
+{
+    if (p == NULL) {
+        return SDDF_LWIP_ERR_INVALID_PBUF;
+    }
+
+    err_t err = lwip_state.netif.input(p, &lwip_state.netif);
+    if (err != ERR_OK) {
+        lwip_state.err_output("LWIP|ERROR: unknown error inputting pbuf into network stack\n");
+    }
+
+    return lwip_err_to_sddf_err(err);
+}
+
 /**
  * Initialise the network interface data structure.
  *
@@ -320,11 +402,7 @@ void sddf_lwip_process_rx(void)
  */
 static err_t ethernet_init(struct netif *netif)
 {
-    if (netif->state == NULL) {
-        return ERR_ARG;
-    }
-
-    memcpy(netif->hwaddr, lwip_state.mac, 6);
+    memcpy(netif->hwaddr, lwip_state.mac, ETH_HWADDR_LEN);
     netif->mtu = SDDF_LWIP_ETHER_MTU;
     netif->hwaddr_len = ETHARP_HWADDR_LEN;
     netif->output = etharp_output;
@@ -349,10 +427,17 @@ static void netif_status_callback(struct netif *netif)
     }
 }
 
-void sddf_lwip_init(lib_sddf_lwip_config_t *lib_sddf_lwip_config, net_client_config_t *net_config,
-                    timer_client_config_t *timer_config, net_queue_handle_t rx_queue, net_queue_handle_t tx_queue,
-                    sddf_lwip_err_output_fn err_output, sddf_lwip_netif_status_callback_fn netif_callback,
-                    sddf_lwip_handle_empty_tx_free_fn handle_empty_tx_free)
+void sddf_lwip_init(lib_sddf_lwip_config_t *lib_sddf_lwip_config,
+                    net_client_config_t *net_config,
+                    timer_client_config_t *timer_config,
+                    net_queue_handle_t rx_queue,
+                    net_queue_handle_t tx_queue,
+                    char *ip_string,
+                    sddf_lwip_err_output_fn err_output,
+                    sddf_lwip_netif_status_callback_fn netif_callback,
+                    sddf_lwip_handle_empty_tx_free_fn handle_empty_tx_free,
+                    sddf_lwip_tx_intercept_condition_fn tx_intercept_condition,
+                    sddf_lwip_tx_handle_intercept_fn tx_handle_intercept)
 {
     char *magic = (char *)lib_sddf_lwip_config;
     for (int i = 0; i < SDDF_LIB_SDDF_LWIP_MAGIC_LEN; i++) {
@@ -372,27 +457,36 @@ void sddf_lwip_init(lib_sddf_lwip_config_t *lib_sddf_lwip_config, net_client_con
     sddf_state.timer_ch = timer_config->driver_id;
 
     /* Initialise lwip state */
-    memcpy(lwip_state.mac, net_config->mac_addr, 6);
+    if (ip_string) {
+        strcpy(lwip_state.ip_string, ip_string);
+    } else {
+        strcpy(lwip_state.ip_string, "0.0.0.0");
+    }
+    memcpy(lwip_state.mac, net_config->mac_addr, ETH_HWADDR_LEN);
     lwip_state.err_output = (err_output == NULL) ? sddf_printf_ : err_output;
     lwip_state.netif_callback = (netif_callback == NULL) ? netif_status_callback_default : netif_callback;
     lwip_state.handle_empty_tx_free = (handle_empty_tx_free == NULL) ? handle_empty_tx_free_default
                                                                      : handle_empty_tx_free;
+    lwip_state.tx_intercept_condition = (tx_intercept_condition == NULL) ? tx_intercept_condition_default
+                                                                         : tx_intercept_condition;
+    lwip_state.tx_handle_intercept = (tx_handle_intercept == NULL) ? tx_handle_intercept_default
+                                                                         : tx_handle_intercept;
 
     lwip_init();
 
-    pbuf_pool = pbuf_pool_init(lib_config.pbuf_pool.vaddr, lib_config.pbuf_pool.size, lib_config.num_pbufs);
+    pbuf_pool_init(lib_config.pbuf_pool.vaddr, lib_config.pbuf_pool.size, lib_config.num_pbufs);
 
     /* Set dummy IP configuration values to get lwIP bootstrapped */
     struct ip4_addr netmask, ipaddr, gw, multicast;
     ipaddr_aton("0.0.0.0", &gw);
-    ipaddr_aton("0.0.0.0", &ipaddr);
+    ipaddr_aton(lwip_state.ip_string, &ipaddr);
     ipaddr_aton("0.0.0.0", &multicast);
     ipaddr_aton("255.255.255.0", &netmask);
 
     lwip_state.netif.name[0] = 'e';
     lwip_state.netif.name[1] = '0';
 
-    if (!netif_add(&(lwip_state.netif), &ipaddr, &netmask, &gw, (void *)&lwip_state, ethernet_init, ethernet_input)) {
+    if (!netif_add(&(lwip_state.netif), &ipaddr, &netmask, &gw, NULL, ethernet_init, ethernet_input)) {
         lwip_state.err_output("LWIP|ERROR: Netif add returned NULL\n");
     }
 
@@ -400,14 +494,16 @@ void sddf_lwip_init(lib_sddf_lwip_config_t *lib_sddf_lwip_config, net_client_con
     netif_set_status_callback(&(lwip_state.netif), netif_status_callback);
     netif_set_up(&(lwip_state.netif));
 
-    if (dhcp_start(&(lwip_state.netif))) {
-        lwip_state.err_output("LWIP|ERROR: failed to start DHCP negotiation\n");
+    if (!ip_string) {
+        if (dhcp_start(&(lwip_state.netif))) {
+            lwip_state.err_output("LWIP|ERROR: failed to start DHCP negotiation\n");
+        }
     }
 }
 
-void sddf_lwip_maybe_notify()
+void sddf_lwip_maybe_notify(void)
 {
-    if (sddf_state.notify_rx && net_require_signal_free(&sddf_state.rx_queue)) {
+    if (sddf_state.rx_queue.capacity && sddf_state.notify_rx && net_require_signal_free(&sddf_state.rx_queue)) {
         net_cancel_signal_free(&sddf_state.rx_queue);
         sddf_state.notify_rx = false;
         sddf_channel curr = sddf_deferred_notify_curr();
@@ -418,7 +514,7 @@ void sddf_lwip_maybe_notify()
         }
     }
 
-    if (sddf_state.notify_tx && net_require_signal_active(&sddf_state.tx_queue)) {
+    if (sddf_state.tx_queue.capacity && sddf_state.notify_tx && net_require_signal_active(&sddf_state.tx_queue)) {
         net_cancel_signal_active(&sddf_state.tx_queue);
         sddf_state.notify_tx = false;
         sddf_channel curr = sddf_deferred_notify_curr();


### PR DESCRIPTION
In order to use lib sDDF LWIP in the Micropython webserver component in the LionsOS Firewall system, a number of additional features/configuration options were needed. This PR implements the following:
- Make the `pbuf` pool available to use by the client. This allows clients to allocate and free `pbuf`s to input buffers into the LWIP stack. Previously this was all handled by the `sddf_lwip_process_rx` function which processed the net queue. The firewall receives packets from the routing component which uses a firewall queue which has a slightly different interface to a net queue, thus processing must be implemented separately.
- Similarly to above, lib sDDF LWIP now supports inserting a pbuf into the LWIP network stack directly.
- Allow packets to be intercepted in between LWIP transmission and insertion into an sDDF queue. Since in the firewall we catch any LWIP ARP packets before they are transmitted and instead pass the request to the ARP requester, we needed a way to intercept certain outgoing packets and handle them separately.
- Add support for Rx or Tx only clients. If a client is one way only, lib sDDF LWIP will now not attempt to signal or enqueue in the direction that is not supported. This is needed for the Firewall since the webserver is a transmit only net client.
- Add support for clients to have a fixed IP address, and therefore not require DHCP.