### PR TITLE
assert: prevent infinite recursion failures from serial assertions

### DIFF
--- a/util/assert.c
+++ b/util/assert.c
@@ -3,10 +3,27 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <stdbool.h>
 #include <sddf/util/printf.h>
+
+/** Our dprintf() functions will sometimes go through our standard printf()
+ *  machinery, which includes assert() statements itself. In the case that
+ *  the machinery is failing, this would lead to infinite recursion and an
+ *  eventual stack overflow. By saving whether or not we were previously
+ *  perform an _assert_fail, and by having two different trap paths, we can
+ *  identify assertion failures due to this.
+ */
+static bool currently_asserting = false;
 
 void _assert_fail(const char  *assertion, const char  *file, unsigned int line, const char  *function)
 {
+    bool previously_asserting = currently_asserting;
+    currently_asserting = true;
+
+    if (previously_asserting) {
+        __builtin_trap();
+    }
+
     sddf_dprintf("Failed assertion '%s' at %s:%u in function %s\n", assertion, file, line, function);
     __builtin_trap();
 }


### PR DESCRIPTION
We now get exceptions at '0x0000000000202a68' which corresponds to the 'previously asserting' branch.

    ; /sddf/util/assert.c:23
    ;     if (previously_asserting) {
      202a64: 54000041      b.ne    0x202a6c <_assert_fail+0x1c>
    ; /sddf/util/assert.c:24
    ;         __builtin_trap();
      202a68: d4200020      brk     #0x1
      202a6c: a9bf7bfd      stp     x29, x30, [sp, #-0x10]!
      202a70: 910003fd      mov     x29, sp
      202a74: aa0303e4      mov     x4, x3
      202a78: 2a0203e3      mov     w3, w2
      202a7c: aa0103e2      mov     x2, x1
      202a80: aa0003e1      mov     x1, x0
    ; /sddf/util/assert.c:27
    ;     sddf_dprintf("Failed assertion '%s' at %s:%u in function %s\n", assertion, file, line, function);
      202a84: d503201f      nop
      202a88: 10005820      adr     x0, 0x20358c
      202a8c: 97fff5d5      bl      0x2001e0 <sddf_printf_>
    ; /sddf/util/assert.c:28
    ;     __builtin_trap();
      202a90: d4200020      brk     #0x1