### PR TITLE
ci: macos fix; remove new type keyword

### DIFF
--- a/ci/lib/runner.py
+++ b/ci/lib/runner.py
@@ -30,8 +30,8 @@ from .backends import (
 )
 from ci.common import TestConfig, loader_img_path
 
-type TestFunction = Callable[[HardwareBackend, TestConfig], Awaitable[None]]
-type BackendFunction = Callable[[TestConfig, Path], HardwareBackend]
+TestFunction = Callable[[HardwareBackend, TestConfig], Awaitable[None]]
+BackendFunction = Callable[[TestConfig, Path], HardwareBackend]
 
 
 async def _watch_stdout_inactivity(


### PR DESCRIPTION
Removes the too new `type` keyword for type aliases.