### PR TITLE
benchmark: fix config checks in idle

### DIFF
--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -15,17 +15,6 @@
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
 
-/* At the moment we run systems that contain this benchmarking code on architectures
- * where we cannot properly do benchmarking. We also include the benchmarking PD
- * on non-benchmarking configurations.
- * This defines whether we actually try to benchmark, setup the PMU etc.
- */
-#if defined(CONFIG_ENABLE_BENCHMARKS) && defined(CONFIG_ARCH_ARM)
-#define ENABLE_BENCHMARKING 1
-#else
-#define ENABLE_BENCHMARKING 0
-#endif
-
 #define LOG_BUFFER_CAP 7
 
 __attribute__((__section__(".benchmark_config"))) benchmark_config_t benchmark_config;

--- a/benchmark/idle.c
+++ b/benchmark/idle.c
@@ -20,7 +20,7 @@ struct bench *b;
 
 void count_idle(void)
 {
-#if defined(MICROKIT_CONFIG_benchmark) && defined(CONFIG_ARCH_ARM)
+#if ENABLE_BENCHMARKING
     uint64_t val;
     SEL4BENCH_READ_CCNT(val);
     b->prev = val;

--- a/include/sddf/benchmark/config.h
+++ b/include/sddf/benchmark/config.h
@@ -8,6 +8,17 @@
 #include <os/sddf.h>
 #include <stdint.h>
 
+/* At the moment we run systems that contain this benchmarking code on architectures
+ * where we cannot properly do benchmarking. We also include the benchmarking PD
+ * on non-benchmarking configurations.
+ * This defines whether we actually try to benchmark, setup the PMU etc.
+ */
+#if defined(CONFIG_ENABLE_BENCHMARKS) && defined(CONFIG_ARCH_ARM)
+#define ENABLE_BENCHMARKING 1
+#else
+#define ENABLE_BENCHMARKING 0
+#endif
+
 #define BENCHMARK_MAX_CHILDREN 64 // TODO: Can we have a higher upper bound on this?
 
 typedef struct benchmark_child_config {


### PR DESCRIPTION
`MICROKIT_CONFIG_benchmark` is still used in idle.c but was removed from echo.mk.

Fixing this by moving benchmark config macro to the header file referenced by both benchmark.c and idle.c.