### PR TITLE
nix: Add missing dependency for gdisk

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,7 @@
               qemu
               gnumake
               dosfstools
+              gptfdisk
               imagemagick
               # for shasum
               perl


### PR DESCRIPTION
Without it blk will fail to set up disks.