### PR TITLE
dwmac: Don't use raw tail index

### DIFF
--- a/drivers/network/dwmac-5.10a/ethernet.c
+++ b/drivers/network/dwmac-5.10a/ethernet.c
@@ -100,7 +100,7 @@ static void rx_provide()
             /* We will update the hardware register that stores the tail address. This tells
             the device that we have new descriptors to use. */
             THREAD_MEMORY_RELEASE();
-            *DMA_REG(DMA_CH0_RXDESC_TAIL_PTR) = rx_desc_base + sizeof(struct descriptor) * rx.tail;
+            *DMA_REG(DMA_CH0_RXDESC_TAIL_PTR) = rx_desc_base + sizeof(struct descriptor) * idx;
             rx.tail++;
         }
 


### PR DESCRIPTION
Previously, we were setting the rx descriptor tail pointer to: 
```c
rx_desc_base + sizeof(struct descriptor) * rx.tail;
```
We should be bounding this by the capacity of the rx descriptor list, which we already do a couple lines above when we calculate `idx`.

Digging into why this worked previously, the NIC will process packets until it finds a packet that is either not owned by DMA, or if the current descriptor pointer that it maintains is equal to the rx descriptor tail. When it reaches either of those 2 cases, the NIC goes into a suspended mode. When we write to the rx descriptor tail register, it will wake up and continue consuming descriptors. When the NIC reaches the end of this list, it'll wrap itself around to the start of the list. In this situation, writing to the tail descriptor register seems to just be used to wake up the NIC.

What happens when we overflow the uint32_t of rx.tail I'm not entirely sure, it may not break anything but this PR changes it to the correct behaviour.