### PR TITLE
fix: blk example qemu_virt_riscv64 args for qemu

### DIFF
--- a/tools/make/board/qemu_virt_riscv64.mk
+++ b/tools/make/board/qemu_virt_riscv64.mk
@@ -14,7 +14,8 @@ QEMU := qemu-system-riscv64
 QEMU_ARCH_ARGS := -machine virt \
 					-kernel $(IMAGE_FILE) \
 					-m size=2G \
-					-serial mon:stdio
+					-serial mon:stdio \
+				    -global virtio-mmio.force-legacy=false
 
 QEMU_NET_ARGS := -device virtio-net-device,netdev=netdev0
 


### PR DESCRIPTION
* On some version of qemu, older version of virtIO MMIO are used by default, causing the blk example to crash. qemu_virt_aarch64 already has that fix and both platforms use correct arguments when ran with zig build system.
* See: https://gitlab.com/qemu-project/qemu/-/issues/1342#note_2869925359
