### PR TITLE
drivers/timer/bcm2835: Fix spurious interrupts

### DIFF
--- a/drivers/timer/bcm2835/config.json
+++ b/drivers/timer/bcm2835/config.json
@@ -11,7 +11,7 @@
         ],
         "irqs": [
             {
-                "dt_index": 0
+                "dt_index": 1
             }
 
         ]


### PR DESCRIPTION
Fixes #507, System Timer channels 0 and 2 are used by the VideoCore on RPi3 and 4

See: https://github.com/seL4/seL4/pull/894