### PR TITLE
benchmark: typo fix + remove deadcode

### DIFF
--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -18,7 +18,7 @@
 /* At the moment we run systems that contain this benchmarking code on architectures
  * where we cannot properly do benchmarking. We also include the benchmarking PD
  * on non-benchmarking configurations.
- * This defines whether we actually try to benchmarking, setup the PMU etc.
+ * This defines whether we actually try to benchmark, setup the PMU etc.
  */
 #if defined(CONFIG_ENABLE_BENCHMARKS) && defined(CONFIG_ARCH_ARM)
 #define ENABLE_BENCHMARKING 1
@@ -207,9 +207,6 @@ void init(void)
 
 #if ENABLE_BENCHMARKING
     sddf_printf("BENCH|LOG: ENABLE_BENCHMARKING defined\n");
-#ifndef CONFIG_ARCH_ARM
-    sddf_printf("BENCH|LOG: System not running on ARM, benchmarking not implemented.\n");
-#endif
 #endif
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
     sddf_printf("BENCH|LOG: CONFIG_BENCHMARK_TRACK_UTILISATION defined\n");


### PR DESCRIPTION
Fixes typo from #518 and removes preprocessor directive deadcode.

The reason for that print though is still valid IMO, as someone who compiles the code with `CONFIG_ENABLE_BENCHMARKS=1` but not on ARM, might be greeted with a silent error of benchmarking code being ignored. However, this message still gets printed, so might be enough 'guidance':

https://github.com/au-ts/sddf/blob/4618759c6f325f294d6213ff780505905ab4503d/benchmark/benchmark.c#L232