### PR TITLE
ci: fix import module path for older Python (3.9)

### DIFF
--- a/ci/run.py
+++ b/ci/run.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     backend_fns: dict[str, BackendFunction] = {}
 
     for example in examples_list:
-        mod = importlib.import_module(f"examples.{example}")
+        mod = importlib.import_module(f"ci.examples.{example}")
         matrix.extend(mod.TEST_MATRIX)
         test_fns[example] = mod.test
         custom_backend_fn = callable(getattr(mod, "backend_fn", None))


### PR DESCRIPTION
Really need to just run these scripts in CI with Python 3.9 instead. https://github.com/au-ts/sddf/issues/628.