### PR TITLE
Fix missing libc build dependencies

### DIFF
--- a/drivers/blk/virtio/mmio/blk_driver.mk
+++ b/drivers/blk/virtio/mmio/blk_driver.mk
@@ -22,7 +22,7 @@ blk/virtio/blk_driver.o: ${VIRTIO_BLK_DRIVER_DIR}/block.c ${CHECK_BLKDRV_FLAGS_M
 	mkdir -p blk/virtio/mmio
 	$(CC) -c $(CFLAGS) -I${VIRTIO_BLK_DRIVER_DIR}/include -o $@ $<
 
-blk/virtio/mmio/transport.o: ${VIRTIO_TRANSPORT_DIR}/mmio.c ${CHECK_BLKDRV_FLAGS_MD5}
+blk/virtio/mmio/transport.o: ${VIRTIO_TRANSPORT_DIR}/mmio.c ${CHECK_BLKDRV_FLAGS_MD5} | $(SDDF_LIBC_INCLUDE)
 	mkdir -p blk/virtio/mmio
 	${CC} -c ${CFLAGS} -o $@ $<
 

--- a/drivers/blk/virtio/pci/blk_driver.mk
+++ b/drivers/blk/virtio/pci/blk_driver.mk
@@ -22,7 +22,7 @@ blk/virtio/blk_driver.o: ${VIRTIO_BLK_DRIVER_DIR}/block.c ${CHECK_BLKDRV_FLAGS_M
 	mkdir -p blk/virtio/pci
 	$(CC) -c $(CFLAGS) -I${VIRTIO_BLK_DRIVER_DIR}/include -o $@ $<
 
-blk/virtio/pci/transport.o: ${VIRTIO_TRANSPORT_DIR}/pci.c ${CHECK_BLKDRV_FLAGS_MD5}
+blk/virtio/pci/transport.o: ${VIRTIO_TRANSPORT_DIR}/pci.c ${CHECK_BLKDRV_FLAGS_MD5} | $(SDDF_LIBC_INCLUDE)
 	mkdir -p blk/virtio/pci
 	${CC} -c ${CFLAGS} -o $@ $<
 

--- a/drivers/network/virtio/mmio/eth_driver.mk
+++ b/drivers/network/virtio/mmio/eth_driver.mk
@@ -27,7 +27,7 @@ network/virtio/mmio/ethernet.o: ${ETHERNET_COMMON_DIR}/ethernet.c ${CHECK_NETDRV
 	mkdir -p network/virtio/mmio
 	${CC} -c ${CFLAGS} ${CFLAGS_network} -I ${ETHERNET_DRIVER_DIR} -o $@ $<
 
-network/virtio/mmio/transport.o: ${VIRTIO_TRANSPORT_DIR}/mmio.c ${CHECK_NETDRV_FLAGS}
+network/virtio/mmio/transport.o: ${VIRTIO_TRANSPORT_DIR}/mmio.c ${CHECK_NETDRV_FLAGS} | $(SDDF_LIBC_INCLUDE)
 	mkdir -p network/virtio/mmio
 	${CC} -c ${CFLAGS} -o $@ $<
 

--- a/drivers/network/virtio/pci/eth_driver.mk
+++ b/drivers/network/virtio/pci/eth_driver.mk
@@ -27,7 +27,7 @@ network/virtio/pci/ethernet.o: ${ETHERNET_COMMON_DIR}/ethernet.c ${CHECK_NETDRV_
 	mkdir -p network/virtio/pci
 	${CC} -c ${CFLAGS} ${CFLAGS_network} -I ${ETHERNET_DRIVER_DIR} -o $@ $<
 
-network/virtio/pci/transport.o: ${VIRTIO_TRANSPORT_DIR}/pci.c ${CHECK_NETDRV_FLAGS}
+network/virtio/pci/transport.o: ${VIRTIO_TRANSPORT_DIR}/pci.c ${CHECK_NETDRV_FLAGS} | $(SDDF_LIBC_INCLUDE)
 	mkdir -p network/virtio/pci
 	${CC} -c ${CFLAGS} -o $@ $<
 


### PR DESCRIPTION
Their absence was causing some multithreaded builds on LionsOS to fail.