### PR TITLE
agnostic: update blk drivers+example+components

### DIFF
--- a/blk/components/partitioning.c
+++ b/blk/components/partitioning.c
@@ -7,6 +7,7 @@
 #include "msdos_mbr.h"
 #include "gpt.h"
 
+#include <os/sddf.h>
 #include <sddf/util/cache.h>
 #include <sddf/util/util.h>
 
@@ -293,7 +294,7 @@ static void mbr_request()
     err = blk_enqueue_req(&drv_h, BLK_REQ_READ, mbr_paddr, 0, 1, mbr_state.req_id);
     assert(!err);
 
-    microkit_deferred_notify(config.driver.conn.id);
+    sddf_deferred_notify(config.driver.conn.id);
 
     mbr_state.sent_request = true;
 }
@@ -371,7 +372,7 @@ static bool mbr_handle_response()
         assert(!err);
         gpt_state.sent_request = true;
 
-        microkit_deferred_notify(config.driver.conn.id);
+        sddf_deferred_notify(config.driver.conn.id);
         return false;
     }
 

--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <microkit.h>
+#include <os/sddf.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <sddf/util/cache.h>
@@ -114,7 +114,7 @@ static void handle_driver()
     /* Notify corresponding client if a response was enqueued */
     for (int i = 0; i < config.num_clients; i++) {
         if (client_notify[i]) {
-            microkit_notify(config.clients[i].conn.id);
+            sddf_notify(config.clients[i].conn.id);
         }
     }
 }
@@ -217,7 +217,7 @@ static bool handle_client(int cli_id)
     }
 
     if (client_notify) {
-        microkit_notify(config.clients[cli_id].conn.id);
+        sddf_notify(config.clients[cli_id].conn.id);
     }
 
     return driver_notify;
@@ -233,11 +233,11 @@ static void handle_clients()
     }
 
     if (driver_notify) {
-        microkit_notify(config.driver.conn.id);
+        sddf_notify(config.driver.conn.id);
     }
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     if (!initialised) {
         /* Continue processing partitions until initialisation has finished. */

--- a/drivers/blk/mmc/imx/usdhc.c
+++ b/drivers/blk/mmc/imx/usdhc.c
@@ -5,7 +5,7 @@
 
 #include "usdhc.h"
 
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/blk/config.h>
 #include <sddf/blk/queue.h>
 #include <sddf/blk/storage_info.h>
@@ -1118,7 +1118,7 @@ void handle_client_device_inactive(void)
         }
     }
 
-    microkit_notify(blk_config.virt.id);
+    sddf_notify(blk_config.virt.id);
 }
 
 void handle_client(bool was_irq)
@@ -1218,7 +1218,7 @@ void handle_client(bool was_irq)
     assert(!err);
     LOG_DRIVER("Enqueued response: status=%d, success_count=%d, id=%d\n", response_status, success_count,
                driver_state.blk_req.id);
-    microkit_notify(blk_config.virt.id);
+    sddf_notify(blk_config.virt.id);
 
     driver_state.blk_req.inflight = false;
 
@@ -1250,12 +1250,12 @@ void do_bringup(void)
     handle_client(/* was_irq: */ false);
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     if (driver_status == DrvStatusBringup) {
         if (ch == device_resources.irqs[0].id) {
             do_bringup();
-            microkit_irq_ack(ch);
+            sddf_irq_ack(ch);
         } else {
             LOG_DRIVER_ERR("notification on non-IRQ channel during bringup: %d\n", ch);
         }
@@ -1265,7 +1265,7 @@ void notified(microkit_channel ch)
 
     if (ch == device_resources.irqs[0].id) {
         handle_client(/* was_irq: */ true);
-        microkit_irq_ack(ch);
+        sddf_irq_ack(ch);
     } else if (ch == blk_config.virt.id) {
         handle_client(/* was_irq: */ false);
     } else if (ch == timer_config.driver_id) {

--- a/drivers/blk/virtio/block.c
+++ b/drivers/blk/virtio/block.c
@@ -15,7 +15,7 @@
  * may be needed if instead this driver was to be used in a different environment.
  */
 
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/util/util.h>
 #include <sddf/util/ialloc.h>
 #include <sddf/virtio/transport/common.h>
@@ -111,7 +111,7 @@ void handle_response(void)
     }
 
     if (notify) {
-        microkit_notify(config.virt.id);
+        sddf_notify(config.virt.id);
     }
 
     last_seen_used = i;
@@ -232,13 +232,13 @@ void handle_request()
         case BLK_REQ_FLUSH: {
             int err = blk_enqueue_resp(&blk_queue, BLK_RESP_OK, 0, id);
             assert(!err);
-            microkit_notify(config.virt.id);
+            sddf_notify(config.virt.id);
             break;
         }
         case BLK_REQ_BARRIER: {
             int err = blk_enqueue_resp(&blk_queue, BLK_RESP_OK, 0, id);
             assert(!err);
-            microkit_notify(config.virt.id);
+            sddf_notify(config.virt.id);
             break;
         }
         default:
@@ -386,7 +386,7 @@ void init(void)
     blk_queue_init(&blk_queue, config.virt.req_queue.vaddr, config.virt.resp_queue.vaddr, config.virt.num_buffers);
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
 // @billn fix ridiculousness
 #if defined(CONFIG_ARCH_X86_64)
@@ -395,7 +395,7 @@ void notified(microkit_channel ch)
     if (ch == device_resources.irqs[0].id) {
 #endif
         handle_irq();
-        microkit_deferred_irq_ack(ch);
+        sddf_deferred_irq_ack(ch);
         /*
          * It is possible that we could not enqueue all requests when being notified
          * by the virtualiser because we ran out of space, so we try again now that

--- a/examples/blk/client.c
+++ b/examples/blk/client.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <microkit.h>
+#include <os/sddf.h>
 #include <sddf/util/printf.h>
 #include <sddf/util/util.h>
 #include <string.h>
@@ -148,14 +148,14 @@ void init(void)
     assert(REQUEST_BLK_NUMBER < storage_info->capacity - REQUEST_NUM_BLOCKS);
 
     test_basic();
-    microkit_notify(blk_config.virt.id);
+    sddf_notify(blk_config.virt.id);
 }
 
-void notified(microkit_channel ch)
+void notified(sddf_channel ch)
 {
     assert(ch == blk_config.virt.id || ch == serial_config.tx.id);
 
     if (ch == blk_config.virt.id && !test_basic()) {
-        microkit_notify(blk_config.virt.id);
+        sddf_notify(blk_config.virt.id);
     }
 }


### PR DESCRIPTION
Further changes to make sDDF OS-agnostic and re-usable with non-microkit systems. follow up from https://github.com/au-ts/sddf/pull/491 and https://github.com/au-ts/sddf/pull/377

Sidenote: discovered the issue fixed with #604 when checking this PR