### PR TITLE
lwip: Disable DHCP ACD on QEMU

### DIFF
--- a/examples/echo_server/include/lwip/lwipopts.h
+++ b/examples/echo_server/include/lwip/lwipopts.h
@@ -11,6 +11,15 @@
 
 #include "echo.h"
 
+#if defined(CONFIG_PLAT_QEMU_ARM_VIRT) || defined(CONFIG_PLAT_QEMU_RISCV_VIRT)
+// We don't need to do any address conflict detection on QEMU
+// as it creates it's own isolated network.
+//
+// Disabling this option drastically decreases the time to
+// complete DHCP on QEMU.
+#define LWIP_DHCP_DOES_ACD_CHECK 0
+#endif
+
 /**
  * Use lwIP without OS-awareness (no thread, semaphores, mutexes or mboxes).
  */


### PR DESCRIPTION
Disable address conflict detection on QEMU platforms. This speeds up DHCP significantly, and due to each instance of QEMU creating its own internal network, this will not have any adverse affects.

This reflects the changes in lionsos: https://github.com/au-ts/lionsos/pull/241