### PR TITLE
ci: do not rm auto-update for qemu run

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -118,7 +118,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Install dependencies (via apt)
         run: |
-          sudo rm /var/lib/man-db/auto-update # speedup
           sudo apt update
           sudo apt-get install qemu-system-arm qemu-system-misc
       - name: Download images


### PR DESCRIPTION
Doesn't seem to exist anymore in the GitHub provided runners.