### PR TITLE
ci: remove imx8mp_evk from being in test list

### DIFF
--- a/ci/matrix.py
+++ b/ci/matrix.py
@@ -88,7 +88,6 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
             "hifive_p550",
             "imx8mm_evk",
             "imx8mq_evk",
-            "imx8mp_evk",
             "maaxboard",
             "odroidc2",
             "odroidc4",
@@ -121,7 +120,6 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
         ],
         "boards_test": [
             "imx8mq_evk",
-            "imx8mp_evk",
             "maaxboard",
             "odroidc2",
             "odroidc4",


### PR DESCRIPTION
We don't actually have an imx8mp_evk, only the iotgate which works with imx8mp_iotgate.

imx8mp_evk builds *usually* work on imx8mp_iotgate but they do not have the same memory layout so we should not be relying on that.