### PR TITLE
ci: add isatty() and fileno() as python3.14 checks these now

### DIFF
--- a/ci/lib/backends/common.py
+++ b/ci/lib/backends/common.py
@@ -56,6 +56,8 @@ class _TeeOut:
     def seekable(self): return False
     @property
     def closed(self): return self.stdout.closed
+    def fileno(self): return self.stdout.fileno()
+    def isatty(self): return self.stdout.isatty()
     # fmt: on
 
 


### PR DESCRIPTION
Specifically, it does check them through TextIOBuffer so its attribute checks don't work.