### PR TITLE
lib_sddf_lwip: add create modifier to ar invocations

### DIFF
--- a/network/lib_sddf_lwip/lib_sddf_lwip.mk
+++ b/network/lib_sddf_lwip/lib_sddf_lwip.mk
@@ -50,11 +50,11 @@ LIB_SDDF_LWIP_LWIP_FILES := \
 LIB_SDDF_LWIP_LWIP_FILES := $(subst $(LWIPDIR)/,,$(LIB_SDDF_LWIP_LWIP_FILES))
 
 lib_sddf_lwip.a: lib_sddf_lwip_out/lib_sddf_lwip.o $(addprefix lib_sddf_lwip_out/, $(LIB_SDDF_LWIP_LWIP_FILES:.c=.o))
-	$(AR) rv $@ $^
+	$(AR) crv $@ $^
 	$(RANLIB) $@
 
 lib_sddf_lwip%.a: lib_sddf_lwip_out%/lib_sddf_lwip.o $(addprefix lib_sddf_lwip_out%/, $(LIB_SDDF_LWIP_LWIP_FILES:.c=.o))
-	$(AR) rv $@ $^
+	$(AR) crv $@ $^
 	$(RANLIB) $@
 
 lib_sddf_lwip_out/lib_sddf_lwip.o: CFLAGS += $(LIB_SDDF_LWIP_CFLAGS)


### PR DESCRIPTION
This hides the 'creating xxx.ar' warning.