### PR TITLE
Renamed libi2c functions to avoid namespace collision in LionsOS

### DIFF
--- a/i2c/devices/ds3231/ds3231.c
+++ b/i2c/devices/ds3231/ds3231.c
@@ -64,7 +64,7 @@ int ds3231_write(uint8_t *data, uint16_t data_len, size_t retries)
             data_region_buf[i] = data[i];
         }
 
-        int error = i2c_write(&libi2c_conf, DS3231_I2C_BUS_ADDRESS, data_region_buf, data_len);
+        int error = sddf_i2c_write(&libi2c_conf, DS3231_I2C_BUS_ADDRESS, data_region_buf, data_len);
         if (!error) {
             return error;
         }
@@ -84,8 +84,8 @@ int ds3231_read(uint8_t *data_region_data, i2c_addr_t reg_addr, uint16_t data_le
         if (attempts == retries)
             return -1;
         // Set register address
-        int error = i2c_writeread(&libi2c_conf, DS3231_I2C_BUS_ADDRESS, reg_addr, (uint8_t *)(data_region_data),
-                                  data_len);
+        int error = sddf_i2c_writeread(&libi2c_conf, DS3231_I2C_BUS_ADDRESS, reg_addr, (uint8_t *)(data_region_data),
+                                       data_len);
         if (!error) {
             return error;
         }

--- a/i2c/devices/pn532/pn532.c
+++ b/i2c/devices/pn532/pn532.c
@@ -68,7 +68,7 @@ uint8_t read_ack_frame(unsigned retries)
     while (attempts < retries) {
         LOG_PN532("\t## %d \n", attempts);
         // Start: read FRAME_SIZE+1
-        int ret = i2c_read(&libi2c_conf, PN532_I2C_BUS_ADDRESS, data_buf, ACK_FRAME_SIZE + 1);
+        int ret = sddf_i2c_read(&libi2c_conf, PN532_I2C_BUS_ADDRESS, data_buf, ACK_FRAME_SIZE + 1);
         if (ret != 0) {
             /*LOG_PN532_ERR("Failed to read ack frame! Retries = %d/%d\n", attempts, retries);*/
             attempts++;
@@ -144,7 +144,7 @@ uint8_t pn532_write_command(uint8_t *header, uint8_t hlen, const uint8_t *body, 
     data_buf[7 + hlen + blen] = (PN532_POSTAMBLE);
 
     int error = 0;
-    error = i2c_write(&libi2c_conf, PN532_I2C_BUS_ADDRESS, data_buf, i2c_req_len);
+    error = sddf_i2c_write(&libi2c_conf, PN532_I2C_BUS_ADDRESS, data_buf, i2c_req_len);
     if (!error) {
         LOG_PN532("Wrote command successfully. Reading ack frame\n");
         error = read_ack_frame(retries);
@@ -166,7 +166,7 @@ uint8_t read_response_length(int8_t *length, unsigned retries)
     uint8_t error = I2C_ERR_OK;
     uint8_t *data_buf = (uint8_t *)(I2C_DATA_REGION + PN532_DATA_BASE);
     while (attempts < retries) {
-        int error = i2c_read(&libi2c_conf, PN532_I2C_BUS_ADDRESS, data_buf, NACK_SIZE + 1);
+        int error = sddf_i2c_read(&libi2c_conf, PN532_I2C_BUS_ADDRESS, data_buf, NACK_SIZE + 1);
         if (error) {
             attempts++;
             continue;
@@ -210,7 +210,7 @@ uint8_t read_response_length(int8_t *length, unsigned retries)
     for (int i = 0; i < NACK_SIZE; i++) {
         data_buf[i] = PN532_NACK[i];
     }
-    error = i2c_write(&libi2c_conf, PN532_I2C_BUS_ADDRESS, data_buf, NACK_SIZE);
+    error = sddf_i2c_write(&libi2c_conf, PN532_I2C_BUS_ADDRESS, data_buf, NACK_SIZE);
     if (error) {
         LOG_PN532_ERR("read_response_len: failed to write NACK\n");
     }
@@ -242,7 +242,7 @@ uint8_t pn532_read_response(uint8_t *buffer, uint8_t buffer_len, unsigned retrie
         }
 
         LOG_PN532("read_response: sent request of size %z\n", num_data_tokens);
-        int error = i2c_read(&libi2c_conf, PN532_I2C_BUS_ADDRESS, data_buf, num_data_tokens);
+        int error = sddf_i2c_read(&libi2c_conf, PN532_I2C_BUS_ADDRESS, data_buf, num_data_tokens);
         if (error) {
             attempts++;
             continue;

--- a/i2c/libi2c.c
+++ b/i2c/libi2c.c
@@ -27,7 +27,7 @@ static inline int check_data_buf(void *data_buf)
 {
     if ((uintptr_t)data_buf < (uintptr_t)I2C_DATA_REGION
         || (uintptr_t)data_buf > ((uintptr_t)I2C_DATA_REGION + i2c_config.data.size)) {
-        LOG_LIBI2C_ERR("i2c_write called with data_buf not in data region!");
+        LOG_LIBI2C_ERR("sddf_i2c_write called with data_buf not in data region!");
         return -1;
     }
     return 0;
@@ -123,18 +123,18 @@ i2c_dispatch_fail:
  * This is a blocking function call.
  * @return -1 if queue ops fail, positive value corresponding to i2c_err_t, or 0 if successful.
  */
-int i2c_write(libi2c_conf_t *conf, i2c_addr_t address, void *write_buf, uint16_t len)
+int sddf_i2c_write(libi2c_conf_t *conf, i2c_addr_t address, void *write_buf, uint16_t len)
 {
     return __i2c_dispatch(conf, address, write_buf, len, I2C_FLAG_STOP);
 }
 
 /**
  * Perform a simple I2C read given a DATA region buffer to store result.
- * To perform a read to a device register, use i2c_writeread!
+ * To perform a read to a device register, use sddf_i2c_writeread!
  * This is a blocking function call.
  * @return -1 if queue ops fail, positive value corresponding to i2c_err_t, or 0 if successful.
  */
-int i2c_read(libi2c_conf_t *conf, i2c_addr_t address, void *read_buf, uint16_t len)
+int sddf_i2c_read(libi2c_conf_t *conf, i2c_addr_t address, void *read_buf, uint16_t len)
 {
     return __i2c_dispatch(conf, address, read_buf, len, I2C_FLAG_STOP | I2C_FLAG_READ);
 }
@@ -145,7 +145,7 @@ int i2c_read(libi2c_conf_t *conf, i2c_addr_t address, void *read_buf, uint16_t l
  * This is a blocking function call.
  * @return -1 if queue ops fail, positive value corresponding to i2c_err_t, or 0 if successful.
  */
-int i2c_writeread(libi2c_conf_t *conf, i2c_addr_t address, i2c_addr_t reg_address, void *read_buf, uint16_t len)
+int sddf_i2c_writeread(libi2c_conf_t *conf, i2c_addr_t address, i2c_addr_t reg_address, void *read_buf, uint16_t len)
 {
     // Check that supplied buffer is within bounds of data region
     if (check_data_buf(read_buf)) {

--- a/include/sddf/i2c/libi2c.h
+++ b/include/sddf/i2c/libi2c.h
@@ -56,7 +56,7 @@ typedef struct libi2c_conf {
 
 int libi2c_init(libi2c_conf_t *conf_struct, i2c_queue_handle_t *queue_handle);
 static i2c_cmd_t *__libi2c_alloc_cmd(libi2c_conf_t *conf);
-int i2c_write(libi2c_conf_t *conf, i2c_addr_t address, void *write_buf, uint16_t len);
-int i2c_read(libi2c_conf_t *conf, i2c_addr_t address, void *read_buf, uint16_t len);
-int i2c_writeread(libi2c_conf_t *conf, i2c_addr_t address, i2c_addr_t reg_address, void *read_buf, uint16_t len);
+int sddf_i2c_write(libi2c_conf_t *conf, i2c_addr_t address, void *write_buf, uint16_t len);
+int sddf_i2c_read(libi2c_conf_t *conf, i2c_addr_t address, void *read_buf, uint16_t len);
+int sddf_i2c_writeread(libi2c_conf_t *conf, i2c_addr_t address, i2c_addr_t reg_address, void *read_buf, uint16_t len);
 int i2c_dispatch(libi2c_conf_t *conf, i2c_addr_t address, void *buf, uint16_t len, uint8_t flag_mask);


### PR DESCRIPTION
Title says it all. i2c_read, i2c_write and i2c_writeread changed to begin as `libi2c_` instead of just `i2c_`. Needed to prevent issues in Micropython for LionsOS.