### PR TITLE
ci: add x86 testing to serial/timer/blk examples

### DIFF
--- a/ci/matrix.py
+++ b/ci/matrix.py
@@ -41,6 +41,7 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
             "maaxboard",
             "qemu_virt_aarch64",
             "qemu_virt_riscv64",
+            "x86_64_generic",
         ],
     },
     "i2c": {
@@ -118,6 +119,7 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
             # "rpi4b_1gb",
             "serengeti",
             "star64",
+            "x86_64_generic",
             "zcu102",
         ],
     },
@@ -155,6 +157,7 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
             # "rpi4b_1gb",
             "serengeti",
             "star64",
+            "x86_64_generic",
             "zcu102",
         ],
     },


### PR DESCRIPTION
It would be good to have this in CI until the seL4 issue with QEMU + SMP gets fixed and we have a Microkit SDK with the fix.