### PR TITLE
ci: add macOS run that uses Nix

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -70,6 +70,19 @@ jobs:
           path: ci_build/**/loader.img
           if-no-files-found: error
 
+  build_macos_arm64_nix:
+    name: Build (macOS ARM64 Nix)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v27
+      - name: Get Nix dependencies
+        run: nix develop -c bash -c 'echo Hello World'
+      - name: Build examples
+        run: nix develop --ignore-environment -c bash -c 'CI=1 ./ci/build.py $MICROKIT_SDK $(nproc)'
+
   build_macos_arm64:
     name: Build (macOS ARM64)
     runs-on: macos-14


### PR DESCRIPTION
Plan is to make this runner self-hosted so we get quicker feedback on whether CI passes. That runner won't have to continously install dependencies unlike the other runner and also has more cores available.