### PR TITLE
toolchain: use -O2

### DIFF
--- a/tools/make/toolchain/clang.mk
+++ b/tools/make/toolchain/clang.mk
@@ -11,7 +11,7 @@ OBJCOPY := llvm-objcopy
 OBJDUMP := llvm-objdump
 SIZE := llvm-size
 
-OPTIMISATION ?= -g3 -O3
+OPTIMISATION ?= -g3 -O2
 
 ifndef BOARD_DIR
 $(error BOARD_DIR not defined)

--- a/tools/make/toolchain/gcc.mk
+++ b/tools/make/toolchain/gcc.mk
@@ -31,7 +31,7 @@ OBJCOPY := ${TRIPLE}-objcopy
 OBJDUMP := ${TRIPLE}-objdump
 SIZE := ${TRIPLE}-size
 
-OPTIMISATION ?= -g -O3
+OPTIMISATION ?= -g -O2
 
 CFLAGS += \
 	-MD \


### PR DESCRIPTION
Currently sddf is compiled using the `-O3` compiler flag. On risc-v with clang, this causes significant performance degradation in the `echo_server` example. This PR sets the default optimisation flag to `-O2`.