### PR TITLE
ci: fix hardware run text match for hifive_p550

### DIFF
--- a/ci/matrix.py
+++ b/ci/matrix.py
@@ -23,6 +23,7 @@ MACHINE_QUEUE_BOARDS: dict[str, list[str]] = {
 
 MACHINE_QUEUE_BOARD_OPTIONS: dict[str, dict[str, Any]] = {
     "cheshire": dict(uboot_image_started=b"Starting kernel ..."),
+    "hifive_p550": dict(uboot_image_started=b"Starting kernel ..."),
 }
 
 EXAMPLES: dict[str, _ExampleMatrixType] = {


### PR DESCRIPTION
HiFive P550 in machine queue boots via uImage instead which means the typical U-Boot log that we wait on does not work since it is for binary images.