### PR TITLE
libi2c: Non-blocking API

### DIFF
--- a/include/sddf/i2c/libi2c.h
+++ b/include/sddf/i2c/libi2c.h
@@ -55,8 +55,23 @@ typedef struct libi2c_conf {
 } libi2c_conf_t;
 
 int libi2c_init(libi2c_conf_t *conf_struct, i2c_queue_handle_t *queue_handle);
-static i2c_cmd_t *__libi2c_alloc_cmd(libi2c_conf_t *conf);
+
+// Blocking interface
 int sddf_i2c_write(libi2c_conf_t *conf, i2c_addr_t address, void *write_buf, uint16_t len);
 int sddf_i2c_read(libi2c_conf_t *conf, i2c_addr_t address, void *read_buf, uint16_t len);
 int sddf_i2c_writeread(libi2c_conf_t *conf, i2c_addr_t address, i2c_addr_t reg_address, void *read_buf, uint16_t len);
-int i2c_dispatch(libi2c_conf_t *conf, i2c_addr_t address, void *buf, uint16_t len, uint8_t flag_mask);
+int sddf_i2c_dispatch(libi2c_conf_t *conf, i2c_addr_t address, void *buf, uint16_t len, uint8_t flag_mask);
+
+// Non-blocking interface. Separates dispatch and completion for applications
+// with custom concurrency models instead of libco/libmicrokitco (e.g. micropython)
+// WARNING: the nb_return function returns whatever response is most recent.
+// Care should be taken if you wish to asynchronously wait on multiple calls,
+// although there is little reason to do this given that all i2c operations
+// are processed monotonically and sequentially.
+
+int sddf_i2c_nb_write(libi2c_conf_t *conf, i2c_addr_t address, void *write_buf, uint16_t len);
+int sddf_i2c_nb_read(libi2c_conf_t *conf, i2c_addr_t address, void *read_buf, uint16_t len);
+int sddf_i2c_nb_writeread(libi2c_conf_t *conf, i2c_addr_t address, i2c_addr_t reg_address, void *read_buf,
+                          uint16_t len);
+int sddf_i2c_nb_dispatch(libi2c_conf_t *conf, i2c_addr_t address, void *buf, uint16_t len, uint8_t flag_mask);
+int sddf_i2c_nb_return(libi2c_conf_t *conf, i2c_addr_t *returned_addr, size_t *err_cmd_idx);

--- a/include/sddf/i2c/queue.h
+++ b/include/sddf/i2c/queue.h
@@ -33,7 +33,8 @@
 #endif
 
 typedef enum i2c_err {
-    I2C_ERR_OK,
+    I2C_ERR_QUEUE = -1,
+    I2C_ERR_OK = 0,
     I2C_ERR_MALFORMED_TRANSACTION,
     I2C_ERR_MALFORMED_HEADER,
     I2C_ERR_UNPERMITTED_ADDR,


### PR DESCRIPTION
This PR adds a new non-blocking API to libi2c to allow arbitrary methods of waiting for the notification. The `_nb_` operations are dispatched directly, the user then blocks however they wish on the virt notification, and finally call `nb_return` to complete the operation as normal.
