### PR TITLE
ci/nix: downgrade python to 3.9, enforce in scripts

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 import contextlib
 
+assert list(map(int, sys.version.split(" ")[0].split("."))) > [3, 9, 0]
+
 sys.path.insert(1, Path(__file__).parents[1].as_posix())
 
 from ci.lib.runner import ArgparseActionList, TestConfig, matrix_product

--- a/ci/examples/blk.py
+++ b/ci/examples/blk.py
@@ -10,6 +10,8 @@ import sys
 import tempfile
 import types
 
+assert list(map(int, sys.version.split(" ")[0].split("."))) > [3, 9, 0]
+
 sys.path.insert(1, Path(__file__).parents[2].as_posix())
 
 from ci.lib.backends import *

--- a/ci/examples/echo_server.py
+++ b/ci/examples/echo_server.py
@@ -7,6 +7,8 @@ import re
 from pathlib import Path
 import sys
 
+assert list(map(int, sys.version.split(" ")[0].split("."))) > [3, 9, 0]
+
 sys.path.insert(1, Path(__file__).parents[2].as_posix())
 
 from ci.lib.backends import *

--- a/ci/examples/i2c.py
+++ b/ci/examples/i2c.py
@@ -6,6 +6,8 @@ import asyncio
 from pathlib import Path
 import sys
 
+assert list(map(int, sys.version.split(" ")[0].split("."))) > [3, 9, 0]
+
 sys.path.insert(1, Path(__file__).parents[2].as_posix())
 
 from ci.lib.backends import *

--- a/ci/examples/i2c_bus_scan.py
+++ b/ci/examples/i2c_bus_scan.py
@@ -6,6 +6,8 @@ import asyncio
 from pathlib import Path
 import sys
 
+assert list(map(int, sys.version.split(" ")[0].split("."))) > [3, 9, 0]
+
 sys.path.insert(1, Path(__file__).parents[2].as_posix())
 
 from ci.lib.backends import *

--- a/ci/examples/serial.py
+++ b/ci/examples/serial.py
@@ -6,6 +6,8 @@ import asyncio
 from pathlib import Path
 import sys
 
+assert list(map(int, sys.version.split(" ")[0].split("."))) > [3, 9, 0]
+
 sys.path.insert(1, Path(__file__).parents[2].as_posix())
 
 from ci.lib.backends import *

--- a/ci/examples/timer.py
+++ b/ci/examples/timer.py
@@ -6,6 +6,8 @@ import asyncio
 from pathlib import Path
 import sys
 
+assert list(map(int, sys.version.split(" ")[0].split("."))) > [3, 9, 0]
+
 sys.path.insert(1, Path(__file__).parents[2].as_posix())
 
 from ci.lib.backends import *

--- a/ci/run.py
+++ b/ci/run.py
@@ -7,6 +7,8 @@ import os
 from pathlib import Path
 import sys
 
+assert list(map(int, sys.version.split(" ")[0].split("."))) > [3, 9, 0]
+
 sys.path.insert(1, Path(__file__).parents[1].as_posix())
 
 from ci.common import TestConfig, backend_fn

--- a/flake.lock
+++ b/flake.lock
@@ -100,9 +100,26 @@
         "type": "github"
       }
     },
+    "python39": {
+      "locked": {
+        "lastModified": 1742943473,
+        "narHash": "sha256-u7+CYuAuCiJH3scDvMV9oj3p22ygnFhTXUefXUgd/LI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c5dd43934613ae0f8ff37c59f61c507c2e8f980d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c5dd43934613ae0f8ff37c59f61c507c2e8f980d",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "python39": "python39",
         "sdfgen": "sdfgen",
         "zig-overlay": "zig-overlay_2"
       }


### PR DESCRIPTION
This prevents issues with too new Python version features, like #629 

If anyone has a better way of preventing that, I'm willing to change it.