### PR TITLE
virtio/pci: cleanup/fixes for PCI metadata checking

### DIFF
--- a/drivers/blk/virtio/block.c
+++ b/drivers/blk/virtio/block.c
@@ -19,12 +19,14 @@
 #include <sddf/util/util.h>
 #include <sddf/util/ialloc.h>
 #include <sddf/virtio/transport/common.h>
+#include <sddf/virtio/transport/pci.h>
 #include <sddf/virtio/queue.h>
 #include <sddf/virtio/feature.h>
 #include <sddf/blk/queue.h>
 #include <sddf/blk/config.h>
 #include <sddf/blk/storage_info.h>
 #include <sddf/resources/device.h>
+#include <sddf/pci/conf_space.h>
 #include "block.h"
 
 virtio_device_handle_t dev;
@@ -380,6 +382,10 @@ void init(void)
     dev.pci_bus = 0;
     dev.pci_dev = 3;
     dev.pci_func = 0;
+    dev.pci_class_code = PCI_CLASS_MASS_STORAGE_CONTROLLER;
+    dev.pci_subclass = PCI_CLASS_BLOCK_SUBCLASS_SCSI;
+    dev.pci_vendor_id = VIRTIO_PCI_VEN_ID;
+    dev.pci_device_id = VIRTIO_BLK_PCI_DEV_ID;
 
     virtio_blk_init();
 

--- a/drivers/network/virtio/common/ethernet.c
+++ b/drivers/network/virtio/common/ethernet.c
@@ -24,9 +24,11 @@
 #include <sddf/util/printf.h>
 #include <sddf/util/ialloc.h>
 #include <sddf/virtio/transport/common.h>
+#include <sddf/virtio/transport/pci.h>
 #include <sddf/virtio/queue.h>
 #include <sddf/virtio/feature.h>
 #include <sddf/resources/device.h>
+#include <sddf/pci/conf_space.h>
 
 #include "ethernet.h"
 
@@ -437,6 +439,10 @@ void init(void)
     dev.pci_bus = 0;
     dev.pci_dev = 2;
     dev.pci_func = 0;
+    dev.pci_class_code = PCI_CLASS_NETWORK_CONTROLLER;
+    dev.pci_subclass = PCI_CLASS_NETWORK_SUBCLASS_ETHERNET;
+    dev.pci_vendor_id = VIRTIO_PCI_VEN_ID;
+    dev.pci_device_id = VIRTIO_NET_PCI_DEV_ID;
 
     eth_setup();
 

--- a/include/sddf/pci/conf_space.h
+++ b/include/sddf/pci/conf_space.h
@@ -41,6 +41,7 @@
 #define PCI_CLASS_NON_ESSENTIAL_INSTRUMENTATIONS 19
 
 #define PCI_CLASS_NETWORK_SUBCLASS_ETHERNET 0
+#define PCI_CLASS_BLOCK_SUBCLASS_SCSI 0
 
 /* Every PCI devices implement these common header fields: */
 typedef volatile struct __attribute__((packed)) pci_common_hdr {

--- a/include/sddf/virtio/transport/common.h
+++ b/include/sddf/virtio/transport/common.h
@@ -16,6 +16,8 @@
 #define LOG_VIRTIO_TRANSPORT(...) do{}while(0)
 #endif
 
+#define LOG_VIRTIO_ERR(...) do{ sddf_dprintf("VIRTIO|ERR: "); sddf_dprintf(__VA_ARGS__); }while(0)
+
 #define VIRTIO_VERSION (0x2)
 
 #define VIRTIO_IRQ_VQUEUE  (1 << 0)
@@ -40,6 +42,10 @@ typedef struct virtio_device_handle {
     uint8_t pci_bus;
     uint8_t pci_dev;
     uint8_t pci_func;
+    uint8_t pci_class_code;
+    uint8_t pci_subclass;
+    uint16_t pci_vendor_id;
+    uint16_t pci_device_id;
 } virtio_device_handle_t;
 
 bool virtio_transport_probe(device_resources_t *device_resources, virtio_device_handle_t *device_handle_ret,

--- a/virtio/transport/pci.c
+++ b/virtio/transport/pci.c
@@ -172,53 +172,33 @@ bool virtio_transport_probe(device_resources_t *device_resources, virtio_device_
     uint8_t dev = device_handle_ret->pci_dev;
     uint8_t func = device_handle_ret->pci_func;
 
+    uint8_t pci_class_code = device_handle_ret->pci_class_code;
+    uint8_t pci_subclass = device_handle_ret->pci_subclass;
+    uint16_t pci_vendor_id = device_handle_ret->pci_vendor_id;
+    uint16_t pci_device_id = device_handle_ret->pci_device_id;
+
     pci_gen_dev_hdr_t pci_device_header;
     assert(read_pci_general_device_header(bus, dev, func, &pci_device_header));
 
-    if (device_id == VIRTIO_DEVICE_ID_NET) {
-        if (pci_device_header.common_hdr.class_code != PCI_CLASS_NETWORK_CONTROLLER) {
-            LOG_VIRTIO_TRANSPORT("PCI device @ %u:%u.%u, with class code 0x%x is not a network controller!\n",
-                                 pci_device_header.common_hdr.class_code, bus, dev, func);
-            return false;
-        }
-        if (pci_device_header.common_hdr.subclass != PCI_CLASS_NETWORK_SUBCLASS_ETHERNET) {
-            LOG_VIRTIO_TRANSPORT("PCI device @ %u:%u.%u, with subclass 0x%x is not an ethernet controller!\n",
-                                 pci_device_header.common_hdr.subclass, bus, dev, func);
-            return false;
-        }
-        if (pci_device_header.common_hdr.vendor_id != VIRTIO_PCI_VEN_ID) {
-            LOG_VIRTIO_TRANSPORT("PCI device @ %u:%u.%u, with vendor id 0x%x isn't a virtio device!\n",
-                                 pci_device_header.common_hdr.vendor_id, bus, dev, func);
-            return false;
-        }
-        if (pci_device_header.common_hdr.device_id != VIRTIO_NET_PCI_DEV_ID) {
-            LOG_VIRTIO_TRANSPORT("PCI device @ %u:%u.%u, with device id 0x%x isn't a virtio network device!\n",
-                                 pci_device_header.common_hdr.device_id, bus, dev, func);
-            return false;
-        }
-    } else if (device_id == VIRTIO_DEVICE_ID_BLK) {
-        if (pci_device_header.common_hdr.class_code != PCI_CLASS_MASS_STORAGE_CONTROLLER) {
-            LOG_VIRTIO_TRANSPORT("PCI device @ %u:%u.%u, with class code 0x%x is not a block controller!\n",
-                                 pci_device_header.common_hdr.class_code, bus, dev, func);
-            return false;
-        }
-        if (pci_device_header.common_hdr.subclass != PCI_CLASS_NETWORK_SUBCLASS_ETHERNET) {
-            LOG_VIRTIO_TRANSPORT("PCI device @ %u:%u.%u, with subclass 0x%x is not an block controller!\n",
-                                 pci_device_header.common_hdr.subclass, bus, dev, func);
-            return false;
-        }
-        if (pci_device_header.common_hdr.vendor_id != VIRTIO_PCI_VEN_ID) {
-            LOG_VIRTIO_TRANSPORT("PCI device @ %u:%u.%u, with vendor id 0x%x isn't a block device!\n",
-                                 pci_device_header.common_hdr.vendor_id, bus, dev, func);
-            return false;
-        }
-        if (pci_device_header.common_hdr.device_id != VIRTIO_BLK_PCI_DEV_ID) {
-            LOG_VIRTIO_TRANSPORT("PCI device @ %u:%u.%u, with device id 0x%x isn't a virtio block device!\n",
-                                 pci_device_header.common_hdr.device_id, bus, dev, func);
-            return false;
-        }
-    } else {
-        LOG_VIRTIO_TRANSPORT("Unknown or undefined device class for virtio PCI transport.\n");
+    if (pci_device_header.common_hdr.class_code != pci_class_code) {
+        LOG_VIRTIO_ERR("PCI device @ %u:%u.%u, expected class code 0x%x, got 0x%x!\n", bus, dev, func, pci_class_code,
+                       pci_device_header.common_hdr.class_code);
+        return false;
+    }
+    if (pci_device_header.common_hdr.subclass != pci_subclass) {
+        LOG_VIRTIO_ERR("PCI device @ %u:%u.%u, expected subclass code 0x%x, got 0x%x!\n", bus, dev, func, pci_subclass,
+                       pci_device_header.common_hdr.subclass);
+        return false;
+    }
+    if (pci_device_header.common_hdr.vendor_id != pci_vendor_id) {
+        LOG_VIRTIO_ERR("PCI device @ %u:%u.%u, expected vendor id 0x%x, got 0x%x!\n", bus, dev, func, pci_vendor_id,
+                       pci_device_header.common_hdr.vendor_id);
+        return false;
+    }
+    if (pci_device_header.common_hdr.device_id != pci_device_id) {
+        LOG_VIRTIO_ERR("PCI device @ %u:%u.%u, expected device id 0x%x, got 0x%x!\n", bus, dev, func, pci_device_id,
+                       pci_device_header.common_hdr.device_id);
+        return false;
     }
 
     pci_debug_print_header(bus, dev, func, &pci_device_header);


### PR DESCRIPTION
Checking the right values for all the possible devices we support doesn't scale well, the drivers should do it themselves.