### PR TITLE
examples: only add GPIO/clock regions for Odroid-C4 I2C

### DIFF
--- a/examples/i2c/meta.py
+++ b/examples/i2c/meta.py
@@ -31,15 +31,15 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
     client_pn532 = ProtectionDomain("client_pn532", "client_pn532.elf", priority=1)
     client_ds3231 = ProtectionDomain("client_ds3231", "client_ds3231.elf", priority=1)
 
-    # Right now we do not have separate clk and GPIO drivers and so our I2C driver does manual
-    # clk/GPIO setup for I2C.
-    clk_mr = MemoryRegion(sdf, "clk", 0x1000, paddr=0xFF63C000)
-    gpio_mr = MemoryRegion(sdf, "gpio", 0x1000, paddr=0xFF634000)
-    sdf.add_mr(clk_mr)
-    sdf.add_mr(gpio_mr)
-
-    i2c_driver.add_map(Map(clk_mr, 0x30_000_000, "rw", cached=False))
-    i2c_driver.add_map(Map(gpio_mr, 0x30_100_000, "rw", cached=False))
+    if board.name == "odroidc4":
+        # Odroid-C4 I2C requires clocks/GPIO setup, for now we give the I2C driver
+        # direct access.
+        clk_mr = MemoryRegion(sdf, "clk", 0x1000, paddr=0xFF63C000)
+        gpio_mr = MemoryRegion(sdf, "gpio", 0x1000, paddr=0xFF634000)
+        sdf.add_mr(clk_mr)
+        sdf.add_mr(gpio_mr)
+        i2c_driver.add_map(Map(clk_mr, 0x30_000_000, "rw", cached=False))
+        i2c_driver.add_map(Map(gpio_mr, 0x30_100_000, "rw", cached=False))
 
     i2c_node = dtb.node(board.i2c)
     assert i2c_node is not None

--- a/examples/i2c_bus_scan/meta.py
+++ b/examples/i2c_bus_scan/meta.py
@@ -31,15 +31,15 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
     i2c_virt = ProtectionDomain("i2c_virt", "i2c_virt.elf", priority=2)
     client_scan = ProtectionDomain("client_scan", "client_scan.elf", priority=1)
 
-    # Right now we do not have separate clk and GPIO drivers and so our I2C driver does manual
-    # clk/GPIO setup for I2C.
-    clk_mr = MemoryRegion(sdf, "clk", 0x1000, paddr=0xFF63C000)
-    gpio_mr = MemoryRegion(sdf, "gpio", 0x1000, paddr=0xFF634000)
-    sdf.add_mr(clk_mr)
-    sdf.add_mr(gpio_mr)
-
-    i2c_driver.add_map(Map(clk_mr, 0x30_000_000, "rw", cached=False))
-    i2c_driver.add_map(Map(gpio_mr, 0x30_100_000, "rw", cached=False))
+    if board.name == "odroidc4":
+        # Odroid-C4 I2C requires clocks/GPIO setup, for now we give the I2C driver
+        # direct access.
+        clk_mr = MemoryRegion(sdf, "clk", 0x1000, paddr=0xFF63C000)
+        gpio_mr = MemoryRegion(sdf, "gpio", 0x1000, paddr=0xFF634000)
+        sdf.add_mr(clk_mr)
+        sdf.add_mr(gpio_mr)
+        i2c_driver.add_map(Map(clk_mr, 0x30_000_000, "rw", cached=False))
+        i2c_driver.add_map(Map(gpio_mr, 0x30_100_000, "rw", cached=False))
 
     i2c_node = dtb.node(board.i2c)
     assert i2c_node is not None


### PR DESCRIPTION
Closes https://github.com/au-ts/sddf/issues/655.