### PR TITLE
drivers/timer/jh7110: make timer ticks define board-specific

### DIFF
--- a/drivers/timer/jh7110/timer.c
+++ b/drivers/timer/jh7110/timer.c
@@ -40,8 +40,12 @@
 #define STARFIVE_TIMER_INTERRUPT_MASKED 1
 #define STARFIVE_TIMER_INTCLR_BUSY (1 << 1)
 
+#if defined(CONFIG_PLAT_STAR64)
 /* 24 MHz frequency. */
 #define STARFIVE_TIMER_TICKS_PER_SECOND 0x16e3600
+#else
+#error "Unknown clock-frequency for JH7110 timer"
+#endif
 
 typedef struct {
     /* Registers */


### PR DESCRIPTION
Until we get this information from the DTS or some other automatic means, we should be careful about hard-coding it.