### PR TITLE
agnostic: Update network, serial and timer classes to use OS agnostic wrappers

### DIFF
--- a/drivers/network/dwmac-5.10a/ethernet.c
+++ b/drivers/network/dwmac-5.10a/ethernet.c
@@ -5,7 +5,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/resources/device.h>
 #include <sddf/network/queue.h>
 #include <sddf/network/config.h>
@@ -145,7 +145,7 @@ static void rx_return(void)
 
     if (packets_transferred && net_require_signal_active(&rx_queue)) {
         net_cancel_signal_active(&rx_queue);
-        microkit_notify(config.virt_rx.id);
+        sddf_notify(config.virt_rx.id);
     }
 }
 
@@ -209,7 +209,7 @@ static void tx_return(void)
 
     if (enqueued && net_require_signal_free(&tx_queue)) {
         net_cancel_signal_free(&tx_queue);
-        microkit_notify(config.virt_tx.id);
+        sddf_notify(config.virt_tx.id);
     }
 }
 
@@ -411,7 +411,7 @@ void init(void)
     assert(TX_COUNT * sizeof(struct descriptor) <= device_resources.regions[2].region.size);
 
     /* Ack any IRQs that were delivered before the driver started. */
-    microkit_irq_ack(device_resources.irqs[0].id);
+    sddf_irq_ack(device_resources.irqs[0].id);
 
     eth_regs = (uintptr_t)device_resources.regions[0].region.vaddr;
 
@@ -451,14 +451,14 @@ void init(void)
                    config.virt_tx.num_buffers);
     eth_setup();
 
-    microkit_irq_ack(device_resources.irqs[0].id);
+    sddf_irq_ack(device_resources.irqs[0].id);
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     if (ch == device_resources.irqs[0].id) {
         handle_irq();
-        microkit_deferred_irq_ack(ch);
+        sddf_deferred_irq_ack(ch);
     } else if (ch == config.virt_rx.id) {
         rx_provide();
     } else if (ch == config.virt_tx.id) {

--- a/drivers/network/imx/ethernet.c
+++ b/drivers/network/imx/ethernet.c
@@ -326,7 +326,7 @@ void notified(sddf_channel ch)
         handle_irq();
         /*
          * Delay calling into the kernel to ack the IRQ until the next loop
-         * in the microkit/sddf event handler loop.
+         * in the event handler loop.
          */
         sddf_deferred_irq_ack(ch);
     } else if (ch == config.virt_rx.id) {

--- a/drivers/network/meson/ethernet.c
+++ b/drivers/network/meson/ethernet.c
@@ -5,7 +5,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/resources/device.h>
 #include <sddf/network/queue.h>
 #include <sddf/network/config.h>
@@ -140,7 +140,7 @@ static void rx_return(void)
 
     if (packets_transferred && net_require_signal_active(&rx_queue)) {
         net_cancel_signal_active(&rx_queue);
-        microkit_notify(config.virt_rx.id);
+        sddf_notify(config.virt_rx.id);
     }
 }
 
@@ -197,7 +197,7 @@ static void tx_return(void)
 
     if (enqueued && net_require_signal_free(&tx_queue)) {
         net_cancel_signal_free(&tx_queue);
-        microkit_notify(config.virt_tx.id);
+        sddf_notify(config.virt_tx.id);
     }
 }
 
@@ -282,7 +282,7 @@ void init(void)
     assert(TX_COUNT * sizeof(struct descriptor) <= device_resources.regions[2].region.size);
 
     /* Ack any IRQs that were delivered before the driver started. */
-    microkit_irq_ack(device_resources.irqs[0].id);
+    sddf_irq_ack(device_resources.irqs[0].id);
 
     eth_setup();
 
@@ -305,11 +305,11 @@ void init(void)
     eth_dma->opmode |= TXSTART | RXSTART;
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     if (ch == device_resources.irqs[0].id) {
         handle_irq();
-        microkit_deferred_irq_ack(ch);
+        sddf_deferred_irq_ack(ch);
     } else if (ch == config.virt_rx.id) {
         rx_provide();
     } else if (ch == config.virt_tx.id) {

--- a/drivers/serial/arm/uart.c
+++ b/drivers/serial/arm/uart.c
@@ -5,7 +5,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/util/printf.h>
 #include <sddf/resources/device.h>
 #include <sddf/serial/config.h>
@@ -57,7 +57,7 @@ static void tx_provide(void)
 
     if (transferred && serial_require_consumer_signal(&tx_queue_handle)) {
         serial_cancel_consumer_signal(&tx_queue_handle);
-        microkit_notify(config.tx.id);
+        sddf_notify(config.tx.id);
     }
 }
 
@@ -87,7 +87,7 @@ static void rx_return(void)
     }
 
     if (enqueued) {
-        microkit_notify(config.rx.id);
+        sddf_notify(config.rx.id);
     }
 }
 
@@ -158,7 +158,7 @@ void init(void)
     assert(device_resources.num_regions == 1);
 
     /* Ack any IRQs that were delivered before the driver started. */
-    microkit_irq_ack(device_resources.irqs[0].id);
+    sddf_irq_ack(device_resources.irqs[0].id);
 
     uart_regs = device_resources.regions[0].region.vaddr;
 
@@ -170,11 +170,11 @@ void init(void)
     serial_queue_init(&tx_queue_handle, config.tx.queue.vaddr, config.tx.data.size, config.tx.data.vaddr);
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     if (ch == device_resources.irqs[0].id) {
         handle_irq();
-        microkit_deferred_irq_ack(ch);
+        sddf_deferred_irq_ack(ch);
     } else if (ch == config.tx.id) {
         tx_provide();
     } else if (ch == config.rx.id) {

--- a/drivers/serial/imx/uart.c
+++ b/drivers/serial/imx/uart.c
@@ -4,7 +4,7 @@
  */
 
 #include "sddf/util/util.h"
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/resources/device.h>
 #include <sddf/util/printf.h>
 #include <sddf/serial/config.h>
@@ -58,7 +58,7 @@ static void tx_provide(void)
 
     if (transferred && serial_require_consumer_signal(&tx_queue_handle)) {
         serial_cancel_consumer_signal(&tx_queue_handle);
-        microkit_notify(config.tx.id);
+        sddf_notify(config.tx.id);
     }
 }
 
@@ -88,7 +88,7 @@ static void rx_return(void)
     }
 
     if (enqueued) {
-        microkit_notify(config.rx.id);
+        sddf_notify(config.rx.id);
     }
 }
 
@@ -165,7 +165,7 @@ void init(void)
     assert(device_resources.num_regions == 1);
 
     /* Ack any IRQs that were delivered before the driver started. */
-    microkit_irq_ack(device_resources.irqs[0].id);
+    sddf_irq_ack(device_resources.irqs[0].id);
 
     uart_setup();
 
@@ -175,11 +175,11 @@ void init(void)
     serial_queue_init(&tx_queue_handle, config.tx.queue.vaddr, config.tx.data.size, config.tx.data.vaddr);
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     if (ch == device_resources.irqs[0].id) {
         handle_irq();
-        microkit_deferred_irq_ack(ch);
+        sddf_deferred_irq_ack(ch);
     } else if (ch == config.tx.id) {
         tx_provide();
     } else if (ch == config.rx.id) {

--- a/drivers/serial/meson/include/uart.h
+++ b/drivers/serial/meson/include/uart.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <stdint.h>
-#include <microkit.h>
 #include <sddf/util/util.h>
 #include <sddf/serial/queue.h>
 

--- a/drivers/serial/meson/uart.c
+++ b/drivers/serial/meson/uart.c
@@ -5,7 +5,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/resources/device.h>
 #include <sddf/util/printf.h>
 #include <sddf/serial/config.h>
@@ -89,7 +89,7 @@ static void tx_provide(void)
 
     if (transferred && serial_require_consumer_signal(&tx_queue_handle)) {
         serial_cancel_consumer_signal(&tx_queue_handle);
-        microkit_notify(config.tx.id);
+        sddf_notify(config.tx.id);
     }
 }
 
@@ -119,7 +119,7 @@ static void rx_return(void)
     }
 
     if (enqueued) {
-        microkit_notify(config.rx.id);
+        sddf_notify(config.rx.id);
     }
 }
 
@@ -198,7 +198,7 @@ void init(void)
     assert(device_resources.num_regions == 1);
 
     /* Ack any IRQs that were delivered before the driver started. */
-    microkit_irq_ack(device_resources.irqs[0].id);
+    sddf_irq_ack(device_resources.irqs[0].id);
 
     uart_setup();
 
@@ -208,11 +208,11 @@ void init(void)
     serial_queue_init(&tx_queue_handle, config.tx.queue.vaddr, config.tx.data.size, config.tx.data.vaddr);
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     if (ch == device_resources.irqs[0].id) {
         handle_irq();
-        microkit_deferred_irq_ack(ch);
+        sddf_deferred_irq_ack(ch);
     } else if (ch == config.tx.id) {
         tx_provide();
     } else if (ch == config.rx.id) {

--- a/drivers/serial/ns16550a/include/uart.h
+++ b/drivers/serial/ns16550a/include/uart.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#define LOG_DRIVER(...) do{ sddf_dprintf("%s|INFO: ", microkit_name); sddf_dprintf(__VA_ARGS__); }while(0)
-#define LOG_DRIVER_ERR(...) do{ sddf_dprintf("%s|ERROR: ", microkit_name); sddf_dprintf(__VA_ARGS__); }while(0)
+#define LOG_DRIVER(...) do{ sddf_dprintf("%s|INFO: ", sddf_get_pd_name()); sddf_dprintf(__VA_ARGS__); }while(0)
+#define LOG_DRIVER_ERR(...) do{ sddf_dprintf("%s|ERROR: ", sddf_get_pd_name()); sddf_dprintf(__VA_ARGS__); }while(0)
 
 /*
  * Divide positive or negative dividend by positive divisor and round

--- a/drivers/serial/ns16550a/uart.c
+++ b/drivers/serial/ns16550a/uart.c
@@ -5,7 +5,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/serial/config.h>
 #include <sddf/serial/queue.h>
 #include <sddf/util/util.h>
@@ -129,7 +129,7 @@ static void tx_provide(void)
 
     if (transferred && serial_require_consumer_signal(&tx_queue_handle)) {
         serial_cancel_consumer_signal(&tx_queue_handle);
-        microkit_notify(config.tx.id);
+        sddf_notify(config.tx.id);
     }
 }
 
@@ -163,7 +163,7 @@ static void rx_return(void)
     }
 
     if (enqueued) {
-        microkit_notify(config.rx.id);
+        sddf_notify(config.rx.id);
     }
 }
 
@@ -194,7 +194,7 @@ void init(void)
     assert(device_resources.num_regions == 1);
 
     /* Ack any IRQs that were delivered before the driver started. */
-    microkit_irq_ack(device_resources.irqs[0].id);
+    sddf_irq_ack(device_resources.irqs[0].id);
 
     uart_base = (uintptr_t)device_resources.regions[0].region.vaddr;
 
@@ -241,11 +241,11 @@ void init(void)
 #endif
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     if (ch == device_resources.irqs[0].id) {
         handle_irq();
-        microkit_deferred_irq_ack(ch);
+        sddf_deferred_irq_ack(ch);
     } else if (ch == config.tx.id) {
         tx_provide();
     } else if (ch == config.rx.id) {

--- a/drivers/serial/zynqmp/include/uart.h
+++ b/drivers/serial/zynqmp/include/uart.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <stdint.h>
-#include <microkit.h>
 #include <sddf/util/util.h>
 
 #if defined(CONFIG_PLAT_ZYNQMP)

--- a/drivers/serial/zynqmp/uart.c
+++ b/drivers/serial/zynqmp/uart.c
@@ -14,7 +14,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/util/util.h>
 #include <sddf/serial/queue.h>
 #include <sddf/util/printf.h>
@@ -266,7 +266,7 @@ void init(void)
     assert(device_resources.num_regions == 1);
 
     /* Ack any IRQs that were delivered before the driver started. */
-    microkit_irq_ack(device_resources.irqs[0].id);
+    sddf_irq_ack(device_resources.irqs[0].id);
 
     uart_base = (uintptr_t)device_resources.regions[0].region.vaddr;
     uart_setup();
@@ -277,7 +277,7 @@ void init(void)
     serial_queue_init(&tx_queue_handle, config.tx.queue.vaddr, config.tx.data.size, config.tx.data.vaddr);
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     if (ch == device_resources.irqs[0].id) {
         handle_irq();

--- a/drivers/timer/jh7110/timer.c
+++ b/drivers/timer/jh7110/timer.c
@@ -13,8 +13,8 @@
 /*
  * The JH7110 SoC contains a timer with four 32-bit counters. Each one of these
  * counters is referred to as a "channel". These are not to be confused with
- * Microkit/sDDF channels. Anything with a prefix STARFIVE_TIMER_* is to do with the
- * hardware.
+ * channels between the driver and clients. Anything with a prefix
+ * STARFIVE_TIMER_* is to do with the hardware.
  */
 #define STARFIVE_TIMER_NUM_CHANNELS 4
 

--- a/drivers/timer/jh7110/timer.c
+++ b/drivers/timer/jh7110/timer.c
@@ -4,7 +4,7 @@
  */
 
 #include <stdint.h>
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/resources/device.h>
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
@@ -13,7 +13,7 @@
 /*
  * The JH7110 SoC contains a timer with four 32-bit counters. Each one of these
  * counters is referred to as a "channel". These are not to be confused with
- * Microkit channels. Anything with a prefix STARFIVE_TIMER_* is to do with the
+ * Microkit/sDDF channels. Anything with a prefix STARFIVE_TIMER_* is to do with the
  * hardware.
  */
 #define STARFIVE_TIMER_NUM_CHANNELS 4
@@ -61,8 +61,8 @@ __attribute__((__section__(".device_resources"))) device_resources_t device_reso
 
 static volatile starfive_timer_regs_t *counter_regs;
 static volatile starfive_timer_regs_t *timeout_regs;
-microkit_channel counter_irq;
-microkit_channel timeout_irq;
+sddf_channel counter_irq;
+sddf_channel timeout_irq;
 
 /* Keep track of how many timer overflows have occured.
  * Used as the most significant segment of ticks.
@@ -105,7 +105,7 @@ static void process_timeouts(uint64_t curr_time)
 {
     for (int i = 0; i < MAX_TIMEOUTS; i++) {
         if (timeouts[i] <= curr_time) {
-            microkit_notify(CLIENT_CH_START + i);
+            sddf_notify(CLIENT_CH_START + i);
             timeouts[i] = UINT64_MAX;
         }
     }
@@ -137,7 +137,7 @@ static void process_timeouts(uint64_t curr_time)
     }
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     if (ch == counter_irq) {
         counter_timer_elapses += 1;
@@ -165,31 +165,31 @@ void notified(microkit_channel ch)
         return;
     }
 
-    microkit_deferred_irq_ack(ch);
+    sddf_deferred_irq_ack(ch);
 }
 
-seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
+seL4_MessageInfo_t protected(sddf_channel ch, seL4_MessageInfo_t msginfo)
 {
-    switch (microkit_msginfo_get_label(msginfo)) {
+    switch (seL4_MessageInfo_get_label(msginfo)) {
     case SDDF_TIMER_GET_TIME: {
         uint64_t time_ns = get_ticks_in_ns();
-        seL4_SetMR(0, time_ns);
-        return microkit_msginfo_new(0, 1);
+        sddf_set_mr(0, time_ns);
+        return seL4_MessageInfo_new(0, 0, 0, 1);
     }
     case SDDF_TIMER_SET_TIMEOUT: {
         uint64_t curr_time = get_ticks_in_ns();
-        uint64_t offset_ns = seL4_GetMR(0);
+        uint64_t offset_ns = sddf_get_mr(0);
         timeouts[ch - CLIENT_CH_START] = curr_time + offset_ns;
         process_timeouts(curr_time);
         break;
     }
     default:
         sddf_dprintf("TIMER DRIVER|LOG: Unknown request %lu to timer from channel %u\n",
-                     microkit_msginfo_get_label(msginfo), ch);
+                     seL4_MessageInfo_get_label(msginfo), ch);
         break;
     }
 
-    return microkit_msginfo_new(0, 0);
+    return seL4_MessageInfo_new(0, 0, 0, 0);
 }
 
 void init(void)
@@ -200,7 +200,7 @@ void init(void)
 
     /* Ack any IRQs that were delivered before the driver started. */
     for (int i = 0; i < device_resources.num_irqs; i++) {
-        microkit_irq_ack(device_resources.irqs[i].id);
+        sddf_irq_ack(device_resources.irqs[i].id);
     }
 
     for (int i = 0; i < MAX_TIMEOUTS; i++) {

--- a/drivers/timer/meson/timer.c
+++ b/drivers/timer/meson/timer.c
@@ -4,7 +4,7 @@
  */
 
 #include <stdint.h>
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/resources/device.h>
 #include <sddf/util/printf.h>
 #include <sddf/timer/protocol.h>
@@ -71,7 +71,7 @@ static void process_timeouts(uint64_t curr_time)
 {
     for (int i = 0; i < MAX_TIMEOUTS; i++) {
         if (timeouts[i] <= curr_time) {
-            microkit_notify(i);
+            sddf_notify(i);
             timeouts[i] = UINT64_MAX;
         }
     }
@@ -90,42 +90,42 @@ static void process_timeouts(uint64_t curr_time)
     }
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     if (ch != device_resources.irqs[0].id) {
         sddf_dprintf("TIMER DRIVER|LOG: unexpected notification from channel %u\n", ch);
         return;
     }
 
-    microkit_deferred_irq_ack(ch);
+    sddf_deferred_irq_ack(ch);
     regs->mux &= ~TIMER_A_EN;
 
     uint64_t curr_time = get_ticks();
     process_timeouts(curr_time);
 }
 
-seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
+seL4_MessageInfo_t protected(sddf_channel ch, seL4_MessageInfo_t msginfo)
 {
-    switch (microkit_msginfo_get_label(msginfo)) {
+    switch (seL4_MessageInfo_get_label(msginfo)) {
     case SDDF_TIMER_GET_TIME: {
         uint64_t time_ns = get_ticks() * NS_IN_US;
-        seL4_SetMR(0, time_ns);
-        return microkit_msginfo_new(0, 1);
+        sddf_set_mr(0, time_ns);
+        return seL4_MessageInfo_new(0, 0, 0, 1);
     }
     case SDDF_TIMER_SET_TIMEOUT: {
         uint64_t curr_time = get_ticks();
-        uint64_t offset_us = seL4_GetMR(0) / NS_IN_US;
+        uint64_t offset_us = sddf_get_mr(0) / NS_IN_US;
         timeouts[ch] = curr_time + offset_us;
         process_timeouts(curr_time);
         break;
     }
     default:
-        sddf_dprintf("TIMER DRIVER|LOG: Unknown request %lu to timer from channel %u\n", microkit_msginfo_get_label(msginfo),
-                     ch);
+        sddf_dprintf("TIMER DRIVER|LOG: Unknown request %lu to timer from channel %u\n",
+                     seL4_MessageInfo_get_label(msginfo), ch);
         break;
     }
 
-    return microkit_msginfo_new(0, 0);
+    return seL4_MessageInfo_new(0, 0, 0, 0);
 }
 
 void init(void)
@@ -134,7 +134,7 @@ void init(void)
     assert(device_resources.num_irqs == 1);
     assert(device_resources.num_regions == 1);
 
-    microkit_irq_ack(device_resources.irqs[0].id);
+    sddf_irq_ack(device_resources.irqs[0].id);
 
     for (int i = 0; i < MAX_TIMEOUTS; i++) {
         timeouts[i] = UINT64_MAX;

--- a/examples/serial/client.c
+++ b/examples/serial/client.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/serial/queue.h>
 #include <sddf/serial/config.h>
 #include <sddf/util/printf.h>
@@ -21,11 +21,11 @@ void init(void)
     serial_queue_init(&tx_queue_handle, config.tx.queue.vaddr, config.tx.data.size, config.tx.data.vaddr);
 
     serial_putchar_init(config.tx.id, &tx_queue_handle);
-    sddf_printf("Hello world! I am %s.\nPlease give me character!\n", microkit_name);
+    sddf_printf("Hello world! I am %s.\nPlease give me character!\n", sddf_get_pd_name());
 }
 
 uint16_t char_count;
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     char c;
     while (!serial_dequeue(&rx_queue_handle, &c)) {
@@ -37,7 +37,7 @@ void notified(microkit_channel ch)
         }
         char_count++;
         if (char_count % 10 == 0) {
-            sddf_printf("\n%s has received %u characters so far!\n", microkit_name, char_count);
+            sddf_printf("\n%s has received %u characters so far!\n", sddf_get_pd_name(), char_count);
         }
     }
 }

--- a/examples/timer/client.c
+++ b/examples/timer/client.c
@@ -4,16 +4,16 @@
  */
 
 #include <stdint.h>
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/timer/client.h>
 #include <sddf/timer/config.h>
 #include <sddf/util/printf.h>
 
 __attribute__((__section__(".timer_client_config"))) timer_client_config_t config;
 
-microkit_channel timer_channel;
+sddf_channel timer_channel;
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     /*
      * In this example we only have a single possible channel,

--- a/include/sddf/timer/client.h
+++ b/include/sddf/timer/client.h
@@ -12,7 +12,7 @@
 /**
  * Request a timeout via PPC into the passive timer driver.
  * Use the label to indicate this request.
- * @param microkit channel of timer driver.
+ * @param microkit/sDDF channel of timer driver.
  * @param timeout relative timeout in nanoseconds.
  */
 static inline void sddf_timer_set_timeout(unsigned int channel, uint64_t timeout)
@@ -24,7 +24,7 @@ static inline void sddf_timer_set_timeout(unsigned int channel, uint64_t timeout
 /**
  * Request the time since start up via PPC into the passive timer driver.
  * Use the label to indicate this request.
- * @param microkit channel of timer driver.
+ * @param microkit/sDDF channel of timer driver.
  * @return the time in nanoseconds since start up.
  */
 static inline uint64_t sddf_timer_time_now(unsigned int channel)

--- a/include/sddf/timer/client.h
+++ b/include/sddf/timer/client.h
@@ -12,7 +12,7 @@
 /**
  * Request a timeout via PPC into the passive timer driver.
  * Use the label to indicate this request.
- * @param microkit/sDDF channel of timer driver.
+ * @param channel ID of the timer driver.
  * @param timeout relative timeout in nanoseconds.
  */
 static inline void sddf_timer_set_timeout(unsigned int channel, uint64_t timeout)
@@ -24,7 +24,7 @@ static inline void sddf_timer_set_timeout(unsigned int channel, uint64_t timeout
 /**
  * Request the time since start up via PPC into the passive timer driver.
  * Use the label to indicate this request.
- * @param microkit/sDDF channel of timer driver.
+ * @param channel ID of the timer driver.
  * @return the time in nanoseconds since start up.
  */
 static inline uint64_t sddf_timer_time_now(unsigned int channel)


### PR DESCRIPTION
* Update serial, timer and network drivers + components to use OS agnostic sddf wrappers
* Update serial, timer, and echo_server examples in the same manner
* **DID NOT* update arp.c component and friends, due to #295

Further changes to allow Djawula to use sDDF components.