### PR TITLE
ZynqMP GEM (Ethernet) Driver

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -28,6 +28,7 @@ Files:
     drivers/network/meson/config.json
     drivers/network/virtio/mmio/config.json
     drivers/network/dwmac-5.10a/config.json
+    drivers/network/zynqmp-gem/config.json
     drivers/serial/arm/config.json
     drivers/serial/imx/config.json
     drivers/serial/meson/config.json

--- a/ci/matrix.py
+++ b/ci/matrix.py
@@ -108,6 +108,7 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
             "rpi4b_1gb",
             "star64",
             "x86_64_generic",
+            "zcu102",
         ],
         "tests_exclude": [
             # not in machine queue
@@ -190,6 +191,7 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
             "rpi4b_1gb",
             "star64",
             "x86_64_generic",
+            "zcu102",
         ],
         "tests_exclude": [
             # not in machine queue

--- a/drivers/network/zynqmp-gem/config.json
+++ b/drivers/network/zynqmp-gem/config.json
@@ -1,0 +1,29 @@
+{
+    "compatible": [
+        "xlnx,zynqmp-gem",
+        "cdns,gem"
+    ],
+    "resources": {
+        "regions": [
+            {
+                "name": "regs",
+                "perms": "rw",
+                "size": 4096,
+                "dt_index": 0
+            },
+            {
+                "name": "device_rx_ring",
+                "size": 32768
+            },
+            {
+                "name": "device_tx_ring",
+                "size": 32768
+            }
+        ],
+        "irqs": [
+            {
+                "dt_index": 0
+            }
+        ]
+    }
+}

--- a/drivers/network/zynqmp-gem/eth_driver.mk
+++ b/drivers/network/zynqmp-gem/eth_driver.mk
@@ -1,0 +1,28 @@
+#
+# Copyright 2026, Skykraft
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Include this snippet in your project Makefile to build
+# the zynqmp-gem NIC driver
+#
+# NOTES
+#  Generates eth_driver_znyqmp_gem.elf
+#  Expects libsddf_util_debug.a to be in LIBS
+
+ETHERNET_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+CHECK_NETDRV_FLAGS_MD5:=.netdrv_cflags-$(shell echo -- ${CFLAGS} ${CFLAGS_network} | shasum | sed 's/ *-//')
+
+${CHECK_NETDRV_FLAGS_MD5}:
+	-rm -f .netdrv_cflags-*
+	touch $@
+
+eth_driver_znyqmp_gem.elf: network/zynqmp-gem/ethernet.o
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+network/zynqmp-gem/ethernet.o: ${ETHERNET_DRIVER_DIR}/ethernet.c ${CHECK_NETDRV_FLAGS_MD5}
+	mkdir -p network/zynqmp-gem
+	${CC} -c ${CFLAGS} ${CFLAGS_network} -I ${ETHERNET_DRIVER_DIR} -o $@ $<
+
+
+-include zynqmp-gem/ethernet.d

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -45,8 +45,6 @@ hw_ring_t tx; /* Tx NIC ring */
 net_queue_handle_t rx_queue;
 net_queue_handle_t tx_queue;
 
-#define MAX_PACKET_SIZE     1536
-
 volatile zynqmp_gem_regs_t *eth;
 
 static inline bool hw_ring_full(hw_ring_t *ring)
@@ -238,6 +236,37 @@ static void handle_irq(void)
     }
 }
 
+/** Disable unused priority queue 1 by pointing it at a permanent terminator descriptor
+ * beyond the end of each active ring (i.e. at index RX_COUNT / TX_COUNT).
+ * Disabled by having the SW-ownership bit set so hardware will never process it.
+ * This region is never touched by rx_provide() / tx_provide(), so the terminator
+ * state is stable for the lifetime of the driver.
+ */
+static void disable_pq1(void) {
+    volatile struct descriptor *rx_q1_terminator =
+        (volatile struct descriptor *)(device_resources.regions[1].region.vaddr +
+                                       rx.capacity * sizeof(struct descriptor));
+    rx_q1_terminator->addr    = RXD_OWN | RXD_WRAP; /* SW owns + wrap terminator */
+    rx_q1_terminator->stat    = 0;
+    rx_q1_terminator->addr_hi = 0;
+    rx_q1_terminator->unused  = 0;
+
+    volatile struct descriptor *tx_q1_terminator =
+        (volatile struct descriptor *)(device_resources.regions[2].region.vaddr +
+                                       tx.capacity * sizeof(struct descriptor));
+    tx_q1_terminator->addr    = 0;
+    tx_q1_terminator->stat    = TXD_USED | TXD_WRAP; /* SW owns + wrap terminator */
+    tx_q1_terminator->addr_hi = 0;
+    tx_q1_terminator->unused  = 0;
+
+    uintptr_t rx_q1_ptr = device_resources.regions[1].io_addr +
+                          rx.capacity * sizeof(struct descriptor);
+    uintptr_t tx_q1_ptr = device_resources.regions[2].io_addr +
+                          tx.capacity * sizeof(struct descriptor);
+    eth->receive_q1_ptr  = (uint32_t)rx_q1_ptr;
+    eth->transmit_q1_ptr = (uint32_t)tx_q1_ptr;
+}
+
 static void eth_setup(void)
 {
     eth = (volatile zynqmp_gem_regs_t *)device_resources.regions[0].region.vaddr;
@@ -282,7 +311,7 @@ static void eth_setup(void)
     /* enable FCS removal */
     eth->nwcfg |= ZYNQ_GEM_NWCFG_FSREM;
     
-    /* 64-bit bus */
+    /* 64 bit AMBA AXI data bus width */
     eth->nwcfg |= ZYNQ_GEM_DBUS_WIDTH;
     
     /* Gigabit speed */
@@ -290,7 +319,7 @@ static void eth_setup(void)
 
     /* MDC clock divisor, for IEEE MDC < 2.5MHz */
     eth->nwcfg |= ZYNQ_GEM_NWCFG_IEEE_MDC;
-    
+
     /* enable checksum offload on receive */
     eth->nwcfg |= ZYNQ_GEM_NWCFG_CHSUM_EN;
     
@@ -318,8 +347,8 @@ static void eth_setup(void)
     
     /* AXI burst length: INCR16, 16 burst packets */
     eth->dmacr |= ZYNQ_GEM_DMACR_BLENGTH_16;
-    
-    /* 64-bit AXI bus width (required for 64-bit addressing) */
+
+    /* 64-bit AXI bus width */
     eth->dmacr |= ZYNQ_GEM_DMA_BUS_WIDTH;
     
     /* 5. Initialise buffer descriptors */
@@ -359,24 +388,9 @@ static void eth_setup(void)
     eth->rxqbase = device_resources.regions[1].io_addr;
     eth->txqbase = device_resources.regions[2].io_addr;
 
-    /* Disable unused rx/tx buffer queue pointers.
-     * Set priority queue 1 to point to the last descriptor (as addr must be valid)
-     * Disable this slot by writing to reserved bit 0 (prior to enabling it)
-     * 
-     * TODO: This works, but the proper solution would be allocate an address
-     * for two 'struct descriptor's, with the proper hardware-inaccessible ownership bits set.
-     * 
-     * Undefined behaviour: in theory the status bits at the address pointed to by the
-     * rx/tx_last_descr may be overwritten by rx/tx_provide() when filling
-     * the final slot in HW_ring.
-    */
-    uintptr_t rx_last_descr = device_resources.regions[1].io_addr + 
-                                (rx.capacity - 1) * sizeof(struct descriptor);
-    uintptr_t tx_last_descr = device_resources.regions[2].io_addr + 
-                                (tx.capacity - 1) * sizeof(struct descriptor);
-    eth->receive_q1_ptr = (uint32_t)rx_last_descr | 0x1;
-    eth->transmit_q1_ptr = (uint32_t)tx_last_descr | 0x1;
-    
+    /* disable the unused priority queue 1 */
+    disable_pq1();
+
     /* 7. Enable RX/TX interrupts */
     eth->ier = ZYNQ_INT_RXC | ZYNQ_INT_TXC;
     
@@ -392,9 +406,9 @@ void init(void)
     assert(device_resources.num_irqs == 1);
     assert(device_resources.num_regions == 3);
     
-    /* All buffers should fit within our DMA region */
-    assert(RX_COUNT * sizeof(struct descriptor) <= device_resources.regions[1].region.size);
-    assert(TX_COUNT * sizeof(struct descriptor) <= device_resources.regions[2].region.size);
+    /* All buffers should fit within our DMA region, plus one for queue1 terminator */
+    assert((RX_COUNT + 1) * sizeof(struct descriptor) <= device_resources.regions[1].region.size);
+    assert((TX_COUNT + 1) * sizeof(struct descriptor) <= device_resources.regions[2].region.size);
 
     eth_setup();
 

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -334,27 +334,14 @@ static void eth_setup(void)
     }
     /* 2 Network configuration */
     eth->nwcfg = 0x0;
-
-    /* enable full duplex */
-    eth->nwcfg |= ZYNQ_GEM_NWCFG_FDEN;
-
-    /* enable FCS removal */
-    eth->nwcfg |= ZYNQ_GEM_NWCFG_FSREM;
-
-    /* 64 bit AMBA AXI data bus width */
-    eth->nwcfg |= ZYNQ_GEM_DBUS_WIDTH;
-
-    /* Gigabit speed */
-    eth->nwcfg |= ZYNQ_GEM_NWCFG_SPEED1000;
-
-    /* MDC clock divisor, for IEEE MDC < 2.5MHz */
-    eth->nwcfg |= ZYNQ_GEM_NWCFG_IEEE_MDC;
-
-    /* enable checksum offload on receive */
-    eth->nwcfg |= ZYNQ_GEM_NWCFG_CHSUM_EN;
-
-    /* copy all valid frames */
-    eth->nwcfg |= ZYNQ_GEM_NWCFG_CPY_ALL_FRAMES;
+    uint32_t nwcfg = ZYNQ_GEM_NWCFG_FDEN            /* Full duplex */
+                   | ZYNQ_GEM_NWCFG_FSREM           /* FCS removal */
+                   | ZYNQ_GEM_DBUS_WIDTH            /* 64-bit AMBA AXI data bus width */
+                   | ZYNQ_GEM_NWCFG_SPEED1000       /* Gigabit speed */
+                   | ZYNQ_GEM_NWCFG_IEEE_MDC        /* MDC clock divisor, IEEE MDC < 2.5MHz */
+                   | ZYNQ_GEM_NWCFG_CHSUM_EN        /* RX checksum offload to HW */
+                   | ZYNQ_GEM_NWCFG_CPY_ALL_FRAMES; /* Copy all valid frames */
+    eth->nwcfg = nwcfg;
 
     /* 3. Set MAC address */
     eth->laddr[0][LADDR_LOW] = mac_l;
@@ -362,24 +349,13 @@ static void eth_setup(void)
 
     /* 4. Configure DMA */
     eth->dmacr = 0x0;
-
-    /* RX buffer size: 1536 bytes */
-    eth->dmacr |= ZYNQ_GEM_DMACR_RXBUF;
-
-    /* RX packet buffer: 32KB */
-    eth->dmacr |= ZYNQ_GEM_DMACR_RXPBUF_32KB;
-
-    /* TX packet buffer: 32KB */
-    eth->dmacr |= ZYNQ_GEM_DMACR_TXPBUF_32KB;
-
-    /* Enable TX checksum offload */
-    eth->dmacr |= ZYNQ_GEM_DMACR_TXPBUF_TCP;
-
-    /* AXI burst length: INCR16, 16 burst packets */
-    eth->dmacr |= ZYNQ_GEM_DMACR_BLENGTH_16;
-
-    /* 64-bit AXI bus width */
-    eth->dmacr |= ZYNQ_GEM_DMA_BUS_WIDTH;
+    uint32_t dmacr = ZYNQ_GEM_DMACR_RXBUF           /* RX buffer size: 1536 bytes */
+                   | ZYNQ_GEM_DMACR_RXPBUF_32KB     /* RX packet buffer: 32KB */
+                   | ZYNQ_GEM_DMACR_TXPBUF_32KB     /* TX packet buffer: 32KB */
+                   | ZYNQ_GEM_DMACR_TXPBUF_TCP      /* TX checksum offload to HW */
+                   | ZYNQ_GEM_DMACR_BLENGTH_16      /* AXI burst length: INCR16 */
+                   | ZYNQ_GEM_DMA_BUS_WIDTH;        /* 64-bit AXI bus width */
+    eth->dmacr = dmacr;
 
     /* 5. Initialise buffer descriptors */
     /* RX descriptors */

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -209,7 +209,7 @@ static void tx_return(void)
 
         THREAD_MEMORY_ACQUIRE();
 
-        uintptr_t phys_addr = ((uintptr_t)d->addr_hi << 32) | (d->addr & TXD_ADDR_MASK);
+        uintptr_t phys_addr = ((uintptr_t)d->addr_hi << 32) | d->addr;
         net_buff_desc_t buffer = { phys_addr, 0 };
         int err = net_enqueue_free(&tx_queue, buffer);
         assert(!err);
@@ -248,8 +248,24 @@ static void handle_irq(void)
             rx_return();
             rx_provide();
         }
+        if (rxsr & ZYNQ_GEM_RXSR_ERR_MASK) {
+            sddf_dprintf("ETH|ERROR: Receive error, status: %u\n", rxsr);
+            /* bit 0: Hw tried to read a Sw-owned buffer */
+            /* bit 2: packets arriving faster than GEM_DMA processes */
+            /* see: https://docs.amd.com/r/en-US/ug1087-zynq-ultrascale-registers/receive_status-GEM-Register */
+        }
+        if (txsr & ZYNQ_GEM_TXSR_ERR_MASK) {
+            sddf_dprintf("ETH|ERROR: Transmit error, status: %u\n", txsr);
+            /* see: https://docs.amd.com/r/en-US/ug1087-zynq-ultrascale-registers/transmit_status-GEM-Register */
+        }
+
         isr = eth->isr & IRQ_MASK;
         eth->isr = isr;
+
+        rxsr = eth->rxsr & ZYNQ_GEM_RXSR_ERR_MASK;
+        eth->rxsr = rxsr;
+        txsr = eth->txsr & ZYNQ_GEM_TXSR_ERR_MASK;
+        eth->txsr = txsr;
     }
 }
 

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -100,7 +100,7 @@ static void rx_provide(void)
 
             uint32_t idx = rx.tail % rx.capacity;
 
-            /* Buffer must be word-aligned; bits [1:0] are reserved by HW for wrap/ownership */
+            /* Buffer must be word-aligned; bits [1:0] are reserved for wrap/ownership */
             assert((buffer.io_or_offset & ~RXD_ADDR_MASK) == 0);
             uintptr_t phys = buffer.io_or_offset;
 

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -65,12 +65,12 @@ static void update_ring_slot_rx(hw_ring_t *ring, unsigned int idx, uintptr_t phy
     volatile struct descriptor *d = &(ring->descr[idx]);
     d->addr_hi = (uint32_t)(phys >> 32);
     d->stat = 0;  /* HW fills on receive */
-    
+
     /* Ensure all writes to the descriptor complete, before we set the flags
      * that makes hardware aware of this slot. Recall d->addr includes ownership bit.
      */
     THREAD_MEMORY_RELEASE();
-    
+
     d->addr = (uint32_t)(phys);
 }
 
@@ -334,12 +334,12 @@ static void eth_setup(void)
     }
     /* 2 Network configuration */
     eth->nwcfg = 0x0;
-    uint32_t nwcfg = ZYNQ_GEM_NWCFG_FDEN            /* Full duplex */
-                   | ZYNQ_GEM_NWCFG_FSREM           /* FCS removal */
-                   | ZYNQ_GEM_DBUS_WIDTH            /* 64-bit AMBA AXI data bus width */
-                   | ZYNQ_GEM_NWCFG_SPEED1000       /* Gigabit speed */
-                   | ZYNQ_GEM_NWCFG_IEEE_MDC        /* MDC clock divisor, IEEE MDC < 2.5MHz */
-                   | ZYNQ_GEM_NWCFG_CHSUM_EN        /* RX checksum offload to HW */
+    uint32_t nwcfg = ZYNQ_GEM_NWCFG_FDEN /* Full duplex */
+                   | ZYNQ_GEM_NWCFG_FSREM /* FCS removal */
+                   | ZYNQ_GEM_DBUS_WIDTH /* 64-bit AMBA AXI data bus width */
+                   | ZYNQ_GEM_NWCFG_SPEED1000 /* Gigabit speed */
+                   | ZYNQ_GEM_NWCFG_IEEE_MDC /* MDC clock divisor, IEEE MDC < 2.5MHz */
+                   | ZYNQ_GEM_NWCFG_CHSUM_EN /* RX checksum offload to HW */
                    | ZYNQ_GEM_NWCFG_CPY_ALL_FRAMES; /* Copy all valid frames */
     eth->nwcfg = nwcfg;
 
@@ -349,12 +349,12 @@ static void eth_setup(void)
 
     /* 4. Configure DMA */
     eth->dmacr = 0x0;
-    uint32_t dmacr = ZYNQ_GEM_DMACR_RXBUF           /* RX buffer size: 1536 bytes */
-                   | ZYNQ_GEM_DMACR_RXPBUF_32KB     /* RX packet buffer: 32KB */
-                   | ZYNQ_GEM_DMACR_TXPBUF_32KB     /* TX packet buffer: 32KB */
-                   | ZYNQ_GEM_DMACR_TXPBUF_TCP      /* TX checksum offload to HW */
-                   | ZYNQ_GEM_DMACR_BLENGTH_16      /* AXI burst length: INCR16 */
-                   | ZYNQ_GEM_DMA_BUS_WIDTH;        /* 64-bit AXI bus width */
+    uint32_t dmacr = ZYNQ_GEM_DMACR_RXBUF /* RX buffer size: 1536 bytes */
+                   | ZYNQ_GEM_DMACR_RXPBUF_32KB /* RX packet buffer: 32KB */
+                   | ZYNQ_GEM_DMACR_TXPBUF_32KB /* TX packet buffer: 32KB */
+                   | ZYNQ_GEM_DMACR_TXPBUF_TCP /* TX checksum offload to HW */
+                   | ZYNQ_GEM_DMACR_BLENGTH_16 /* AXI burst length: INCR16 */
+                   | ZYNQ_GEM_DMA_BUS_WIDTH; /* 64-bit AXI bus width */
     eth->dmacr = dmacr;
 
     /* 5. Initialise buffer descriptors */

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -64,19 +64,19 @@ static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys,
     d->addr = (uint32_t)(phys & MAX_BIT_32_MASK);
     d->addr_hi = (uint32_t)(phys >> 32);
     d->unused = 0;
-    
+
     /* Ensure all writes to the descriptor complete, before we set the flags
      * that makes hardware aware of this slot.
      */
     THREAD_MEMORY_RELEASE();
-    
+
     d->stat = stat | (len & TXD_LEN_MASK);
 }
 
 static void rx_provide(void)
 {
     bool reprocess = true;
-    
+
     while (reprocess) {
         while (!hw_ring_full(&rx) && !net_queue_empty_free(&rx_queue)) {
             net_buff_desc_t buffer;
@@ -86,7 +86,7 @@ static void rx_provide(void)
             uint32_t idx = rx.tail % rx.capacity;
             uint32_t stat = RXD_MK_HW_OWNR; /* Set HW as owner */
             uintptr_t phys = buffer.io_or_offset & (RXD_ADDR_MASK & MAX_BIT_64_MASK);
-            
+
             if (idx + 1 == rx.capacity) {
                 phys |= RXD_WRAP;
             }
@@ -101,7 +101,7 @@ static void rx_provide(void)
         } else {
             net_cancel_signal_free(&rx_queue);
         }
-        
+
         reprocess = false;
 
         if (!net_queue_empty_free(&rx_queue) && !hw_ring_full(&rx)) {
@@ -114,7 +114,7 @@ static void rx_provide(void)
 static void rx_return(void)
 {
     bool packets_transferred = false;
-    
+
     while (!hw_ring_empty(&rx)) {
         /* If buffer slot is still empty, we have processed all packets the device has filled */
         uint32_t idx = rx.head % rx.capacity;
@@ -130,7 +130,7 @@ static void rx_return(void)
         uint16_t len = d->stat & RXD_LEN_MASK;
         uintptr_t phys_addr = ((uintptr_t)d->addr_hi << 32) | (d->addr & RXD_ADDR_MASK);
         net_buff_desc_t buffer = { phys_addr, len };
-        
+
         int err = net_enqueue_active(&rx_queue, buffer);
         assert(!err);
 
@@ -156,14 +156,14 @@ static void tx_provide(void)
             uint32_t idx = tx.tail % tx.capacity;
             uint32_t stat = TXD_LAST | TXD_MK_HW_OWNR; /* Set HW as owner */
             uintptr_t phys = buffer.io_or_offset & (TXD_ADDR_MASK & MAX_BIT_64_MASK);
-            
+
             if (idx + 1 == tx.capacity) {
                 stat |= TXD_WRAP;
             }
-            
+
             update_ring_slot(&tx, idx, phys, buffer.len, stat);
             tx.tail++;
-            
+
             eth->nwctrl |= ZYNQ_GEM_NWCTRL_STARTTX_MASK;
         }
 
@@ -242,28 +242,29 @@ static void handle_irq(void)
  * This region is never touched by rx_provide() / tx_provide(), so the terminator
  * state is stable for the lifetime of the driver.
  */
-static void disable_pq1(void) {
+static void disable_pq1(void)
+{
     volatile struct descriptor *rx_q1_terminator =
         (volatile struct descriptor *)(device_resources.regions[1].region.vaddr +
                                        rx.capacity * sizeof(struct descriptor));
-    rx_q1_terminator->addr    = RXD_OWN | RXD_WRAP; /* SW owns + wrap terminator */
-    rx_q1_terminator->stat    = 0;
+    rx_q1_terminator->addr = RXD_OWN | RXD_WRAP; /* SW owns + wrap terminator */
+    rx_q1_terminator->stat = 0;
     rx_q1_terminator->addr_hi = 0;
-    rx_q1_terminator->unused  = 0;
+    rx_q1_terminator->unused = 0;
 
     volatile struct descriptor *tx_q1_terminator =
         (volatile struct descriptor *)(device_resources.regions[2].region.vaddr +
                                        tx.capacity * sizeof(struct descriptor));
-    tx_q1_terminator->addr    = 0;
-    tx_q1_terminator->stat    = TXD_USED | TXD_WRAP; /* SW owns + wrap terminator */
+    tx_q1_terminator->addr = 0;
+    tx_q1_terminator->stat = TXD_USED | TXD_WRAP; /* SW owns + wrap terminator */
     tx_q1_terminator->addr_hi = 0;
-    tx_q1_terminator->unused  = 0;
+    tx_q1_terminator->unused = 0;
 
     uintptr_t rx_q1_ptr = device_resources.regions[1].io_addr +
                           rx.capacity * sizeof(struct descriptor);
     uintptr_t tx_q1_ptr = device_resources.regions[2].io_addr +
                           tx.capacity * sizeof(struct descriptor);
-    eth->receive_q1_ptr  = (uint32_t)rx_q1_ptr;
+    eth->receive_q1_ptr = (uint32_t)rx_q1_ptr;
     eth->transmit_q1_ptr = (uint32_t)tx_q1_ptr;
 }
 
@@ -290,11 +291,11 @@ static void eth_setup(void)
 
     /* disable interrupts */
     eth->idr = ZYNQ_GEM_IDR_CLEAR;
-    
+
     /* clear rx/tx buffer queue */
     eth->rxqbase = 0x0;
     eth->txqbase = 0x0;
-    
+
     /* clear hash regs */
     eth->hashl = 0x0;
     eth->hashh = 0x0;
@@ -304,16 +305,16 @@ static void eth_setup(void)
     }
     /* 2 Network configuration */
     eth->nwcfg = 0x0;
-    
+
     /* enable full duplex */
     eth->nwcfg |= ZYNQ_GEM_NWCFG_FDEN;
-    
+
     /* enable FCS removal */
     eth->nwcfg |= ZYNQ_GEM_NWCFG_FSREM;
-    
+
     /* 64 bit AMBA AXI data bus width */
     eth->nwcfg |= ZYNQ_GEM_DBUS_WIDTH;
-    
+
     /* Gigabit speed */
     eth->nwcfg |= ZYNQ_GEM_NWCFG_SPEED1000;
 
@@ -322,35 +323,35 @@ static void eth_setup(void)
 
     /* enable checksum offload on receive */
     eth->nwcfg |= ZYNQ_GEM_NWCFG_CHSUM_EN;
-    
+
     /* copy all valid frames */
     eth->nwcfg |= ZYNQ_GEM_NWCFG_CPY_ALL_FRAMES;
-    
+
     /* 3. Set MAC address */
     eth->laddr[0][LADDR_LOW] = mac_l;
     eth->laddr[0][LADDR_HIGH] = mac_h;
-    
+
     /* 4. Configure DMA */
     eth->dmacr = 0x0;
-    
+
     /* RX buffer size: 1536 bytes */
     eth->dmacr |= ZYNQ_GEM_DMACR_RXBUF;
-    
+
     /* RX packet buffer: 32KB */
     eth->dmacr |= ZYNQ_GEM_DMACR_RXPBUF_32KB;
-    
+
     /* TX packet buffer: 32KB */
     eth->dmacr |= ZYNQ_GEM_DMACR_TXPBUF_32KB;
-    
+
     /* Enable TX checksum offload */
     eth->dmacr |= ZYNQ_GEM_DMACR_TXPBUF_TCP;
-    
+
     /* AXI burst length: INCR16, 16 burst packets */
     eth->dmacr |= ZYNQ_GEM_DMACR_BLENGTH_16;
 
     /* 64-bit AXI bus width */
     eth->dmacr |= ZYNQ_GEM_DMA_BUS_WIDTH;
-    
+
     /* 5. Initialise buffer descriptors */
     /* RX descriptors */
     for (uint32_t i = 0; i < rx.capacity; i++) {
@@ -383,7 +384,7 @@ static void eth_setup(void)
      */
     eth->upper_rxqbase = 0x0;
     eth->upper_txqbase = 0x0;
-    
+
     /* Set rx/tx queue base address */
     eth->rxqbase = device_resources.regions[1].io_addr;
     eth->txqbase = device_resources.regions[2].io_addr;
@@ -393,7 +394,7 @@ static void eth_setup(void)
 
     /* 7. Enable RX/TX interrupts */
     eth->ier = ZYNQ_INT_RXC | ZYNQ_INT_TXC;
-    
+
     /* 8. Enable MDIO and transmitter (receiver enabled later after buffer init) */
     eth->nwctrl |= ZYNQ_GEM_NWCTRL_MDEN_MASK;
     eth->nwctrl |= ZYNQ_GEM_NWCTRL_TXEN_MASK;
@@ -405,7 +406,7 @@ void init(void)
     assert(device_resources_check_magic(&device_resources));
     assert(device_resources.num_irqs == 1);
     assert(device_resources.num_regions == 3);
-    
+
     /* All buffers should fit within our DMA region, plus one for queue1 terminator */
     assert((RX_COUNT + 1) * sizeof(struct descriptor) <= device_resources.regions[1].region.size);
     assert((TX_COUNT + 1) * sizeof(struct descriptor) <= device_resources.regions[2].region.size);

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -63,9 +63,8 @@ static inline bool hw_ring_empty(hw_ring_t *ring)
 static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys, uint16_t len, uint32_t stat)
 {
     volatile struct descriptor *d = &(ring->descr[idx]);
-    d->addr = (uint32_t)(phys & MAX_BIT_32_MASK);
+    d->addr = (uint32_t)(phys);
     d->addr_hi = (uint32_t)(phys >> 32);
-    d->unused = 0;
 
     /* Ensure all writes to the descriptor complete, before we set the flags
      * that makes hardware aware of this slot.
@@ -87,7 +86,7 @@ static void rx_provide(void)
 
             uint32_t idx = rx.tail % rx.capacity;
             uint32_t stat = RXD_MK_HW_OWNR; /* Set HW as owner */
-            uintptr_t phys = buffer.io_or_offset & (RXD_ADDR_MASK & MAX_BIT_64_MASK);
+            uintptr_t phys = buffer.io_or_offset & RXD_ADDR_MASK;
 
             if (idx + 1 == rx.capacity) {
                 phys |= RXD_WRAP;
@@ -157,7 +156,7 @@ static void tx_provide(void)
 
             uint32_t idx = tx.tail % tx.capacity;
             uint32_t stat = TXD_LAST | TXD_MK_HW_OWNR; /* Set HW as owner */
-            uintptr_t phys = buffer.io_or_offset & (TXD_ADDR_MASK & MAX_BIT_64_MASK);
+            uintptr_t phys = buffer.io_or_offset & TXD_ADDR_MASK;
 
             if (idx + 1 == tx.capacity) {
                 stat |= TXD_WRAP;
@@ -252,7 +251,6 @@ static void disable_pq1(void)
     rx_q1_terminator->addr = RXD_OWN | RXD_WRAP; /* SW owns + wrap terminator */
     rx_q1_terminator->stat = 0;
     rx_q1_terminator->addr_hi = 0;
-    rx_q1_terminator->unused = 0;
 
     volatile struct descriptor *tx_q1_terminator =
         (volatile struct descriptor *)(device_resources.regions[2].region.vaddr
@@ -260,7 +258,6 @@ static void disable_pq1(void)
     tx_q1_terminator->addr = 0;
     tx_q1_terminator->stat = TXD_USED | TXD_WRAP; /* SW owns + wrap terminator */
     tx_q1_terminator->addr_hi = 0;
-    tx_q1_terminator->unused = 0;
 
     uintptr_t rx_q1_ptr = device_resources.regions[1].io_addr + rx.capacity * sizeof(struct descriptor);
     uintptr_t tx_q1_ptr = device_resources.regions[2].io_addr + tx.capacity * sizeof(struct descriptor);
@@ -359,7 +356,6 @@ static void eth_setup(void)
         d->addr = 0;
         d->stat = RXD_MK_HW_OWNR; /* HW owns initially */
         d->addr_hi = 0;
-        d->unused = 0;
         if (i == rx.capacity - 1) {
             d->addr |= RXD_WRAP;
         }
@@ -371,7 +367,6 @@ static void eth_setup(void)
         d->addr = 0;
         d->stat = TXD_USED; /* SW owns initially */
         d->addr_hi = 0;
-        d->unused = 0;
         if (i == tx.capacity - 1) {
             d->stat |= TXD_WRAP;
         }

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -57,8 +57,7 @@ static inline bool hw_ring_empty(hw_ring_t *ring)
     return ring->tail - ring->head == 0;
 }
 
-static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys,
-                             uint16_t len, uint32_t stat)
+static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys, uint16_t len, uint32_t stat)
 {
     volatile struct descriptor *d = &(ring->descr[idx]);
     d->addr = (uint32_t)(phys & MAX_BIT_32_MASK);
@@ -245,25 +244,23 @@ static void handle_irq(void)
 static void disable_pq1(void)
 {
     volatile struct descriptor *rx_q1_terminator =
-        (volatile struct descriptor *)(device_resources.regions[1].region.vaddr +
-                                       rx.capacity * sizeof(struct descriptor));
+        (volatile struct descriptor *)(device_resources.regions[1].region.vaddr
+                                       + rx.capacity * sizeof(struct descriptor));
     rx_q1_terminator->addr = RXD_OWN | RXD_WRAP; /* SW owns + wrap terminator */
     rx_q1_terminator->stat = 0;
     rx_q1_terminator->addr_hi = 0;
     rx_q1_terminator->unused = 0;
 
     volatile struct descriptor *tx_q1_terminator =
-        (volatile struct descriptor *)(device_resources.regions[2].region.vaddr +
-                                       tx.capacity * sizeof(struct descriptor));
+        (volatile struct descriptor *)(device_resources.regions[2].region.vaddr
+                                       + tx.capacity * sizeof(struct descriptor));
     tx_q1_terminator->addr = 0;
     tx_q1_terminator->stat = TXD_USED | TXD_WRAP; /* SW owns + wrap terminator */
     tx_q1_terminator->addr_hi = 0;
     tx_q1_terminator->unused = 0;
 
-    uintptr_t rx_q1_ptr = device_resources.regions[1].io_addr +
-                          rx.capacity * sizeof(struct descriptor);
-    uintptr_t tx_q1_ptr = device_resources.regions[2].io_addr +
-                          tx.capacity * sizeof(struct descriptor);
+    uintptr_t rx_q1_ptr = device_resources.regions[1].io_addr + rx.capacity * sizeof(struct descriptor);
+    uintptr_t tx_q1_ptr = device_resources.regions[2].io_addr + tx.capacity * sizeof(struct descriptor);
     eth->receive_q1_ptr = (uint32_t)rx_q1_ptr;
     eth->transmit_q1_ptr = (uint32_t)tx_q1_ptr;
 }

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -60,7 +60,21 @@ static inline bool hw_ring_empty(hw_ring_t *ring)
     return ring->tail - ring->head == 0;
 }
 
-static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys, uint16_t len, uint32_t stat)
+static void update_ring_slot_rx(hw_ring_t *ring, unsigned int idx, uintptr_t phys)
+{
+    volatile struct descriptor *d = &(ring->descr[idx]);
+    d->addr_hi = (uint32_t)(phys >> 32);
+    d->stat = 0;  /* HW fills on receive */
+    
+    /* Ensure all writes to the descriptor complete, before we set the flags
+     * that makes hardware aware of this slot. Recall d->addr includes ownership bit.
+     */
+    THREAD_MEMORY_RELEASE();
+    
+    d->addr = (uint32_t)(phys);
+}
+
+static void update_ring_slot_tx(hw_ring_t *ring, unsigned int idx, uintptr_t phys, uint16_t len, uint32_t stat)
 {
     volatile struct descriptor *d = &(ring->descr[idx]);
     d->addr = (uint32_t)(phys);
@@ -85,14 +99,14 @@ static void rx_provide(void)
             assert(!err);
 
             uint32_t idx = rx.tail % rx.capacity;
-            uint32_t stat = RXD_MK_HW_OWNR; /* Set HW as owner */
-            uintptr_t phys = buffer.io_or_offset & RXD_ADDR_MASK;
+            /* RXD_ADDR_MASK also sets HW ownership */
+            uintptr_t phys = buffer.io_or_offset & RXD_ADDR_MASK; 
 
             if (idx + 1 == rx.capacity) {
                 phys |= RXD_WRAP;
             }
 
-            update_ring_slot(&rx, idx, phys, 0, stat);
+            update_ring_slot_rx(&rx, idx, phys);
             rx.tail++;
         }
 
@@ -162,7 +176,7 @@ static void tx_provide(void)
                 stat |= TXD_WRAP;
             }
 
-            update_ring_slot(&tx, idx, phys, buffer.len, stat);
+            update_ring_slot_tx(&tx, idx, phys, buffer.len, stat);
             tx.tail++;
 
             eth->nwctrl |= ZYNQ_GEM_NWCTRL_STARTTX_MASK;

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2026, Skykraft
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <microkit.h>
+#include <sddf/resources/device.h>
+#include <sddf/network/queue.h>
+#include <sddf/network/config.h>
+#include <sddf/util/util.h>
+#include <sddf/util/fence.h>
+#include <sddf/util/printf.h>
+
+#include "ethernet.h"
+
+__attribute__((__section__(".device_resources"))) device_resources_t device_resources;
+__attribute__((__section__(".net_driver_config"))) net_driver_config_t config;
+
+/* HW ring capacity must be a power of 2 */
+#define RX_COUNT 256
+#define TX_COUNT 256
+#define MAX_COUNT MAX(RX_COUNT, TX_COUNT)
+
+/* HW ring descriptor, 64-bit (shared with device) */
+struct descriptor {
+    uint32_t addr;      /* Word 0: Buffer address low [31:2], wrap [1], used [0] */
+    uint32_t stat;      /* Word 1: Status/control */
+    uint32_t addr_hi;   /* Word 2: Buffer address high (upper 32 bits) */
+    uint32_t unused;
+};
+
+/* HW ring buffer data type */
+typedef struct {
+    uint32_t tail; /* index to insert at */
+    uint32_t head; /* index to remove from */
+    uint32_t capacity; /* capacity of the ring */
+    volatile struct descriptor *descr; /* buffer descriptor array */
+} hw_ring_t;
+
+hw_ring_t rx; /* Rx NIC ring */
+hw_ring_t tx; /* Tx NIC ring */
+
+net_queue_handle_t rx_queue;
+net_queue_handle_t tx_queue;
+
+#define MAX_PACKET_SIZE     1536
+
+volatile zynqmp_gem_regs_t *eth;
+
+static inline bool hw_ring_full(hw_ring_t *ring)
+{
+    return ring->tail - ring->head == ring->capacity;
+}
+
+static inline bool hw_ring_empty(hw_ring_t *ring)
+{
+    return ring->tail - ring->head == 0;
+}
+
+static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys,
+                             uint16_t len, uint32_t stat)
+{
+    volatile struct descriptor *d = &(ring->descr[idx]);
+    d->addr = (uint32_t)(phys & MAX_BIT_32_MASK);
+    d->addr_hi = (uint32_t)(phys >> 32);
+    d->unused = 0;
+    
+    /* Ensure all writes to the descriptor complete, before we set the flags
+     * that makes hardware aware of this slot.
+     */
+    THREAD_MEMORY_RELEASE();
+    
+    d->stat = stat | (len & TXD_LEN_MASK);
+}
+
+static void rx_provide(void)
+{
+    bool reprocess = true;
+    
+    while (reprocess) {
+        while (!hw_ring_full(&rx) && !net_queue_empty_free(&rx_queue)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_free(&rx_queue, &buffer);
+            assert(!err);
+
+            uint32_t idx = rx.tail % rx.capacity;
+            uint32_t stat = RXD_MK_HW_OWNR; /* Set HW as owner */
+            uintptr_t phys = buffer.io_or_offset & (RXD_ADDR_MASK & MAX_BIT_64_MASK);
+            
+            if (idx + 1 == rx.capacity) {
+                phys |= RXD_WRAP;
+            }
+
+            update_ring_slot(&rx, idx, phys, 0, stat);
+            rx.tail++;
+        }
+
+        /* Only request a notification from virtualiser if HW ring not full */
+        if (!hw_ring_full(&rx)) {
+            net_request_signal_free(&rx_queue);
+        } else {
+            net_cancel_signal_free(&rx_queue);
+        }
+        
+        reprocess = false;
+
+        if (!net_queue_empty_free(&rx_queue) && !hw_ring_full(&rx)) {
+            net_cancel_signal_free(&rx_queue);
+            reprocess = true;
+        }
+    }
+}
+
+static void rx_return(void)
+{
+    bool packets_transferred = false;
+    
+    while (!hw_ring_empty(&rx)) {
+        /* If buffer slot is still empty, we have processed all packets the device has filled */
+        uint32_t idx = rx.head % rx.capacity;
+        volatile struct descriptor *d = &(rx.descr[idx]);
+
+        if (!(d->addr & RXD_OWN)) {
+            break;
+        }
+
+        THREAD_MEMORY_ACQUIRE();
+
+        /* See Table 34-5: RX Buffer Descriptor Entry (64-bit mode) */
+        uint16_t len = d->stat & RXD_LEN_MASK;
+        uintptr_t phys_addr = ((uintptr_t)d->addr_hi << 32) | (d->addr & RXD_ADDR_MASK);
+        net_buff_desc_t buffer = { phys_addr, len };
+        
+        int err = net_enqueue_active(&rx_queue, buffer);
+        assert(!err);
+
+        packets_transferred = true;
+        rx.head++;
+    }
+
+    if (packets_transferred && net_require_signal_active(&rx_queue)) {
+        net_cancel_signal_active(&rx_queue);
+        sddf_notify(config.virt_rx.id);
+    }
+}
+
+static void tx_provide(void)
+{
+    bool reprocess = true;
+    while (reprocess) {
+        while (!hw_ring_full(&tx) && !net_queue_empty_active(&tx_queue)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_active(&tx_queue, &buffer);
+            assert(!err);
+
+            uint32_t idx = tx.tail % tx.capacity;
+            uint32_t stat = TXD_LAST | TXD_MK_HW_OWNR; /* Set HW as owner */
+            uintptr_t phys = buffer.io_or_offset & (TXD_ADDR_MASK & MAX_BIT_64_MASK);
+            
+            if (idx + 1 == tx.capacity) {
+                stat |= TXD_WRAP;
+            }
+            
+            update_ring_slot(&tx, idx, phys, buffer.len, stat);
+            tx.tail++;
+            
+            eth->nwctrl |= ZYNQ_GEM_NWCTRL_STARTTX_MASK;
+        }
+
+        net_request_signal_active(&tx_queue);
+        reprocess = false;
+
+        if (!hw_ring_full(&tx) && !net_queue_empty_active(&tx_queue)) {
+            net_cancel_signal_active(&tx_queue);
+            reprocess = true;
+        }
+    }
+}
+
+static void tx_return(void)
+{
+    bool enqueued = false;
+    while (!hw_ring_empty(&tx)) {
+        /* Ensure that this buffer has been sent by the device */
+        uint32_t idx = tx.head % tx.capacity;
+        volatile struct descriptor *d = &(tx.descr[idx]);
+
+        /* TXD_USED bit set by hardware when transmission complete */
+        if (!(d->stat & TXD_USED)) {
+            break;
+        }
+
+        THREAD_MEMORY_ACQUIRE();
+
+        uintptr_t phys_addr = ((uintptr_t)d->addr_hi << 32) | (d->addr & TXD_ADDR_MASK);
+        net_buff_desc_t buffer = { phys_addr, 0 };
+        int err = net_enqueue_free(&tx_queue, buffer);
+        assert(!err);
+
+        enqueued = true;
+        tx.head++;
+    }
+
+    if (enqueued && net_require_signal_free(&tx_queue)) {
+        net_cancel_signal_free(&tx_queue);
+        sddf_notify(config.virt_tx.id);
+    }
+}
+
+static void handle_irq(void)
+{
+    uint32_t isr = eth->isr & IRQ_MASK;
+    uint32_t rxsr = eth->rxsr;
+    uint32_t txsr = eth->txsr;
+    eth->isr = isr;
+
+    /* Clear any RX/TX status (write to clear) */
+    if (rxsr) {
+        eth->rxsr = rxsr;
+    }
+    if (txsr) {
+        eth->txsr = txsr;
+    }
+
+    while (isr & IRQ_MASK) {
+        if (isr & ZYNQ_INT_TXC) {
+            tx_return();
+            tx_provide();
+        }
+        if (isr & ZYNQ_INT_RXC) {
+            rx_return();
+            rx_provide();
+        }
+        isr = eth->isr & IRQ_MASK;
+        eth->isr = isr;
+    }
+}
+
+static void eth_setup(void)
+{
+    eth = (volatile zynqmp_gem_regs_t *)device_resources.regions[0].region.vaddr;
+
+    uint32_t mac_l = eth->laddr[0][LADDR_LOW];
+    uint32_t mac_h = eth->laddr[0][LADDR_HIGH];
+
+    /* Set up HW rings */
+    rx.descr = (volatile struct descriptor *)device_resources.regions[1].region.vaddr;
+    tx.descr = (volatile struct descriptor *)device_resources.regions[2].region.vaddr;
+    rx.capacity = RX_COUNT;
+    tx.capacity = TX_COUNT;
+
+    /* 1. Initialise controller - clear everything */
+    eth->nwctrl = 0x0;
+    eth->nwctrl |= ZYNQ_GEM_NWCTRL_CLEARSTAT;
+
+    /* clear status regs */
+    eth->rxsr = ZYNQ_GEM_RXSR_CLEAR;
+    eth->txsr = ZYNQ_GEM_TXSR_CLEAR;
+
+    /* disable interrupts */
+    eth->idr = ZYNQ_GEM_IDR_CLEAR;
+    
+    /* clear rx/tx buffer queue */
+    eth->rxqbase = 0x0;
+    eth->txqbase = 0x0;
+    
+    /* clear hash regs */
+    eth->hashl = 0x0;
+    eth->hashh = 0x0;
+    /* clear stat counters */
+    for (int i = 0; i < STAT_SIZE; i++) {
+        eth->stat[i] = 0x0;
+    }
+    /* 2 Network configuration */
+    eth->nwcfg = 0x0;
+    
+    /* enable full duplex */
+    eth->nwcfg |= ZYNQ_GEM_NWCFG_FDEN;
+    
+    /* enable FCS removal */
+    eth->nwcfg |= ZYNQ_GEM_NWCFG_FSREM;
+    
+    /* 64-bit bus */
+    eth->nwcfg |= ZYNQ_GEM_DBUS_WIDTH;
+    
+    /* Gigabit speed */
+    eth->nwcfg |= ZYNQ_GEM_NWCFG_SPEED1000;
+
+    /* MDC clock divisor, for IEEE MDC < 2.5MHz */
+    eth->nwcfg |= ZYNQ_GEM_NWCFG_IEEE_MDC;
+    
+    /* enable checksum offload on receive */
+    eth->nwcfg |= ZYNQ_GEM_NWCFG_CHSUM_EN;
+    
+    /* copy all valid frames */
+    eth->nwcfg |= ZYNQ_GEM_NWCFG_CPY_ALL_FRAMES;
+    
+    /* 3. Set MAC address */
+    eth->laddr[0][LADDR_LOW] = mac_l;
+    eth->laddr[0][LADDR_HIGH] = mac_h;
+    
+    /* 4. Configure DMA */
+    eth->dmacr = 0x0;
+    
+    /* RX buffer size: 1536 bytes */
+    eth->dmacr |= ZYNQ_GEM_DMACR_RXBUF;
+    
+    /* RX packet buffer: 32KB */
+    eth->dmacr |= ZYNQ_GEM_DMACR_RXPBUF_32KB;
+    
+    /* TX packet buffer: 32KB */
+    eth->dmacr |= ZYNQ_GEM_DMACR_TXPBUF_32KB;
+    
+    /* Enable TX checksum offload */
+    eth->dmacr |= ZYNQ_GEM_DMACR_TXPBUF_TCP;
+    
+    /* AXI burst length: INCR16, 16 burst packets */
+    eth->dmacr |= ZYNQ_GEM_DMACR_BLENGTH_16;
+    
+    /* 64-bit AXI bus width (required for 64-bit addressing) */
+    eth->dmacr |= ZYNQ_GEM_DMA_BUS_WIDTH;
+    
+    /* 5. Initialise buffer descriptors */
+    /* RX descriptors */
+    for (uint32_t i = 0; i < rx.capacity; i++) {
+        volatile struct descriptor *d = &(rx.descr[i]);
+        d->addr = 0;
+        d->stat = RXD_MK_HW_OWNR; /* HW owns initially */
+        d->addr_hi = 0;
+        d->unused = 0;
+        if (i == rx.capacity - 1) {
+            d->addr |= RXD_WRAP;
+        }
+    }
+
+    /* TX descriptors */
+    for (uint32_t i = 0; i < tx.capacity; i++) {
+        volatile struct descriptor *d = &(tx.descr[i]);
+        d->addr = 0;
+        d->stat = TXD_USED; /* SW owns initially */
+        d->addr_hi = 0;
+        d->unused = 0;
+        if (i == tx.capacity - 1) {
+            d->stat |= TXD_WRAP;
+        }
+    }
+
+    /* 6. Configure buffer descriptor queue addresses */
+    /* Clear upper address registers
+     * If you are actually using > 4GB memory addresses,
+     * set this to your actual upper address bits
+     */
+    eth->upper_rxqbase = 0x0;
+    eth->upper_txqbase = 0x0;
+    
+    /* Set rx/tx queue base address */
+    eth->rxqbase = device_resources.regions[1].io_addr;
+    eth->txqbase = device_resources.regions[2].io_addr;
+
+    /* Disable unused rx/tx buffer queue pointers.
+     * Set priority queue 1 to point to the last descriptor (as addr must be valid)
+     * Disable this slot by writing to reserved bit 0 (prior to enabling it)
+     * 
+     * TODO: This works, but the proper solution would be allocate an address
+     * for two 'struct descriptor's, with the proper hardware-inaccessible ownership bits set.
+     * 
+     * Undefined behaviour: in theory the status bits at the address pointed to by the
+     * rx/tx_last_descr may be overwritten by rx/tx_provide() when filling
+     * the final slot in HW_ring.
+    */
+    uintptr_t rx_last_descr = device_resources.regions[1].io_addr + 
+                                (rx.capacity - 1) * sizeof(struct descriptor);
+    uintptr_t tx_last_descr = device_resources.regions[2].io_addr + 
+                                (tx.capacity - 1) * sizeof(struct descriptor);
+    eth->receive_q1_ptr = (uint32_t)rx_last_descr | 0x1;
+    eth->transmit_q1_ptr = (uint32_t)tx_last_descr | 0x1;
+    
+    /* 7. Enable RX/TX interrupts */
+    eth->ier = ZYNQ_INT_RXC | ZYNQ_INT_TXC;
+    
+    /* 8. Enable MDIO and transmitter (receiver enabled later after buffer init) */
+    eth->nwctrl |= ZYNQ_GEM_NWCTRL_MDEN_MASK;
+    eth->nwctrl |= ZYNQ_GEM_NWCTRL_TXEN_MASK;
+}
+
+void init(void)
+{
+    assert(net_config_check_magic(&config));
+    assert(device_resources_check_magic(&device_resources));
+    assert(device_resources.num_irqs == 1);
+    assert(device_resources.num_regions == 3);
+    
+    /* All buffers should fit within our DMA region */
+    assert(RX_COUNT * sizeof(struct descriptor) <= device_resources.regions[1].region.size);
+    assert(TX_COUNT * sizeof(struct descriptor) <= device_resources.regions[2].region.size);
+
+    eth_setup();
+
+    net_queue_init(&rx_queue, config.virt_rx.free_queue.vaddr, config.virt_rx.active_queue.vaddr,
+                   config.virt_rx.num_buffers);
+    net_queue_init(&tx_queue, config.virt_tx.free_queue.vaddr, config.virt_tx.active_queue.vaddr,
+                   config.virt_tx.num_buffers);
+
+    rx_provide();
+    tx_provide();
+
+    /* Now that buffers are in the descriptor ring, enable the receiver */
+    eth->nwctrl |= ZYNQ_GEM_NWCTRL_RXEN_MASK;
+}
+
+void notified(microkit_channel ch)
+{
+    if (ch == device_resources.irqs[0].id) {
+        handle_irq();
+        /*
+         * Delay calling into the kernel to ack the IRQ until the next loop
+         * in the event handler loop.
+         */
+        sddf_deferred_irq_ack(ch);
+    } else if (ch == config.virt_rx.id) {
+        rx_provide();
+    } else if (ch == config.virt_tx.id) {
+        tx_provide();
+    } else {
+        sddf_dprintf("ETH|LOG: unexpected notification on channel: %u\n", ch);
+    }
+}

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -371,11 +371,13 @@ static void eth_setup(void)
         }
     }
 
-    /* 6. Configure buffer descriptor queue addresses */
-    /* Clear upper address registers
-     * If you are actually using > 4GB memory addresses,
-     * set this to your actual upper address bits
+    /* 6. Configure buffer descriptor queue addresses
+     * Upper address registers are cleared assuming 32-bit addresses.
+     * If you are using > 4GB memory addresses,
+     * set these to your upper address bits.
      */
+    assert((device_resources.regions[1].io_addr >> 32) == 0);
+    assert((device_resources.regions[2].io_addr >> 32) == 0);
     eth->upper_rxqbase = 0x0;
     eth->upper_txqbase = 0x0;
 

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -358,18 +358,9 @@ static void eth_setup(void)
     eth->dmacr = dmacr;
 
     /* 5. Initialise buffer descriptors */
-    /* RX descriptors */
-    for (uint32_t i = 0; i < rx.capacity; i++) {
-        volatile struct descriptor *d = &(rx.descr[i]);
-        d->addr = 0;
-        d->stat = RXD_MK_HW_OWNR; /* HW owns initially */
-        d->addr_hi = 0;
-        if (i == rx.capacity - 1) {
-            d->addr |= RXD_WRAP;
-        }
-    }
+    /* RX descriptors are initialised by rx_provide() before NIC is enabled */
 
-    /* TX descriptors */
+    /* TX descriptors must started as SW owned */
     for (uint32_t i = 0; i < tx.capacity; i++) {
         volatile struct descriptor *d = &(tx.descr[i]);
         d->addr = 0;

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -23,9 +23,12 @@ __attribute__((__section__(".net_driver_config"))) net_driver_config_t config;
 #define TX_COUNT 256
 #define MAX_COUNT MAX(RX_COUNT, TX_COUNT)
 
-/* HW ring descriptor, 64-bit (shared with device) */
+/* HW ring descriptor, 64-bit (shared with device).
+ * For RX, Word 0 (addr) also includes the wrap bit [1] and ownership bit [0] (Table 34-5)
+ * For TX, Word 0 (addr) is only an address, wrap and ownership bits in Word 1 (stat) (Table 34-8)
+ */
 struct descriptor {
-    uint32_t addr;      /* Word 0: Buffer address low [31:2], wrap [1], used [0] */
+    uint32_t addr;      /* Word 0: Buffer address (RX: wrap + ownership as well) */
     uint32_t stat;      /* Word 1: Status/control */
     uint32_t addr_hi;   /* Word 2: Buffer address high (upper 32 bits) */
     uint32_t unused;

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -99,8 +99,10 @@ static void rx_provide(void)
             assert(!err);
 
             uint32_t idx = rx.tail % rx.capacity;
-            /* RXD_ADDR_MASK also sets HW ownership */
-            uintptr_t phys = buffer.io_or_offset & RXD_ADDR_MASK; 
+
+            /* Buffer must be word-aligned; bits [1:0] are reserved by HW for wrap/ownership */
+            assert((buffer.io_or_offset & ~RXD_ADDR_MASK) == 0);
+            uintptr_t phys = buffer.io_or_offset;
 
             if (idx + 1 == rx.capacity) {
                 phys |= RXD_WRAP;
@@ -170,7 +172,7 @@ static void tx_provide(void)
 
             uint32_t idx = tx.tail % tx.capacity;
             uint32_t stat = TXD_LAST | TXD_MK_HW_OWNR; /* Set HW as owner */
-            uintptr_t phys = buffer.io_or_offset & TXD_ADDR_MASK;
+            uintptr_t phys = buffer.io_or_offset;
 
             if (idx + 1 == tx.capacity) {
                 stat |= TXD_WRAP;

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -227,17 +227,13 @@ static void tx_return(void)
 static void handle_irq(void)
 {
     uint32_t isr = eth->isr & IRQ_MASK;
-    uint32_t rxsr = eth->rxsr;
-    uint32_t txsr = eth->txsr;
+    uint32_t rxsr = eth->rxsr & ZYNQ_GEM_RXSR_ERR_MASK;
+    uint32_t txsr = eth->txsr & ZYNQ_GEM_TXSR_ERR_MASK;
     eth->isr = isr;
 
     /* Clear any RX/TX status (write to clear) */
-    if (rxsr) {
-        eth->rxsr = rxsr;
-    }
-    if (txsr) {
-        eth->txsr = txsr;
-    }
+    eth->rxsr = rxsr;
+    eth->txsr = txsr;
 
     while (isr & IRQ_MASK) {
         if (isr & ZYNQ_INT_TXC) {
@@ -248,13 +244,13 @@ static void handle_irq(void)
             rx_return();
             rx_provide();
         }
-        if (rxsr & ZYNQ_GEM_RXSR_ERR_MASK) {
+        if (rxsr) {
             sddf_dprintf("ETH|ERROR: Receive error, status: %u\n", rxsr);
             /* bit 0: Hw tried to read a Sw-owned buffer */
             /* bit 2: packets arriving faster than GEM_DMA processes */
             /* see: https://docs.amd.com/r/en-US/ug1087-zynq-ultrascale-registers/receive_status-GEM-Register */
         }
-        if (txsr & ZYNQ_GEM_TXSR_ERR_MASK) {
+        if (txsr) {
             sddf_dprintf("ETH|ERROR: Transmit error, status: %u\n", txsr);
             /* see: https://docs.amd.com/r/en-US/ug1087-zynq-ultrascale-registers/transmit_status-GEM-Register */
         }

--- a/drivers/network/zynqmp-gem/ethernet.c
+++ b/drivers/network/zynqmp-gem/ethernet.c
@@ -65,12 +65,10 @@ static void update_ring_slot_rx(hw_ring_t *ring, unsigned int idx, uintptr_t phy
     volatile struct descriptor *d = &(ring->descr[idx]);
     d->addr_hi = (uint32_t)(phys >> 32);
     d->stat = 0;  /* HW fills on receive */
-
-    /* Ensure all writes to the descriptor complete, before we set the flags
-     * that makes hardware aware of this slot. Recall d->addr includes ownership bit.
+    /* Ensure all writes to the descriptor are ordered before we set the flags
+     * that makes hardware aware of this slot.
      */
-    THREAD_MEMORY_RELEASE();
-
+    wwmb();
     d->addr = (uint32_t)(phys);
 }
 
@@ -79,12 +77,10 @@ static void update_ring_slot_tx(hw_ring_t *ring, unsigned int idx, uintptr_t phy
     volatile struct descriptor *d = &(ring->descr[idx]);
     d->addr = (uint32_t)(phys);
     d->addr_hi = (uint32_t)(phys >> 32);
-
-    /* Ensure all writes to the descriptor complete, before we set the flags
+    /* Ensure all writes to the descriptor are ordered before we set the flags
      * that makes hardware aware of this slot.
      */
-    THREAD_MEMORY_RELEASE();
-
+    wwmb();
     d->stat = stat | (len & TXD_LEN_MASK);
 }
 
@@ -141,7 +137,11 @@ static void rx_return(void)
             break;
         }
 
-        THREAD_MEMORY_ACQUIRE();
+        /*
+         * The following barrier orders the following reads from the descriptor to be after
+         * the read from the 'status' field of the descriptor.
+         */
+        rrmb();
 
         /* See Table 34-5: RX Buffer Descriptor Entry (64-bit mode) */
         uint16_t len = d->stat & RXD_LEN_MASK;
@@ -180,8 +180,6 @@ static void tx_provide(void)
 
             update_ring_slot_tx(&tx, idx, phys, buffer.len, stat);
             tx.tail++;
-
-            eth->nwctrl |= ZYNQ_GEM_NWCTRL_STARTTX_MASK;
         }
 
         net_request_signal_active(&tx_queue);
@@ -192,6 +190,13 @@ static void tx_provide(void)
             reprocess = true;
         }
     }
+
+    /* The following barrier orders the write to the DMA register to be after the write to
+     * the 'status' fields of the descriptors updated in function update_ring_slot().
+     */
+    wwmb();
+
+    eth->nwctrl |= ZYNQ_GEM_NWCTRL_STARTTX_MASK;
 }
 
 static void tx_return(void)
@@ -207,7 +212,11 @@ static void tx_return(void)
             break;
         }
 
-        THREAD_MEMORY_ACQUIRE();
+        /*
+         * The following barrier orders the following reads to the descriptor to be after
+         * the read to the 'status' field of the descriptor.
+         */
+        rrmb();
 
         uintptr_t phys_addr = ((uintptr_t)d->addr_hi << 32) | d->addr;
         net_buff_desc_t buffer = { phys_addr, 0 };

--- a/drivers/network/zynqmp-gem/ethernet.h
+++ b/drivers/network/zynqmp-gem/ethernet.h
@@ -13,10 +13,6 @@
  * The ethernet device is described in Chapter 34
  */
 
-/* General */
-#define MAX_BIT_32_MASK      0xFFFFFFFF
-#define MAX_BIT_64_MASK      0xFFFFFFFFFFFFFFFF
-
 /* Table 34-8: TX Buffer Descriptor Entry
  *
  */

--- a/drivers/network/zynqmp-gem/ethernet.h
+++ b/drivers/network/zynqmp-gem/ethernet.h
@@ -125,9 +125,9 @@ typedef struct zynqmp_gem_regs {
 #define ZYNQ_GEM_NWCFG_CHSUM_EN         (1 << 24)  /* enable checksum offload on receive */
 #define ZYNQ_GEM_NWCFG_IEEE_MDC         (0x7 << 18)
 
+
 /* dmacr: DMA config register */
-#define ZYNQ_GEM_DMACR_BLENGTH          0x00000004    /* INCR4 AHB bursts */
-#define ZYNQ_GEM_DMACR_RXBUF            0x00180000    /* Set with binary 00011000 to use 1536 byte(1*max length frame/buffer) */
+#define ZYNQ_GEM_DMACR_RXBUF            0x00180000    /* RX DMA Buffer size 1536 bytes */
 #define ZYNQ_GEM_DMACR_TXPBUF_32KB      (1UL << 10)   /* TX packet buffer 32KB */
 #define ZYNQ_GEM_DMACR_TXPBUF_TCP       (1UL << 11)   /* TX checksum offload */
 #define ZYNQ_GEM_DMACR_RXPBUF_SHIFT     8

--- a/drivers/network/zynqmp-gem/ethernet.h
+++ b/drivers/network/zynqmp-gem/ethernet.h
@@ -134,7 +134,9 @@ typedef struct zynqmp_gem_regs {
 
 /* rxsr/txsr: Receive/Transmit status register */
 #define ZYNQ_GEM_RXSR_CLEAR             0x0F
+#define ZYNQ_GEM_RXSR_ERR_MASK          0x0D
 #define ZYNQ_GEM_TXSR_CLEAR             0xFF
+#define ZYNQ_GEM_TXSR_ERR_MASK          0x450
 
 /* idr/isr: Interrupt Disable/Status register */
 #define ZYNQ_GEM_IDR_CLEAR              0x7FFFEFF

--- a/drivers/network/zynqmp-gem/ethernet.h
+++ b/drivers/network/zynqmp-gem/ethernet.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026, Skykraft
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+/* The reference manual used to acquire these values:
+ * Zynq UltraScale+ Device Technical Reference Manual
+ * Document number: UG1085
+ * Rev. 2.5, 21st March 2025
+ *
+ * The ethernet device is described in Chapter 34
+ */
+
+/* General */
+#define MAX_BIT_32_MASK      0xFFFFFFFF
+#define MAX_BIT_64_MASK      0xFFFFFFFFFFFFFFFF
+
+/* Table 34-8: TX Buffer Descriptor Entry
+ *
+ */
+/* TX Descriptor Word 0 bits */
+#define TXD_ADDR_MASK   (0xFFFFFFFF)  /* Address bits 31:0 */
+
+/* TX Descriptor Word 1 bits */
+#define TXD_USED        (1UL << 31)   /* Ownership: 0=HW, 1=SW */
+#define TXD_WRAP        (1UL << 30)   /* Wrap bit */
+#define TXD_LAST        (1UL << 15)   /* Last buffer in frame */
+#define TXD_LEN_MASK    (0x3FFF)      /* Length mask (bits 13:0) */
+#define TXD_MK_HW_OWNR  (0UL << 31)
+
+/* Table 34-5: RX Buffer Descriptor Entry
+ *
+ */
+/* RX Descriptor Word 0 bits */
+#define RXD_WRAP        (1UL << 1)    /* Wrap bit */
+#define RXD_OWN         1UL           /* Ownership: 0=HW, 1=SW */
+#define RXD_ADDR_MASK   (0xFFFFFFFC)  /* Address bits 31:2 */
+#define RXD_MK_HW_OWNR  0             /* Set ownership to HW */
+
+/* RX Descriptor Word 1 bits */
+#define RXD_LEN_MASK    (0x1FFF)      /* Length mask bits (12:0) */
+
+/* Hardware registers structure */
+typedef struct zynqmp_gem_regs {
+    uint32_t nwctrl;                    /* 0x0 - Network Control reg */
+    uint32_t nwcfg;                     /* 0x4 - Network Config reg */
+    uint32_t nwsr;                      /* 0x8 - Network Status reg */
+    uint32_t reserved1;
+    uint32_t dmacr;                     /* 0x10 - DMA Control reg */
+    uint32_t txsr;                      /* 0x14 - TX Status reg */
+    uint32_t rxqbase;                   /* 0x18 - RX Queue Base address reg */
+    uint32_t txqbase;                   /* 0x1c - TX Queue Base address reg */
+    uint32_t rxsr;                      /* 0x20 - RX Status reg */
+    uint32_t isr;                       /* 0x24 - Interrupt status reg */
+    uint32_t ier;                       /* 0x28 - Interrupt enable reg */
+    uint32_t idr;                       /* 0x2c - Interrupt Disable reg */
+    uint32_t reserved3;                 /* 0x30 - Current interrupt mask register */
+    uint32_t phymntnc;                  /* 0x34 - Phy Maintaince reg */
+    uint32_t reserved4[18];
+    uint32_t hashl;                     /* 0x80 - Hash Low address reg */
+    uint32_t hashh;                     /* 0x84 - Hash High address reg */
+#define LADDR_LOW    0
+#define LADDR_HIGH   1
+    uint32_t laddr[4][LADDR_HIGH + 1];  /* 0x88 - Specific1 addr low/high reg */
+    uint32_t match[4];                  /* 0xa8 - Type ID1 Match reg */
+    uint32_t reserved6[18];
+#define STAT_SIZE    44
+    uint32_t stat[STAT_SIZE];           /* 0x100 - Octects transmitted Low reg + stat regs */
+    uint32_t reserved9[20];
+    uint32_t pcscntrl;                  /* 0x200 - PCS control reg */
+    uint32_t pcsstatus;                 /* 0x204 - PCS status reg */
+    uint32_t reserved12[35];
+    uint32_t dcfg6;                     /* 0x294 - Design config reg6 */
+    uint32_t reserved7[106];
+    uint32_t transmit_q1_ptr;           /* 0x440 - Transmit priority queue 1 */
+    uint32_t reserved8[15];
+    uint32_t receive_q1_ptr;            /* 0x480 - Receive priority queue 1 */
+    uint32_t reserved10[17];
+    uint32_t upper_txqbase;             /* 0x4C8 - Upper tx_q base addr */
+    uint32_t reserved11[2];
+    uint32_t upper_rxqbase;             /* 0x4D4 - Upper rx_q base addr */
+    uint32_t screening_type1_0;         /* 0x500 - Screening_type_1_register_0 */
+    uint32_t screening_type1_1;         /* 0x504 - Screening_type_1_register_1 */
+    uint32_t screening_type1_2;         /* 0x508 - Screening_type_1_register_2 */
+    uint32_t screening_type1_3;         /* 0x50c - Screening_type_1_register_3 */
+    uint32_t screening_type2_0;         /* 0x540 - Screening_type_2_register_0 */
+    uint32_t screening_type2_1;         /* 0x544 - Screening_type_2_register_1 */
+    uint32_t screening_type2_2;         /* 0x548 - Screening_type_2_register_2 */
+    uint32_t screening_type2_3;         /* 0x54c - Screening_type_2_register_3 */
+    uint32_t int_q1_enable;             /* 0x600 - Interrupts enable*/
+    uint32_t int_q1_disable;            /* 0x620 - Interrupts disable*/
+    uint32_t int_q1_mask;               /* 0x640 - Interrupts mask */
+    uint32_t screening_type2_ethertype_0;/* 0x6e0 - Screening_type_2_ethertype_register_0 */
+    uint32_t screening_type2_ethertype_1;/* 0x6e4 - Screening_type_2_ethertype_register_1 */
+    uint32_t screening_type2_ethertype_2;/* 0x6e8 - Screening_type_2_ethertype_register_2 */
+    uint32_t screening_type2_ethertype_3;/* 0x6ec - Screening_type_2_ethertype_register_3 */
+    uint32_t type2_comp_0_wrd_0;        /* 0x700 - type2_compare_0_word_0 */
+    uint32_t type2_comp_0_wrd_1;        /* 0x704 - type2_compare_0_word_1 */
+    uint32_t type2_comp_1_wrd_0;        /* 0x708 - type2_compare_1_word_0 */
+    uint32_t type2_comp_1_wrd_1;        /* 0x70c - type2_compare_1_word_1 */
+    uint32_t type2_comp_2_wrd_0;        /* 0x710 - type2_compare_2_word_0 */
+    uint32_t type2_comp_2_wrd_1;        /* 0x714 - type2_compare_2_word_1 */
+    uint32_t type2_comp_3_wrd_0;        /* 0x718 - type2_compare_3_word_0 */
+    uint32_t type2_comp_3_wrd_1;        /* 0x71c - type2_compare_3_word_1 */
+} zynqmp_gem_regs_t;
+
+/* nwcntrl: Network control register */
+#define ZYNQ_GEM_NWCTRL_CLEARSTAT       BIT(5)
+#define ZYNQ_GEM_NWCTRL_TXEN_MASK       0x00000008 /* Enable transmit */
+#define ZYNQ_GEM_NWCTRL_RXEN_MASK       0x00000004 /* Enable receive */
+#define ZYNQ_GEM_NWCTRL_MDEN_MASK       0x00000010 /* Enable MDIO port */
+#define ZYNQ_GEM_NWCTRL_STARTTX_MASK    0x00000200 /* Start tx (tx_go) */
+
+/* nwcfg: Network config register */
+#define ZYNQ_GEM_NWCFG_SPEED100         0x00000001 /* 100 Mbps operation */
+#define ZYNQ_GEM_NWCFG_SPEED1000        0x00000400 /* 1Gbps operation */
+#define ZYNQ_GEM_NWCFG_FDEN             0x00000002 /* Full Duplex mode */
+#define ZYNQ_GEM_NWCFG_FSREM            0x00020000 /* FCS removal */
+#define ZYNQ_GEM_NWCFG_SGMII_ENBL       0x08000000 /* SGMII Enable */
+#define ZYNQ_GEM_NWCFG_PCS_SEL          0x00000800 /* PCS select */
+#define ZYNQ_GEM_DBUS_WIDTH             (1 << 21)  /* 64 bit bus */
+#define ZYNQ_GEM_NWCFG_CPY_ALL_FRAMES   BIT(4)
+#define ZYNQ_GEM_NWCFG_CHSUM_EN         (1 << 24)  /* enable checksum offload on receive */
+#define ZYNQ_GEM_NWCFG_IEEE_MDC         (0x7 << 18)
+
+/* dmacr: DMA config register */
+#define ZYNQ_GEM_DMACR_BLENGTH          0x00000004    /* INCR4 AHB bursts */
+#define ZYNQ_GEM_DMACR_RXBUF            0x00180000    /* Set with binary 00011000 to use 1536 byte(1*max length frame/buffer) */
+#define ZYNQ_GEM_DMACR_TXPBUF_32KB      (1UL << 10)   /* TX packet buffer 32KB */
+#define ZYNQ_GEM_DMACR_TXPBUF_TCP       (1UL << 11)   /* TX checksum offload */
+#define ZYNQ_GEM_DMACR_RXPBUF_SHIFT     8
+#define ZYNQ_GEM_DMACR_RXPBUF_MASK      (0x3 << ZYNQ_GEM_DMACR_RXPBUF_SHIFT)
+#define ZYNQ_GEM_DMACR_RXPBUF_32KB      (0x3 << ZYNQ_GEM_DMACR_RXPBUF_SHIFT) /* RX packet buffer 32KB */
+#define ZYNQ_GEM_DMACR_BLENGTH_MASK     (0x1F)
+#define ZYNQ_GEM_DMACR_BLENGTH_16       (0x10)        /* INCR16 bursts */
+#define ZYNQ_GEM_DMA_BUS_WIDTH          BIT(30)       /* 64 bit bus */
+
+/* rxsr/txsr: Receive/Transmit status register */
+#define ZYNQ_GEM_RXSR_CLEAR             0x0F
+#define ZYNQ_GEM_TXSR_CLEAR             0xFF
+
+/* idr/isr: Interrupt Disable/Status register */
+#define ZYNQ_GEM_IDR_CLEAR              0x7FFFEFF
+
+/* Interrupts - based on int_status register */
+#define ZYNQ_INT_RXC                    BIT(1)  /* Receive completed */
+#define ZYNQ_INT_TXC                    BIT(7)  /* Transmit completed */
+#define IRQ_MASK                   (ZYNQ_INT_RXC | ZYNQ_INT_TXC) /* Only rx and tx interrupts */

--- a/drivers/network/zynqmp-gem/ethernet.h
+++ b/drivers/network/zynqmp-gem/ethernet.h
@@ -125,7 +125,6 @@ typedef struct zynqmp_gem_regs {
 #define ZYNQ_GEM_NWCFG_CHSUM_EN         (1 << 24)  /* enable checksum offload on receive */
 #define ZYNQ_GEM_NWCFG_IEEE_MDC         (0x7 << 18)
 
-
 /* dmacr: DMA config register */
 #define ZYNQ_GEM_DMACR_RXBUF            0x00180000    /* RX DMA Buffer size 1536 bytes */
 #define ZYNQ_GEM_DMACR_TXPBUF_32KB      (1UL << 10)   /* TX packet buffer 32KB */

--- a/examples/echo_server/echo.mk
+++ b/examples/echo_server/echo.mk
@@ -16,6 +16,7 @@ SUPPORTED_BOARDS := \
 		    imx8mp_evk \
 			imx8mq_evk \
 		    imx8mp_iotgate \
+			kria_k26 \
 			maaxboard \
 			odroidc2 \
 			odroidc4 \

--- a/examples/echo_server/echo.mk
+++ b/examples/echo_server/echo.mk
@@ -25,7 +25,8 @@ SUPPORTED_BOARDS := \
 			rock3b \
 			star64 \
 			x86_64_generic \
-			rpi4b_1gb
+			rpi4b_1gb \
+			zcu102
 
 TOOLCHAIN ?= clang
 MICROKIT_CONFIG ?= debug

--- a/examples/vswitch/vswitch.mk
+++ b/examples/vswitch/vswitch.mk
@@ -23,7 +23,8 @@ SUPPORTED_BOARDS := \
 			rock3b \
 			star64 \
 			x86_64_generic \
-			rpi4b_1gb
+			rpi4b_1gb \
+			zcu102
 TOOLCHAIN ?= clang
 MICROKIT_CONFIG ?= debug
 SYSTEM_FILE := vswitch.system

--- a/include/sddf/network/constants.h
+++ b/include/sddf/network/constants.h
@@ -17,6 +17,6 @@
  */
 #if defined(CONFIG_PLAT_IMX8MM_EVK) || defined(CONFIG_PLAT_MAAXBOARD) || defined(CONFIG_PLAT_IMX8MP_EVK)               \
     || defined(CONFIG_PLAT_ODROIDC4) || defined(CONFIG_PLAT_STAR64) || defined(CONFIG_PLAT_HIFIVE_P550)                \
-    || defined(CONFIG_PLAT_ODROIDC2)
+    || defined(CONFIG_PLAT_ODROIDC2) || defined(CONFIG_PLAT_ZYNQMP)
 #define NETWORK_HW_HAS_CHECKSUM
 #endif

--- a/tools/make/board/kria_k26.mk
+++ b/tools/make/board/kria_k26.mk
@@ -6,6 +6,8 @@
 # Set up variables for kria_k26
 # Should be included _before_ toolchain makefile.
 PLATFORM := zynqmp
+NET_DRIV_DIR := zynqmp-gem
+ETH_DRIV := eth_driver_znyqmp_gem.elf
 TIMER_DRIV_DIR := cdns
 UART_DRIV_DIR := ${PLATFORM}
 

--- a/tools/make/board/zcu102.mk
+++ b/tools/make/board/zcu102.mk
@@ -7,8 +7,8 @@
 # Should be included _before_ toolchain makefile.
 PLATFORM := zynqmp
 # I2C_DRIV_DIR := ${PLATFORM}
-# NET_DRIV_DIR :=
-# ETH_DRIV := eth_driver_dwmac-5.10a.elf
+# NET_DRIV_DIR := zynqmp-gem
+# ETH_DRIV := eth_driver_znyqmp_gem.elf
 TIMER_DRIV_DIR := cdns
 UART_DRIV_DIR := ${PLATFORM}
 

--- a/tools/make/board/zcu102.mk
+++ b/tools/make/board/zcu102.mk
@@ -7,8 +7,8 @@
 # Should be included _before_ toolchain makefile.
 PLATFORM := zynqmp
 # I2C_DRIV_DIR := ${PLATFORM}
-# NET_DRIV_DIR := zynqmp-gem
-# ETH_DRIV := eth_driver_znyqmp_gem.elf
+NET_DRIV_DIR := zynqmp-gem
+ETH_DRIV := eth_driver_znyqmp_gem.elf
 TIMER_DRIV_DIR := cdns
 UART_DRIV_DIR := ${PLATFORM}
 

--- a/tools/meta/board.py
+++ b/tools/meta/board.py
@@ -103,6 +103,7 @@ BOARDS: List[Board] = [
         paddr_top=0x70000000,
         timer="axi/timer@ff140000",
         serial="axi/serial@ff010000",
+        ethernet="axi/ethernet@ff0e0000",
     ),
     Board(
         name="maaxboard",
@@ -191,6 +192,7 @@ BOARDS: List[Board] = [
         paddr_top=0x80000000,
         timer="axi/timer@ff140000",
         serial="axi/serial@ff000000",
+        ethernet="axi/ethernet@ff0e0000",
     ),
     Board(
         name="x86_64_generic",


### PR DESCRIPTION
## General

This PR adds the GEM driver for the ZynqMP platform, tested on the Kria K26 board. Made in collaboration with @potanin.

Below are some key configurations set in the driver.

| Configuration | Value | Notes |
|---|---|---|
| Link speed | 1 Gbps | Full duplex |
| Priority queue 0 | Enabled | Rx/Tx buffer descriptor ring |
| Priority queue 1 | Disabled | Terminated with permanent wrap descriptor |
| Buffer Descriptor format | 64-bit | Required by GEM due to underlying 64-bit DMA controller, higher address bits left zero'd |
| RX checksum offload | Enabled | Hardware validates IP/TCP/UDP checksums |
| TX checksum offload | Enabled | Hardware generates checksums |

Regarding disabling "priority queue 1", I would appreciate feedback as to whether the approach is reasonable (please see `ethernet.c/disable_pq1()`).

## Benchmark
Combined Rx/Tx Throughput as they are virtually identical. Compare the results against Xilinx: [ZynqMP lwIP Performance](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842366/Standalone+LWIP+library#ZynqMP).

### UDP

<img width="1134" height="756" alt="UDP Performance" src="https://github.com/user-attachments/assets/6382d01e-a8e8-467d-93b6-9fbc5addba48" />

### TCP

<img width="1181" height="727" alt="TCP Performance" src="https://github.com/user-attachments/assets/5a3a4d64-7447-458a-810c-0da13b8a9337" />

Clearly, there's an interesting bottleneck here somewhere. All checksum components have been offloaded to HW, and I believe I enabled the appropriate sDDF setting in `include/sddf/network/constants.h`. In debugging, I also ran Xilinx's own [lwip_tcp_perf_server](https://github.com/Xilinx/embeddedsw/tree/master/lib/sw_apps/lwip_tcp_perf_server) (outside of seL4 world) and observed a max TCP throughput of 270 Mbps. So comparatively the GEM driver performs better in sDDF. I also used the specific lwIP settings as that repo and observed no change.

The only way to get anywhere near [Xilinx TCP performance](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842366/Standalone+LWIP+library#ZynqMP) in `lwip_tcp_perf_server` is to use TCP clients in parallel (see the Table below), which I cannot currently test in sDDF. 

| Number of TCP Clients | Throughput (Mbps)
|---|---|
| 1 | 270 |
| 5 | 900 |
| 10 | 929 |
| 15 | 929 |

### Results

See RAW data here:

[output-UDP.csv](https://github.com/user-attachments/files/26198031/output-2026-03-23T10.45.48_udp.csv)

[output-TCP.csv](https://github.com/user-attachments/files/26198036/output-2026-03-23T12.03.11_tcp.csv)

Comparing these results against IMX Maaxboard results (12/11/2025, thanks @Ivan-Velickovic !), the GEM driver has significantly higher mean and median RTT times.

**Using UDP results**
| Load (Mbps) | GEM Median RTT (μs) | iMX Median RTT (μs) | Delta (%, relative to iMX) |
|-------------|--------------------:|--------------------:|-------------:|
| 10          | 277                 | 147                 | +88%         |
| 20          | 254                 | 147                 | +73%         |
| 50          | 278                 | 133                 | +109%        |
| 100         | 341                 | 133                 | +156%        |
| 200         | 362                 | 119                 | +204%        |
| 300         | 443                 | 244                 | +82%         |
| 400         | 670                 | 363                 | +85%         |
| 500         | 781                 | 426                 | +83%         |
| 600         | 798                 | 702                 | +14%         |
| 700         | 816                 | 795                 | +3%          |
| 800         | 828                 | 803                 | +3%          |
| 900         | 844                 | 796                 | +6%          |
| 970         | 2139                | 1384                | +55%         |

The GEM median RTT (and standard deviation) is a fair bit higher than IMX Maaxboard. The IMX driver configures 128-frame TX interrupt coalescing, which is not available on the ZynqMP GEM. Instead a Tx completion interrupt fires for each transmitted frame, consuming a larger share of the driver's scheduling budget.

Both drivers converging in RTT around 800-900 Mbps should support this, since at that point both drivers are processing packets back-to-back and the per-interrupt overhead is amortised across larger bursts (more IRQs processed per context switch). If the gap were caused by a driver bug or hardware limitation rather than interrupt overhead, I imagine it would persist (or worsen) at high loads, not disappear (obviously disregarding the saturation at Gigabit speeds).

### Other

I've refrained from adding ZCU102 as a network-supported board for the moment since I haven't tested it on that board but it would be great to be able to do that as a part of this PR as well.