### PR TITLE
ci: use python3.13 explicitly on github hosted macos

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -101,10 +101,10 @@ jobs:
           version: ${{ env.ZIG_VERSION }}
       - name: Setup pyenv
         run: |
-          python3 -m venv venv
+          python3.13 -m venv venv
           ./venv/bin/pip install --upgrade sdfgen==${{ env.SDFGEN_VERSION }}
       - name: Build examples
-        run: ./ci/build.py ${PWD}/microkit-sdk-${{ env.MICROKIT_VERSION }}-macos-aarch64 $(nproc)
+        run: python3.13 ./ci/build.py ${PWD}/microkit-sdk-${{ env.MICROKIT_VERSION }}-macos-aarch64 $(nproc)
         shell: bash
         env:
           PYTHON: ${{ github.workspace }}/venv/bin/python

--- a/ci/build.py
+++ b/ci/build.py
@@ -87,7 +87,7 @@ def build(args: argparse.Namespace, example_name: str, test_config: TestConfig):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser()
 
     parser.add_argument("microkit_sdk")
     parser.add_argument("num_jobs", nargs="?", type=int, default=os.cpu_count())


### PR DESCRIPTION
What a fantastic situation! You can pin the version of macOS to use for CI where the default version of Python is perfectly fine to change at any given moment.

Python 3.14 only got recently I believe last week or the week before so sdfgen does not have a package for it yet. I will fix that soon.