### PR TITLE
ci/matrix.py: add zcu102_2

### DIFF
--- a/ci/matrix.py
+++ b/ci/matrix.py
@@ -17,7 +17,7 @@ MACHINE_QUEUE_BOARDS: dict[str, list[str]] = {
     "odroidc2": ["odroidc2"],
     "odroidc4": ["odroidc4_1", "odroidc4_2"],
     "star64": ["star64"],
-    "zcu102": ["zcu102"],
+    "zcu102": ["zcu102", "zcu102_2"],
     "rpi4b_1gb": ["pi4B"],
 }
 


### PR DESCRIPTION
Wasn't originally done because zcu102_2 always defaulted to booting ELF files, I've changed it to boot binary unless ELF is detected.

zcu102 is being used by a thesis student so we need this to get hardware CI passing for now...