### PR TITLE
drivers/i2c/opentitan: fix log printing

### DIFF
--- a/drivers/i2c/i2c_common.c
+++ b/drivers/i2c/i2c_common.c
@@ -73,7 +73,7 @@ void fsm_virt_notified(fsm_data_t *fsm_data)
  * Reset driver data and goto request state if there's work to do. Otherwise, go to sleep.
  *
  * Succeeds: S_RESP, or any state when failing
- * Sucessor(s): S_REQ
+ * Successor(s): S_REQ
  */
 void state_idle(fsm_data_t *fsm, i2c_driver_data_t *data, i2c_queue_handle_t *queue_handle)
 {
@@ -106,7 +106,7 @@ void state_req(fsm_data_t *fsm, i2c_driver_data_t *data, i2c_queue_handle_t *que
 
     // Sanity check. This should be impossible.
     if (i2c_queue_empty(queue_handle->request->ctrl)) {
-        LOG_I2C_DRIVER_ERR("State machine reached invalid state! In request state without work to do...");
+        LOG_I2C_DRIVER_ERR("State machine reached invalid state! In request state without work to do...\n");
         assert(false);
     }
 
@@ -149,7 +149,7 @@ void state_req(fsm_data_t *fsm, i2c_driver_data_t *data, i2c_queue_handle_t *que
  * This sets up the await flags and rw_idx, as well as keeping track of progression through
  * the buffer. It also decides when the request is finished.
  * Succeeds: S_REQ, S_CMD_RET
- * Sucessor(s): S_CMD, S_IDLE (fatal), S_RESPONSE (done or error)
+ * Successor(s): S_CMD, S_IDLE (fatal), S_RESPONSE (done or error)
  */
 void state_sel_cmd(fsm_data_t *fsm, i2c_driver_data_t *data, i2c_queue_handle_t *queue_handle)
 {
@@ -207,7 +207,7 @@ void state_sel_cmd(fsm_data_t *fsm, i2c_driver_data_t *data, i2c_queue_handle_t 
  * Handle returning current request to virt.
  *
  * Succeeds: S_SEL_CMD (success), any other state (err set)
- * Sucessor(s): S_IDLE
+ * Successor(s): S_IDLE
  */
 void state_resp(fsm_data_t *f, i2c_driver_data_t *data, i2c_queue_handle_t *queue_handle)
 {

--- a/drivers/i2c/opentitan/i2c.c
+++ b/drivers/i2c/opentitan/i2c.c
@@ -147,7 +147,7 @@ int i2c_fmt_write(uint8_t data, fdata_fmt_flags_t *flags)
                         || (flags->stop && !flags->nakok && flags->readb && !flags->rcont));
     if (!flags_valid) {
         LOG_I2C_DRIVER_ERR("Invalid fmt flags supplied to sddf_i2c_write! Combination cannot be represented "
-                           "by hardware!");
+                           "by hardware!\n");
         return -1;
     }
     uint32_t addr_fdata = (data)&I2C_FDATA_FBYTE_MASK;
@@ -268,7 +268,7 @@ void state_cmd(fsm_data_t *fsm, i2c_driver_data_t *data, i2c_queue_handle_t *que
     if (work_done) {
         fsm->next_state = S_CMD_RET;
     } else {
-        LOG_I2C_DRIVER_ERR("Warning: S_CMD exited without progress! Sleeping to retry.");
+        LOG_I2C_DRIVER_ERR("Warning: S_CMD exited without progress! Sleeping to retry.\n");
         fsm->next_state = S_CMD;
     }
     fsm->yield = true; // We want to go to sleep awaiting the IRQ coming back to us.
@@ -280,7 +280,7 @@ void state_cmd(fsm_data_t *fsm, i2c_driver_data_t *data, i2c_queue_handle_t *que
  * continue working on the current command or to return to S_SEL_CMD for a new one.
  *
  * Succeeds: S_CMD
- * Sucessor(s): S_CMD (cmd not finished yet), S_SEL_CMD (cmd finished), S_RESP (error)
+ * Successor(s): S_CMD (cmd not finished yet), S_SEL_CMD (cmd finished), S_RESP (error)
  */
 void state_cmd_ret(fsm_data_t *f, i2c_driver_data_t *data, i2c_queue_handle_t *queue_handle)
 {
@@ -328,18 +328,18 @@ void init(void)
 
     regs = (volatile opentitan_i2c_regs_t *)device_resources.regions[0].region.vaddr;
 
-    LOG_I2C_DRIVER("I2C DRIVER|INFO: Timing parameters configuration:\n");
-    LOG_I2C_DRIVER("I2C DRIVER|INFO: \t t_high_min = %u\n", timing_params.t_high_min);
-    LOG_I2C_DRIVER("I2C DRIVER|INFO: \t t_low_min = %u\n", timing_params.t_low_min);
-    LOG_I2C_DRIVER("I2C DRIVER|INFO: \t t_hd_dat_min = %u\n", timing_params.t_hd_dat_min);
-    LOG_I2C_DRIVER("I2C DRIVER|INFO: \t t_hd_sta_min = %u\n", timing_params.t_hd_sta_min);
-    LOG_I2C_DRIVER("I2C DRIVER|INFO: \t t_su_sta_min = %u\n", timing_params.t_su_sta_min);
-    LOG_I2C_DRIVER("I2C DRIVER|INFO: \t t_buf_min = %u\n", timing_params.t_buf_min);
-    LOG_I2C_DRIVER("I2C DRIVER|INFO: \t t_sto_min = %u\n", timing_params.t_sto_min);
-    LOG_I2C_DRIVER("I2C DRIVER|INFO: \t t_r = %u\n", timing_params.t_r);
-    LOG_I2C_DRIVER("I2C DRIVER|INFO: \t t_f = %u\n", timing_params.t_f);
-    LOG_I2C_DRIVER("I2C DRIVER|INFO: \t t_h = %u\n", timing_params.t_h);
-    LOG_I2C_DRIVER("I2C DRIVER|INFO: \t t_l = %u\n", timing_params.t_l);
+    LOG_I2C_DRIVER("Timing parameters configuration:\n");
+    LOG_I2C_DRIVER("\t t_high_min = %u\n", timing_params.t_high_min);
+    LOG_I2C_DRIVER("\t t_low_min = %u\n", timing_params.t_low_min);
+    LOG_I2C_DRIVER("\t t_hd_dat_min = %u\n", timing_params.t_hd_dat_min);
+    LOG_I2C_DRIVER("\t t_hd_sta_min = %u\n", timing_params.t_hd_sta_min);
+    LOG_I2C_DRIVER("\t t_su_sta_min = %u\n", timing_params.t_su_sta_min);
+    LOG_I2C_DRIVER("\t t_buf_min = %u\n", timing_params.t_buf_min);
+    LOG_I2C_DRIVER("\t t_sto_min = %u\n", timing_params.t_sto_min);
+    LOG_I2C_DRIVER("\t t_r = %u\n", timing_params.t_r);
+    LOG_I2C_DRIVER("\t t_f = %u\n", timing_params.t_f);
+    LOG_I2C_DRIVER("\t t_h = %u\n", timing_params.t_h);
+    LOG_I2C_DRIVER("\t t_l = %u\n", timing_params.t_l);
 
     // Perform initial set up - calculate and validate timing parameters.
     // If any of the below conditions are not true, the device cannot initialise!
@@ -447,7 +447,7 @@ void notified(microkit_channel ch)
         driver_data.err = I2C_ERR_OTHER;
         microkit_irq_ack(ch);
     } else {
-        microkit_dbg_puts("DRIVER|ERROR: unexpected notification!\n");
+        LOG_I2C_DRIVER_ERR("unexpected notification!\n");
     }
     // Handle error IRQ if we are in the process of handling a request
     if (driver_data.err != I2C_ERR_OK && (fsm_data.curr_state == S_CMD || fsm_data.curr_state == S_CMD_RET)) {

--- a/i2c/libi2c.c
+++ b/i2c/libi2c.c
@@ -27,7 +27,7 @@ static inline int check_data_buf(void *data_buf)
 {
     if ((uintptr_t)data_buf < (uintptr_t)I2C_DATA_REGION
         || (uintptr_t)data_buf > ((uintptr_t)I2C_DATA_REGION + i2c_config.data.size)) {
-        LOG_LIBI2C_ERR("sddf_i2c_write called with data_buf not in data region!");
+        LOG_LIBI2C_ERR("sddf_i2c_write called with data_buf not in data region!\n");
         return -1;
     }
     return 0;
@@ -56,7 +56,7 @@ static void __i2c_block(libi2c_conf_t *conf)
  */
 static int __i2c_dispatch(libi2c_conf_t *conf, i2c_addr_t address, void *buf, uint16_t len, uint8_t flag_mask)
 {
-    LOG_LIBI2C("Dispatch: to=%zu, buf = %p, flag_mask = %zu, len = %zu\n", address, buf, flag_mask, len);
+    LOG_LIBI2C("Dispatch: to=%u, buf = %p, flag_mask = 0x%x, len = %u\n", address, buf, flag_mask, len);
     // Check that supplied buffer is within bounds of data region
     if (check_data_buf(buf)) {
         return -1;
@@ -81,7 +81,7 @@ static int __i2c_dispatch(libi2c_conf_t *conf, i2c_addr_t address, void *buf, ui
 
     // Slice buffer into 255 byte long segments and enqueue.
     for (uint16_t i = 0; i < num_batches; i++) {
-        LOG_LIBI2C("Slice %zu / %zu\n", i + 1, num_batches);
+        LOG_LIBI2C("Slice %u / %u\n", i + 1, num_batches);
         uint16_t curr_offset = ((1 << 8) * i);
         // Batch of 255, unless there are fewer commands left.
         uint8_t data_len = (len - curr_offset) >= 255 ? 255 : (uint8_t)(len - curr_offset);


### PR DESCRIPTION
1. Forgotten newline
2. Duplicate I2C DRIVER|INFO print
3. Typos