### PR TITLE
Update max timeouts to sddf timer max clients

### DIFF
--- a/drivers/timer/apb_timer/timer.c
+++ b/drivers/timer/apb_timer/timer.c
@@ -23,7 +23,6 @@
 
 #define NUM_TIMERS 2 // Adjust if synthesised with more timers.                                                                       \
                         // Minimum = 2 due to a bug in the HDL, assumed for rest of this driver.
-#define MAX_TIMEOUTS (NUM_TIMERS)
 #define APBTIMER_MAX_TICKS (UINT32_MAX)
 #define APBTIMER_CLK_FREQ ((uint64_t)50000000) // 50MHz
 #define NANO_INVERSE NS_IN_S

--- a/drivers/timer/arm/timer.c
+++ b/drivers/timer/arm/timer.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <os/sddf.h>
 #include <sddf/timer/protocol.h>
+#include <sddf/timer/config.h>
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
 #include <sddf/util/udivmodti4.h>
@@ -17,7 +18,7 @@
 
 static uint64_t timer_freq;
 
-#define MAX_TIMEOUTS 6
+#define MAX_TIMEOUTS SDDF_TIMER_MAX_CLIENTS
 
 #define GENERIC_TIMER_ENABLE (1 << 0)
 #define GENERIC_TIMER_IMASK  (1 << 1)

--- a/drivers/timer/bcm2835/timer.c
+++ b/drivers/timer/bcm2835/timer.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <os/sddf.h>
 #include <sddf/timer/protocol.h>
+#include <sddf/timer/config.h>
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
 #include <sddf/resources/device.h>
@@ -51,7 +52,7 @@ static volatile bcm2835_timer_regs_t *timer_regs;
 #define BCM2835_TIMER_MAX_US UINT32_MAX
 
 #define CLIENT_CH_START 1
-#define MAX_TIMEOUTS 6
+#define MAX_TIMEOUTS SDDF_TIMER_MAX_CLIENTS
 static uint64_t timeouts[MAX_TIMEOUTS];
 
 static inline uint64_t get_ticks_in_ns(void)

--- a/drivers/timer/cdns/timer.c
+++ b/drivers/timer/cdns/timer.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <os/sddf.h>
 #include <sddf/timer/protocol.h>
+#include <sddf/timer/config.h>
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
 #include <sddf/resources/device.h>
@@ -87,7 +88,7 @@ sddf_channel timeout_irq;
 
 /* offset for the 2 interrupt channels */
 #define CLIENT_CH_START 2
-#define MAX_TIMEOUTS 6
+#define MAX_TIMEOUTS SDDF_TIMER_MAX_CLIENTS
 static uint64_t timeouts[MAX_TIMEOUTS];
 
 static inline uint64_t get_ticks_in_ns(void)

--- a/drivers/timer/goldfish/timer.c
+++ b/drivers/timer/goldfish/timer.c
@@ -6,11 +6,12 @@
 #include <stdint.h>
 #include <os/sddf.h>
 #include <sddf/timer/protocol.h>
+#include <sddf/timer/config.h>
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
 #include <sddf/resources/device.h>
 
-#define MAX_TIMEOUTS 6
+#define MAX_TIMEOUTS SDDF_TIMER_MAX_CLIENTS
 
 /* taken from: https://github.com/torvalds/linux/blob/master/include/clocksource/timer-goldfish.h */
 typedef struct {

--- a/drivers/timer/hpet/timer.c
+++ b/drivers/timer/hpet/timer.c
@@ -8,6 +8,7 @@
 #include <sddf/util/printf.h>
 #include <sddf/resources/device.h>
 #include <sddf/timer/protocol.h>
+#include <sddf/timer/config.h>
 
 __attribute__((__section__(".device_resources"))) device_resources_t device_resources;
 
@@ -76,7 +77,7 @@ uintptr_t HPET_REGION = 0x50000000;
 volatile hpet_timer_t *timer_0;
 uint64_t tick_period_fs; // main counter tick period in femtoseconds
 
-#define MAX_TIMEOUTS 6
+#define MAX_TIMEOUTS SDDF_TIMER_MAX_CLIENTS
 
 uint64_t timeouts[MAX_TIMEOUTS];
 uint64_t next_timeout = UINT64_MAX;

--- a/drivers/timer/imx/timer.c
+++ b/drivers/timer/imx/timer.c
@@ -13,6 +13,7 @@
 #include <sddf/resources/device.h>
 #include <sddf/util/printf.h>
 #include <sddf/timer/protocol.h>
+#include <sddf/timer/config.h>
 
 #define GPT_STATUS_REGISTER_CLEAR 0x3F
 #define CR 0
@@ -26,7 +27,7 @@
 #define ICR2 8
 #define CNT 9
 
-#define MAX_TIMEOUTS 6
+#define MAX_TIMEOUTS SDDF_TIMER_MAX_CLIENTS
 
 #define GPT_FREQ   (12u)
 

--- a/drivers/timer/jh7110/timer.c
+++ b/drivers/timer/jh7110/timer.c
@@ -9,6 +9,7 @@
 #include <sddf/util/util.h>
 #include <sddf/util/printf.h>
 #include <sddf/timer/protocol.h>
+#include <sddf/timer/config.h>
 
 /*
  * The JH7110 SoC contains a timer with four 32-bit counters. Each one of these
@@ -29,7 +30,7 @@
 #endif
 
 #define CLIENT_CH_START 2
-#define MAX_TIMEOUTS 6
+#define MAX_TIMEOUTS SDDF_TIMER_MAX_CLIENTS
 
 #define STARFIVE_TIMER_MAX_TICKS UINT32_MAX
 #define STARFIVE_TIMER_MODE_CONTINUOUS 0

--- a/drivers/timer/meson/timer.c
+++ b/drivers/timer/meson/timer.c
@@ -8,8 +8,9 @@
 #include <sddf/resources/device.h>
 #include <sddf/util/printf.h>
 #include <sddf/timer/protocol.h>
+#include <sddf/timer/config.h>
 
-#define MAX_TIMEOUTS 6
+#define MAX_TIMEOUTS SDDF_TIMER_MAX_CLIENTS
 
 #define TIMER_REG_START   0x70    // TIMER_MUX
 


### PR DESCRIPTION
Updates the MAX_TIMEOUTS constant to use SDDF_TIMER_MAX_CLIENTS. Except in the case of the apb_timer, which remains unchanged