### PR TITLE
benchmark: simplify config checks for actually doing benchmarking

### DIFF
--- a/examples/echo_server/echo.mk
+++ b/examples/echo_server/echo.mk
@@ -133,7 +133,6 @@ CFLAGS := $(CFLAGS_ARCH) \
 	  -ffreestanding \
 	  -g3 -O3 -Wall \
 	  -Wno-unused-function \
-	  -DMICROKIT_CONFIG_$(MICROKIT_CONFIG) \
 	  -I$(BOARD_DIR)/include \
 	  -I$(SDDF)/include/microkit \
 	  -I$(SDDF)/include \


### PR DESCRIPTION
I verified this by taking the pre-processor output before/after this patch for both debug and benchmark builds and making sure they were semantically the same (the only difference was the print I changed).

Closes https://github.com/au-ts/sddf/issues/402.