### PR TITLE
Rpi4 genet driver no hw csum

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -23,6 +23,7 @@ Files:
     drivers/blk/virtio/config.json
     drivers/i2c/meson/config.json
     drivers/i2c/opentitan/config.json
+    drivers/network/genet/config.json
     drivers/network/imx/config.json
     drivers/network/meson/config.json
     drivers/network/virtio/mmio/config.json

--- a/ci/matrix.py
+++ b/ci/matrix.py
@@ -99,6 +99,7 @@ EXAMPLES: dict[str, _ExampleMatrixType] = {
             "qemu_virt_aarch64",
             "qemu_virt_riscv64",
             "rock3b",
+            "rpi4b_1gb",
             "star64",
             "x86_64_generic",
         ],

--- a/drivers/network/genet/config.json
+++ b/drivers/network/genet/config.json
@@ -1,0 +1,32 @@
+{
+    "compatible": [
+        "brcm,bcm2711-genet-v5"
+    ],
+    "resources": {
+        "regions": [
+            {
+                "name": "regs",
+                "perms": "rw",
+                "size": 65536,
+                "dt_index": 0
+            },
+            {
+                "name": "device_rx_ring",
+                "size": 32768
+            },
+            {
+                "name": "device_tx_ring",
+                "size": 32768
+            },
+            {
+                "name": "mbox_message",
+                "size": 32768
+            }
+        ],
+        "irqs": [
+            {
+                "dt_index": 0
+            }
+        ]
+    }
+}

--- a/drivers/network/genet/eth_driver.mk
+++ b/drivers/network/genet/eth_driver.mk
@@ -1,0 +1,27 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Include this snippet in your project Makefile to build
+# the GENET NIC driver
+#
+# NOTES
+#  Generates eth_driver.elf (alternative unique name eth_driver_genet.elf)
+#  Expects libsddf_util_debug.a to be in LIBS
+
+ETHERNET_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+CHECK_NETDRV_GENET_FLAGS_MD5:=.netdrv_genet_cflags-$(shell echo -- ${CFLAGS} ${CFLAGS_network} | shasum | sed 's/ *-//')
+
+${CHECK_NETDRV_GENET_FLAGS_MD5}:
+	-rm -f .netdrv_genet_cflags-*
+	touch $@
+
+eth_driver_genet.elf: network/genet/ethernet.o libsddf_util.a
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+network/genet/ethernet.o: ${ETHERNET_DRIVER_DIR}/ethernet.c ${CHECK_NETDRV_FLAGS_MD5} | $(SDDF_LIBC_INCLUDE)
+	mkdir -p network/genet
+	${CC} -c ${CFLAGS} ${CFLAGS_network} -I ${ETHERNET_DRIVER_DIR} -o $@ $<
+
+-include genet/ethernet.d

--- a/drivers/network/genet/ethernet.c
+++ b/drivers/network/genet/ethernet.c
@@ -1,0 +1,533 @@
+/*
+ * Copyright 2026, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This driver is based on the Linux driver:
+ *      drivers/net/ethernet/broadcom/genet/bcmgenet.c
+ *      which is: Copyright (c) 2014-2017 Broadcom
+ *
+ * Also referred to:
+ *      https://github.com/u-boot/u-boot/blob/master/drivers/net/bcmgenet.c
+ *      https://github.com/RT-Thread/rt-thread/blob/master/bsp/raspberry-pi/raspi4-32/driver/drv_eth.c
+ *      BCM54213PE Datasheet
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <os/sddf.h>
+#include <sddf/resources/device.h>
+#include <sddf/network/queue.h>
+#include <sddf/network/config.h>
+#include <sddf/network/constants.h>
+#include <sddf/util/util.h>
+#include <sddf/util/fence.h>
+#include <sddf/util/printf.h>
+#include <sddf/timer/config.h>
+#include <sddf/timer/client.h>
+
+#include "ethernet.h"
+
+__attribute__((__section__(".device_resources"))) device_resources_t device_resources;
+__attribute__((__section__(".net_driver_config"))) net_driver_config_t config;
+__attribute__((__section__(".timer_client_config"))) timer_client_config_t timer_config;
+
+volatile struct genet_regs *eth;
+volatile struct mbox_regs *mbox_regs;
+volatile uint32_t *mbox;
+
+volatile struct genet_dma_ring_rx *ring_rx;
+volatile struct genet_dma_ring_tx *ring_tx;
+
+/* HW ring buffer data type */
+typedef struct {
+    uint32_t tail; /* index to insert at */
+    uint32_t head; /* index to remove from */
+    uint32_t capacity; /* capacity of description ring */
+    uint32_t desc_id_mask; /* mask of description id */
+    uint32_t index_mask; /* mask of index in ring */
+    volatile struct genet_dma_desc *descr; /* buffer descriptor array */
+} hw_ring_t;
+
+hw_ring_t rx;
+hw_ring_t tx;
+
+net_queue_handle_t rx_queue;
+net_queue_handle_t tx_queue;
+
+static inline bool hw_ring_full(hw_ring_t *ring)
+{
+    return ring->tail - ring->head == ring->capacity;
+}
+
+static inline bool hw_ring_empty(hw_ring_t *ring)
+{
+    return ring->tail - ring->head == 0;
+}
+
+static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys, uint32_t stat)
+{
+    volatile struct genet_dma_desc *d = &(ring->descr[idx]);
+    d->addr_lo = phys & 0xFFFFFFFF;
+    d->addr_hi = phys >> 32;
+    d->status = stat;
+
+    /* Ensure all writes to the descriptor complete, before we set the flags
+     * that makes hardware aware of this slot.
+     */
+    THREAD_MEMORY_RELEASE();
+}
+
+static void sleep_us(uint32_t us)
+{
+    uint64_t start = sddf_timer_time_now(timer_config.driver_id);
+    while ((sddf_timer_time_now(timer_config.driver_id) - start) < us * NS_IN_US);
+}
+
+static void bcmgenet_mdio_write(uint8_t reg_addr, uint16_t val)
+{
+    uint32_t cmd = MDIO_WR | (GENET_PHY_ID << MDIO_PMD_SHIFT) | ((reg_addr & MDIO_REG_MASK) << MDIO_REG_SHIFT) | val;
+    eth->umac_mdio_cmd = cmd;
+
+    uint32_t reg = eth->umac_mdio_cmd | MDIO_START_BUSY;
+    eth->umac_mdio_cmd = reg;
+
+    while (eth->umac_mdio_cmd & MDIO_START_BUSY);
+}
+
+static uint16_t bcmgenet_mdio_read(uint8_t reg_addr)
+{
+    uint32_t cmd = MDIO_RD | (GENET_PHY_ID << MDIO_PMD_SHIFT) | ((reg_addr & MDIO_REG_MASK) << MDIO_REG_SHIFT);
+    eth->umac_mdio_cmd = cmd;
+
+    uint32_t reg = eth->umac_mdio_cmd | MDIO_START_BUSY;
+    eth->umac_mdio_cmd = reg;
+
+    while (eth->umac_mdio_cmd & MDIO_START_BUSY);
+
+    return eth->umac_mdio_cmd & 0xFFFF;
+}
+
+static void rx_provide(void)
+{
+    bool reprocess = true;
+    while (reprocess) {
+        while (!hw_ring_full(&rx) && !net_queue_empty_free(&rx_queue)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_free(&rx_queue, &buffer);
+            assert(!err);
+
+            uint32_t idx = rx.tail & rx.desc_id_mask;
+            update_ring_slot(&rx, idx, buffer.io_or_offset, 0);
+            rx.tail++;
+        }
+        // Doorbell the device
+        ring_rx->cons_index = (rx.tail - NUM_DESCS) & rx.index_mask;
+
+        // Only request a notification from virtualiser if HW ring not full
+        if (!hw_ring_full(&rx)) {
+            net_request_signal_free(&rx_queue);
+        } else {
+            net_cancel_signal_free(&rx_queue);
+        }
+        reprocess = false;
+
+        if (!net_queue_empty_free(&rx_queue) && !hw_ring_full(&rx)) {
+            net_cancel_signal_free(&rx_queue);
+            reprocess = true;
+        }
+    }
+}
+
+static void rx_return(void)
+{
+    bool packets_transferred = false;
+
+    // Each register read takes over 300 cycles, so we read prod_index once
+    // for optimisation. The packets arrived before clearing IRQ status will
+    // be handled in next iteration.
+    uint32_t prod_index = ring_rx->prod_index & rx.index_mask;
+    while (!hw_ring_empty(&rx)) {
+        if ((rx.head & rx.index_mask) == prod_index) {
+            break;
+        }
+        uint32_t idx = rx.head & rx.desc_id_mask;
+        volatile struct genet_dma_desc *d = &(rx.descr[idx]);
+
+        THREAD_MEMORY_ACQUIRE();
+
+        uint64_t addr = ((uint64_t)(d->addr_hi) << 32) | d->addr_lo;
+        net_buff_desc_t buffer = { addr, d->status >> DMA_BUFLENGTH_SHIFT };
+        int err = net_enqueue_active(&rx_queue, buffer);
+        assert(!err);
+
+        packets_transferred = true;
+        rx.head++;
+    }
+
+    if (packets_transferred && net_require_signal_active(&rx_queue)) {
+        net_cancel_signal_active(&rx_queue);
+        sddf_notify(config.virt_rx.id);
+    }
+}
+
+static void tx_provide()
+{
+    bool reprocess = true;
+    while (reprocess) {
+        while (!(hw_ring_full(&tx)) && !net_queue_empty_active(&tx_queue)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_active(&tx_queue, &buffer);
+            assert(!err);
+
+            uint32_t idx = tx.tail & tx.desc_id_mask;
+            uint32_t stat = (buffer.len << DMA_BUFLENGTH_SHIFT) | (0x3F << DMA_TX_QTAG_SHIFT) | DMA_TX_APPEND_CRC
+                          | DMA_TX_DO_CSUM | DMA_SOP | DMA_EOP;
+            update_ring_slot(&tx, idx, buffer.io_or_offset, stat);
+
+            tx.tail++;
+        }
+        ring_tx->prod_index = tx.tail & tx.index_mask;
+
+        net_request_signal_active(&tx_queue);
+        reprocess = false;
+
+        if (!hw_ring_full(&tx) && !net_queue_empty_active(&tx_queue)) {
+            net_cancel_signal_active(&tx_queue);
+            reprocess = true;
+        }
+    }
+}
+
+static void tx_return(void)
+{
+    bool enqueued = false;
+    uint32_t cons_index = ring_tx->cons_index & tx.index_mask;
+    while (!hw_ring_empty(&tx)) {
+        if ((tx.head & tx.index_mask) == cons_index) {
+            break;
+        }
+        uint32_t idx = tx.head & tx.desc_id_mask;
+        volatile struct genet_dma_desc *d = &(tx.descr[idx]);
+
+        THREAD_MEMORY_ACQUIRE();
+
+        uint64_t addr = ((uint64_t)(d->addr_hi) << 32) | d->addr_lo;
+        net_buff_desc_t buffer = { addr, 0 };
+        int err = net_enqueue_free(&tx_queue, buffer);
+        assert(!err);
+
+        enqueued = true;
+        tx.head++;
+    }
+
+    if (enqueued && net_require_signal_free(&tx_queue)) {
+        net_cancel_signal_free(&tx_queue);
+        sddf_notify(config.virt_tx.id);
+    }
+}
+
+static void handle_irq(void)
+{
+    uint32_t irq_status = eth->intrl2_0_cpu_stat & ~(eth->intrl2_0_cpu_stat_mask);
+    eth->intrl2_0_cpu_clear = irq_status;
+    while (irq_status) {
+        if (irq_status & GENET_IRQ_TXDMA_DONE) {
+            tx_return();
+            tx_provide();
+        }
+        if (irq_status & GENET_IRQ_RXDMA_DONE) {
+            rx_return();
+            rx_provide();
+        }
+        irq_status = eth->intrl2_0_cpu_stat & ~(eth->intrl2_0_cpu_stat_mask);
+        eth->intrl2_0_cpu_clear = irq_status;
+    }
+}
+
+static void eth_setup(void)
+{
+    eth = device_resources.regions[0].region.vaddr;
+
+    uint8_t version_major = (eth->sys_rev_ctrl >> 24) & 0x0f;
+    if (version_major != 6) {
+        sddf_dprintf("Unsupported GENET version\n");
+    }
+
+    // Set PHY interface
+    eth->sys_port_ctrl = PORT_MODE_EXT_GPHY;
+
+    // Rbuf clear
+    eth->sys_rbuf_flush_ctrl = 0;
+
+    // Disable MAC while updating its registers
+    eth->umac_cmd = 0;
+    // issue soft reset with (rg)mii loopback to ensure a stable rxclk
+    eth->umac_cmd = CMD_SW_RESET | CMD_LCL_LOOP_EN;
+
+    // MDIO init
+    uint32_t uid_high = bcmgenet_mdio_read(BCM54213PE_PHY_IDENTIFIER_HIGH);
+    uint32_t uid_low = bcmgenet_mdio_read(BCM54213PE_PHY_IDENTIFIER_LOW);
+    if (((uid_high << 16) | (uid_low & 0xFFFF)) == 0) {
+        sddf_dprintf("ERROR: invalid ethernet UID '0'\n");
+        return;
+    }
+
+    // reset phy
+    bcmgenet_mdio_write(BCM54213PE_MII_CONTROL, MII_CONTROL_PHY_RESET);
+    // read control reg
+    bcmgenet_mdio_read(BCM54213PE_MII_CONTROL);
+    // reset phy again
+    bcmgenet_mdio_write(BCM54213PE_MII_CONTROL, MII_CONTROL_PHY_RESET);
+    // read control reg
+    bcmgenet_mdio_read(BCM54213PE_MII_CONTROL);
+    // read status reg
+    bcmgenet_mdio_read(BCM54213PE_MII_STATUS);
+    // read status reg
+    bcmgenet_mdio_read(BCM54213PE_IEEE_EXTENDED_STATUS);
+    bcmgenet_mdio_read(BCM54213PE_AUTO_NEGOTIATION_ADV);
+
+    bcmgenet_mdio_read(BCM54213PE_MII_STATUS);
+    bcmgenet_mdio_read(BCM54213PE_CONTROL);
+    // half full duplex capability
+    bcmgenet_mdio_write(BCM54213PE_CONTROL, (CONTROL_HALF_DUPLEX_CAPABILITY | CONTROL_FULL_DUPLEX_CAPABILITY));
+    bcmgenet_mdio_read(BCM54213PE_MII_CONTROL);
+
+    // set mii control
+    bcmgenet_mdio_write(BCM54213PE_MII_CONTROL,
+                        (MII_CONTROL_AUTO_NEGOTIATION_ENABLED | MII_CONTROL_AUTO_NEGOTIATION_RESTART
+                         | MII_CONTROL_PHY_FULL_DUPLEX | MII_CONTROL_SPEED_SELECTION));
+
+    while (~bcmgenet_mdio_read(BCM54213PE_MII_STATUS) & MII_STATUS_AUTO_NEGOTIATION_COMPLETE);
+
+    // Set MAC address
+    mbox[0] = 8 * 4;                                 // length of the message
+    mbox[1] = MBOX_REQUEST;                        // this is a request message
+    mbox[2] = MBOX_TAG_HARDWARE_GET_MAC_ADDRESS;
+    mbox[3] = 6;                                   // buffer size
+    mbox[4] = 0;                                   // len
+    mbox[5] = 0;
+    mbox[6] = 0;
+    mbox[7] = MBOX_TAG_LAST;
+
+    // 0x8 is the channel identifier for Property Tags
+    unsigned int r = device_resources.regions[3].io_addr | 0x8;
+    /* wait until we can write to the mailbox */
+    while (mbox_regs->status & MBOX_FULL);
+    // write the address of our message to the mailbox with channel identifier
+    mbox_regs->write = r;
+    // wait for the response
+    while (1) {
+        // check if response is ready
+        while (mbox_regs->status & MBOX_EMPTY);
+        // check if response is for us
+        if (r == mbox_regs->read) {
+            if (mbox[1] != MBOX_RESPONSE) {
+                sddf_dprintf("ERROR: Invalid mbox response\n");
+                return;
+            }
+            break;
+        }
+    }
+    char *mac = (char *)&mbox[5];
+    eth->umac_mac0 = mac[0] << 24 | mac[1] << 16 | mac[2] << 8 | mac[3];
+    eth->umac_mac1 = mac[4] << 8 | mac[5];
+
+    // UMAC Reset
+    eth->sys_rbuf_flush_ctrl |= BIT(1);
+    eth->sys_rbuf_flush_ctrl &= ~BIT(1);
+    sleep_us(10);
+
+    eth->sys_rbuf_flush_ctrl = 0;
+    sleep_us(10);
+
+    eth->umac_cmd = 0;
+    eth->umac_cmd = CMD_SW_RESET | CMD_LCL_LOOP_EN;
+    sleep_us(2);
+
+    eth->umac_cmd = 0;
+    eth->umac_mib_ctrl = MIB_RESET_RX | MIB_RESET_TX | MIB_RESET_RUNT;
+    eth->umac_mib_ctrl = 0;
+    eth->umac_max_frame_len = ENET_MAX_MTU_SIZE;
+
+    // Disable this bit to not pad two bytes at the beginning of every packet
+    eth->rbuf_ctrl &= ~RBUF_ALIGN_2B;
+    eth->rbuf_tbuf_size_ctrl = 1;
+
+    // Disable DMA
+    eth->dma_tx.ctrl &= ~BIT(DMA_EN);
+    eth->dma_rx.ctrl &= ~BIT(DMA_EN);
+    eth->umac_tx_flush = 1;
+    sleep_us(100);
+    eth->umac_tx_flush = 0;
+
+    // Rx Ring Init
+    ring_rx = (struct genet_dma_ring_rx *)&eth->dma_rx.ring;
+    eth->dma_rx.burst_size = DMA_MAX_BURST_LENGTH;
+    ring_rx->start_addr = 0;
+    ring_rx->read_ptr = 0;
+    ring_rx->write_ptr = 0;
+    ring_rx->end_addr = NUM_DESCS * DESC_SIZE / 4 - 1;
+    ring_rx->prod_index = 0;
+    ring_rx->cons_index = 0;
+    ring_rx->buf_size = (NUM_DESCS << 16) | NET_BUFFER_SIZE;
+    ring_rx->mbuf_done_thresh = 0x1;
+    ring_rx->xon_xoff_thresh = (NUM_DESCS >> 4) | (5 << 16);
+    // We only use the default ring (i.e. ring 16)
+    eth->dma_rx.ring_cfg = BIT(DEFAULT_Q);
+
+    // Tx Ring Init
+    ring_tx = (struct genet_dma_ring_tx *)&eth->dma_tx.ring;
+    eth->dma_tx.burst_size = DMA_MAX_BURST_LENGTH;
+    ring_tx->start_addr = 0;
+    ring_tx->read_ptr = 0;
+    ring_tx->write_ptr = 0;
+    ring_tx->prod_index = ring_tx->cons_index;
+    ring_tx->end_addr = NUM_DESCS * DESC_SIZE / 4 - 1;
+    ring_tx->mbuf_done_thresh = 0x80;
+    ring_tx->flow_period = 0;
+    ring_tx->buf_size = (NUM_DESCS << 16) | NET_BUFFER_SIZE;
+    eth->dma_tx.ring_cfg = BIT(DEFAULT_Q);
+    // No timeout for Tx Coalescing but IRQs generated after mbuf_done_thresh or empty buffer
+
+    // Enable DMA
+    uint32_t dma_ctrl = (1 << (DEFAULT_Q + DMA_RING_BUF_EN_SHIFT)) | DMA_EN;
+    eth->dma_tx.ctrl = dma_ctrl;
+    eth->dma_rx.ctrl |= dma_ctrl;
+
+    // Adjust Link
+    uint32_t oob_ctrl = eth->ext_rgmii_oob_ctrl | RGMII_LINK | RGMII_MODE_EN | ID_MODE_DIS;
+    eth->ext_rgmii_oob_ctrl = oob_ctrl;
+    sleep_us(1000);
+    eth->umac_cmd = UMAC_SPEED_1000 << CMD_SPEED_SHIFT;
+
+    // Index Reset
+    tx.descr = (struct genet_dma_desc *)&eth->dma_tx.descs;
+    tx.head = ring_tx->cons_index;
+    tx.tail = ring_tx->prod_index;
+    tx.capacity = NUM_DESCS;
+    tx.desc_id_mask = NUM_DESCS - 1;
+    tx.index_mask = 0xFFFF;
+
+    rx.head = ring_rx->prod_index;
+    rx.tail = rx.head;
+    rx.capacity = NUM_DESCS;
+    rx.desc_id_mask = NUM_DESCS - 1;
+    rx.index_mask = 0xFFFF;
+    rx.descr = (struct genet_dma_desc *)&eth->dma_rx.descs;
+
+    // Fill empty buffers for Rx
+    rx_provide();
+
+    ring_rx->cons_index = rx.head;
+    ring_rx->prod_index = rx.head;
+
+    // Enable promisc mode
+    eth->umac_cmd = eth->umac_cmd | CMD_PROMISC;
+    eth->umac_mdf_ctrl = 0;
+
+    // Enable Rx/Tx
+    eth->umac_cmd |= (CMD_TX_EN | CMD_RX_EN);
+
+    // Clear IRQ status
+    uint32_t irq_status = eth->intrl2_0_cpu_stat & ~(eth->intrl2_1_cpu_stat_mask);
+    eth->intrl2_0_cpu_clear = irq_status;
+
+    // Enable IRQ
+    eth->intrl2_0_cpu_clear_mask = GENET_IRQ_TXDMA_DONE | GENET_IRQ_RXDMA_DONE;
+}
+
+uint32_t rpi4_get_cpu_frequency()
+{
+    mbox[0] = 8 * 4;                                 // Length of the message
+    mbox[1] = MBOX_REQUEST;                        // Request code
+    mbox[2] = MBOX_TAG_HARDWARE_GET_CLK_RATE;      // tag
+    mbox[3] = 8;                                   // Buffer size
+    mbox[4] = 0;                                   // Response size
+    mbox[5] = 0x00000003;                          // Clock ID: ARM
+    mbox[6] = MBOX_TAG_LAST;                       // End tag
+
+    // 0x8 is the channel identifier for Property Tags
+    unsigned int r = device_resources.regions[3].io_addr | 0x8;
+    /* wait until we can write to the mailbox */
+    while (mbox_regs->status & MBOX_FULL);
+    // write the address of our message to the mailbox with channel identifier
+    mbox_regs->write = r;
+    // wait for the response
+    while (1) {
+        // check if response is ready
+        while (mbox_regs->status & MBOX_EMPTY);
+        // check if response is for us
+        if (r == mbox_regs->read) {
+            if (mbox[1] != MBOX_RESPONSE) {
+                return 0;
+            }
+            break;
+        }
+    }
+
+    uint32_t *cpu_freq = (uint32_t *)&mbox[6];
+    return *cpu_freq;
+}
+
+void rpi4_set_cpu_frequency(uint32_t freq)
+{
+    mbox[0] = 8 * 4;                                 // Length of the message
+    mbox[1] = MBOX_REQUEST;                        // Request code
+    mbox[2] = MBOX_TAG_HARDWARE_SET_CLK_RATE;      // tag
+    mbox[3] = 12;                                  // Buffer size
+    mbox[4] = 8;                                   // Response size
+    mbox[5] = 0x00000003;                          // Clock ID: ARM
+    mbox[6] = freq;                                // Frequency in Hz
+    mbox[7] = MBOX_TAG_LAST;                       // End tag
+
+    // 0x8 is the channel identifier for Property Tags
+    unsigned int r = device_resources.regions[3].io_addr | 0x8;
+    /* wait until we can write to the mailbox */
+    while (mbox_regs->status & MBOX_FULL);
+    // write the address of our message to the mailbox with channel identifier
+    mbox_regs->write = r;
+    // wait for the response
+    while (1) {
+        // check if response is ready
+        while (mbox_regs->status & MBOX_EMPTY);
+        // check if response is for us
+        if (r == mbox_regs->read) {
+            if (mbox[1] != MBOX_RESPONSE) {
+                return;
+            }
+            break;
+        }
+    }
+}
+
+void init(void)
+{
+    mbox_regs = (struct mbox_regs *)0x3000880;
+    mbox = device_resources.regions[3].region.vaddr;
+
+    net_queue_init(&rx_queue, config.virt_rx.free_queue.vaddr, config.virt_rx.active_queue.vaddr,
+                   config.virt_rx.num_buffers);
+    net_queue_init(&tx_queue, config.virt_tx.free_queue.vaddr, config.virt_tx.active_queue.vaddr,
+                   config.virt_tx.num_buffers);
+
+    rpi4_set_cpu_frequency(1000000000);
+
+    eth_setup();
+
+    tx_provide();
+}
+
+void notified(sddf_channel ch)
+{
+    if (ch == device_resources.irqs[0].id) {
+        handle_irq();
+
+        sddf_deferred_irq_ack(ch);
+    } else if (ch == config.virt_rx.id) {
+        rx_provide();
+    } else if (ch == config.virt_tx.id) {
+        tx_provide();
+    } else {
+        sddf_dprintf("ETH|LOG: received notification on unexpected channel: %u\n", ch);
+    }
+}

--- a/drivers/network/genet/ethernet.c
+++ b/drivers/network/genet/ethernet.c
@@ -70,11 +70,6 @@ static void update_ring_slot(hw_ring_t *ring, unsigned int idx, uintptr_t phys, 
     d->addr_lo = phys & 0xFFFFFFFF;
     d->addr_hi = phys >> 32;
     d->status = stat;
-
-    /* Ensure all writes to the descriptor complete, before we set the flags
-     * that makes hardware aware of this slot.
-     */
-    THREAD_MEMORY_RELEASE();
 }
 
 static void sleep_us(uint32_t us)
@@ -120,6 +115,7 @@ static void rx_provide(void)
             update_ring_slot(&rx, idx, buffer.io_or_offset, 0);
             rx.tail++;
         }
+        THREAD_MEMORY_RELEASE();
         // Doorbell the device
         ring_rx->cons_index = (rx.tail - NUM_DESCS) & rx.index_mask;
 
@@ -146,14 +142,13 @@ static void rx_return(void)
     // for optimisation. The packets arrived before clearing IRQ status will
     // be handled in next iteration.
     uint32_t prod_index = ring_rx->prod_index & rx.index_mask;
+    THREAD_MEMORY_ACQUIRE();
     while (!hw_ring_empty(&rx)) {
         if ((rx.head & rx.index_mask) == prod_index) {
             break;
         }
         uint32_t idx = rx.head & rx.desc_id_mask;
         volatile struct genet_dma_desc *d = &(rx.descr[idx]);
-
-        THREAD_MEMORY_ACQUIRE();
 
         uint64_t addr = ((uint64_t)(d->addr_hi) << 32) | d->addr_lo;
         net_buff_desc_t buffer = { addr, d->status >> DMA_BUFLENGTH_SHIFT };
@@ -186,6 +181,7 @@ static void tx_provide()
 
             tx.tail++;
         }
+        THREAD_MEMORY_RELEASE();
         ring_tx->prod_index = tx.tail & tx.index_mask;
 
         net_request_signal_active(&tx_queue);
@@ -202,14 +198,13 @@ static void tx_return(void)
 {
     bool enqueued = false;
     uint32_t cons_index = ring_tx->cons_index & tx.index_mask;
+    THREAD_MEMORY_ACQUIRE();
     while (!hw_ring_empty(&tx)) {
         if ((tx.head & tx.index_mask) == cons_index) {
             break;
         }
         uint32_t idx = tx.head & tx.desc_id_mask;
         volatile struct genet_dma_desc *d = &(tx.descr[idx]);
-
-        THREAD_MEMORY_ACQUIRE();
 
         uint64_t addr = ((uint64_t)(d->addr_hi) << 32) | d->addr_lo;
         net_buff_desc_t buffer = { addr, 0 };

--- a/drivers/network/genet/ethernet.h
+++ b/drivers/network/genet/ethernet.h
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2026, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This driver is based on the Linux driver:
+ *      drivers/net/ethernet/broadcom/genet/bcmgenet.c
+ *      which is: Copyright (c) 2014-2017 Broadcom
+ *
+ * Also referred to:
+ *      https://github.com/u-boot/u-boot/blob/master/drivers/net/bcmgenet.c
+ *      https://github.com/RT-Thread/rt-thread/blob/master/bsp/raspberry-pi/raspi4-32/driver/drv_eth.c
+ *      BCM54213PE Datasheet
+ */
+
+#pragma once
+
+#define PORT_MODE_EXT_GPHY 3
+#define CMD_PROMISC                 BIT(4)
+#define CMD_SW_RESET                BIT(13)
+#define CMD_LCL_LOOP_EN             BIT(15)
+
+#define GENET_PHY_ID 1
+#define MDIO_START_BUSY             BIT(29)
+#define MDIO_READ_FAIL              BIT(28)
+#define MDIO_RD                     (2 << 26)
+#define MDIO_WR                     BIT(26)
+#define MDIO_PMD_SHIFT              (21)
+#define MDIO_PMD_MASK               (0x1f)
+#define MDIO_REG_SHIFT              (16)
+#define MDIO_REG_MASK               (0x1f)
+
+#define CMD_TX_EN                   BIT(0)
+#define CMD_RX_EN                   BIT(1)
+#define UMAC_SPEED_10               (0)
+#define UMAC_SPEED_100              (1)
+#define UMAC_SPEED_1000             (2)
+#define UMAC_SPEED_2500             (3)
+#define CMD_SPEED_SHIFT             (2)
+#define CMD_SPEED_MASK              (3)
+#define CMD_SW_RESET                BIT(13)
+#define CMD_LCL_LOOP_EN             BIT(15)
+
+#define GENET_IRQ_TXDMA_DONE           BIT(16)
+#define GENET_IRQ_RXDMA_DONE           BIT(13)
+
+#define RGMII_LINK                  BIT(4)
+#define RGMII_MODE_EN               BIT(6)
+#define ID_MODE_DIS                 BIT(16)
+
+#define MIB_RESET_RX                BIT(0)
+#define MIB_RESET_RUNT              BIT(1)
+#define MIB_RESET_TX                BIT(2)
+
+/* Body(1500) + EH_SIZE(14) + VLANTAG(4) + BRCMTAG(6) + FCS(4) = 1528.
+ * MTU must be a multiple of 256, so we set ENET_PAD to 8.
+ * RSB/TSB (64Bytes) is not included.
+ */
+#define ETH_DATA_LEN                (1500)
+#define ETH_HLEN                    (14)
+#define VLAN_HLEN                   (4)
+#define ETH_FCS_LEN                 (4)
+#define ENET_BRCM_TAG_LEN           (6)
+#define ENET_PAD                    (8)
+#define ENET_MAX_MTU_SIZE        (ETH_DATA_LEN + ETH_HLEN +     \
+                                  VLAN_HLEN + ENET_BRCM_TAG_LEN +   \
+                                  ETH_FCS_LEN + ENET_PAD)
+
+#define GENET_RBUF_OFF              (0x0300)
+#define RBUF_TBUF_SIZE_CTRL         (GENET_RBUF_OFF + 0xb4)
+#define RBUF_CTRL                   (GENET_RBUF_OFF + 0x00)
+#define RBUF_ALIGN_2B               BIT(1)
+
+#define RBUF_64B_EN                 BIT(0)
+#define RBUF_CTRL_CHKSUM_EN         BIT(0)
+#define TBUF_64B_EN                 BIT(0)
+#define TBUF_CTRL_CHKSUM_EN         BIT(0)
+
+/* Tx/Rx Dma Descriptor common bits */
+#define DMA_EN                       BIT(0)
+#define DMA_RING_BUF_EN_SHIFT        (0x01)
+#define DMA_RING_BUF_EN_MASK         (0xffff)
+#define DMA_BUFLENGTH_MASK           (0x0fff)
+#define DMA_BUFLENGTH_SHIFT          (16)
+#define DMA_RING_SIZE_SHIFT          (16)
+#define DMA_OWN                      (0x8000)
+#define DMA_EOP                      (0x4000)
+#define DMA_SOP                      (0x2000)
+#define DMA_WRAP                     (0x1000)
+#define DMA_MAX_BURST_LENGTH         (0x8)
+/* Tx specific DMA descriptor bits */
+#define DMA_TX_UNDERRUN              (0x0200)
+#define DMA_TX_APPEND_CRC            (0x0040)
+#define DMA_TX_OW_CRC                (0x0020)
+#define DMA_TX_DO_CSUM               (0x0010)
+#define DMA_TX_CHKSUM_EN             BIT(15)
+#define DMA_TX_QTAG_SHIFT            (7)
+
+#define DMA_TIMEOUT_MASK             0xFFFF
+
+#define DEFAULT_Q                    0x10
+#define RING_INDEX_CAPACITY          0x10000
+
+#define BCM54213PE_MII_CONTROL                 (0x00)
+#define BCM54213PE_MII_STATUS                  (0x01)
+#define BCM54213PE_PHY_IDENTIFIER_HIGH         (0x02)
+#define BCM54213PE_PHY_IDENTIFIER_LOW          (0x03)
+
+#define BCM54213PE_AUTO_NEGOTIATION_ADV        (0x04)
+#define BCM54213PE_AUTO_NEGOTIATION_LINK       (0x05)
+#define BCM54213PE_AUTO_NEGOTIATION_EXPANSION  (0x06)
+
+#define BCM54213PE_NEXT_PAGE_TX                (0x07)
+
+#define BCM54213PE_PARTNER_RX                  (0x08)
+
+#define BCM54213PE_CONTROL                     (0x09)
+#define BCM54213PE_STATUS                      (0x0A)
+
+#define BCM54213PE_IEEE_EXTENDED_STATUS        (0x0F)
+#define BCM54213PE_PHY_EXTENDED_CONTROL        (0x10)
+#define BCM54213PE_PHY_EXTENDED_STATUS         (0x11)
+
+#define BCM54213PE_RECEIVE_ERROR_COUNTER       (0x12)
+#define BCM54213PE_FALSE_C_S_COUNTER           (0x13)
+#define BCM54213PE_RECEIVE_NOT_OK_COUNTER      (0x14)
+
+#define BCM54213PE_VERSION_B1                   (0x600d84a2)
+#define BCM54213PE_VERSION_X                    (0x600d84a0)
+
+//BCM54213PE_MII_CONTROL
+#define MII_CONTROL_PHY_RESET                   BIT(15)
+#define MII_CONTROL_AUTO_NEGOTIATION_ENABLED    BIT(12)
+#define MII_CONTROL_AUTO_NEGOTIATION_RESTART    BIT(9)
+#define MII_CONTROL_PHY_FULL_DUPLEX             BIT(8)
+#define MII_CONTROL_SPEED_SELECTION             BIT(6)
+
+//BCM54213PE_MII_STATUS
+#define MII_STATUS_LINK_UP                      BIT(2)
+#define MII_STATUS_AUTO_NEGOTIATION_COMPLETE    BIT(5)
+
+//BCM54213PE_CONTROL
+#define CONTROL_FULL_DUPLEX_CAPABILITY          BIT(9)
+#define CONTROL_HALF_DUPLEX_CAPABILITY          BIT(8)
+
+struct genet_dma_desc {
+    uint32_t status;
+    uint32_t addr_lo;
+    uint32_t addr_hi;
+};
+
+#define NUM_DESCS                    256
+#define DESC_SIZE                    sizeof(struct genet_dma_desc)
+
+struct genet_dma_ring_rx {
+    uint32_t write_ptr;               // 0x00
+    uint32_t unused1;                 // 0x04
+    uint32_t prod_index;              // 0x08
+    uint32_t cons_index;              // 0x0C
+    uint32_t buf_size;                // 0x10
+    uint32_t start_addr;              // 0x14
+    uint32_t unused2;                 // 0x18
+    uint32_t end_addr;                // 0x1C
+    uint32_t unused3;                 // 0x20
+    uint32_t mbuf_done_thresh;        // 0x24
+    uint32_t xon_xoff_thresh;         // 0x28
+    uint32_t read_ptr;                // 0x2C
+    uint8_t unused4[16];              // 0x30-0x40
+};
+
+struct genet_dma_ring_tx {
+    uint32_t read_ptr;                // 0x00
+    uint32_t unused1;                 // 0x04
+    uint32_t cons_index;              // 0x08
+    uint32_t prod_index;              // 0x0C
+    uint32_t buf_size;                // 0x10
+    uint32_t start_addr;              // 0x14
+    uint32_t unused2;                 // 0x18
+    uint32_t end_addr;                // 0x1C
+    uint32_t unused3;                 // 0x20
+    uint32_t mbuf_done_thresh;        // 0x24
+    uint32_t flow_period;             // 0x28
+    uint32_t write_ptr;               // 0x2C
+    uint8_t unused4[16];              // 0x30-0x40
+};
+
+typedef struct genet_dma_ring {
+    uint8_t x[64];
+} genet_dma_ring_t;
+
+struct genet_dma {
+    struct genet_dma_desc descs[NUM_DESCS];               // 0x000
+    genet_dma_ring_t default_rings[DEFAULT_Q];            // 0xC00-0x1000
+    genet_dma_ring_t ring;                                // 0x1000-0x1040
+    uint32_t ring_cfg;                                    // 0x1040
+    uint32_t ctrl;                                        // 0x1044
+    uint8_t unused1[4];                                   // 0x1048
+    uint32_t burst_size;                                  // 0x104C
+    uint8_t unused3[92];                                  // 0x1050-0x10AC
+    uint32_t ring16_timeout;                              // 0x10AC
+};
+
+struct genet_regs {
+    uint32_t sys_rev_ctrl;              // 0x00
+    uint32_t sys_port_ctrl;             // 0x04
+    uint32_t sys_rbuf_flush_ctrl;       // 0x08
+    uint32_t sys_tbuf_flush_ctrl;       // 0x0C
+    uint8_t sys_unused[112];            // 0x10-0x80
+    uint32_t ext_pwr_mgmt;              // 0x80
+    uint8_t ext_unused1[8];             // 0x84-0x8C
+    uint32_t ext_rgmii_oob_ctrl;        // 0x8C
+    uint8_t ext_unused2[12];            // 0x90-0x9C
+    uint32_t ext_gphy_ctrl;             // 0x9C
+    uint8_t ext_unused3[352];           // 0xA0-0x200
+    uint32_t intrl2_0_cpu_stat;         // 0x200
+    uint32_t intrl2_0_cpu_set;          // 0x204
+    uint32_t intrl2_0_cpu_clear;        // 0x208
+    uint32_t intrl2_0_cpu_stat_mask;    // 0x20C
+    uint32_t intrl2_0_cpu_set_mask;     // 0x210
+    uint32_t intrl2_0_cpu_clear_mask;   // 0x214
+    uint8_t intrl2_0_unused2[40];       // 0x218-0x240
+    uint32_t intrl2_1_cpu_stat;         // 0x240
+    uint32_t intrl2_1_cpu_set;          // 0x244
+    uint32_t intrl2_1_cpu_clear;        // 0x248
+    uint32_t intrl2_1_cpu_stat_mask;    // 0x24C
+    uint32_t intrl2_1_cpu_set_mask;     // 0x250
+    uint32_t intrl2_1_cpu_clear_mask;   // 0x254
+    uint8_t intrl2_unused2[168];        // 0x258-0x300
+    uint32_t rbuf_ctrl;                 // 0x300
+    uint8_t rbuf_unused1[176];          // 0x304-0x3B4
+    uint32_t rbuf_tbuf_size_ctrl;       // 0x3B4
+    uint8_t rbuf_unused2[584];          // 0x3B8-0x600
+    uint32_t tbuf_ctrl;                 // 0x600
+    uint32_t tbuf_ck_ctrl;              // 0x604
+    uint8_t tbuf_unused[504];           // 0x608-0x800
+    uint8_t umac_unused1[8];            // 0x800-0x808
+    uint32_t umac_cmd;                  // 0x808
+    uint32_t umac_mac0;                 // 0x80C
+    uint32_t umac_mac1;                 // 0x810
+    uint32_t umac_max_frame_len;        // 0x814
+    uint8_t umac_unused2[796];          // 0x818-0xB34
+    uint32_t umac_tx_flush;             // 0xB34
+    uint8_t umac_unused3[584];          // 0xB38-0xD80
+    uint32_t umac_mib_ctrl;             // 0xD80
+    uint8_t umac_unused4[144];          // 0xD84-0xE14
+    uint32_t umac_mdio_cmd;             // 0xE14
+    uint8_t unused1[56];                // 0xE18-0xE50
+    uint32_t umac_mdf_ctrl;             // 0xE50
+    uint8_t unused2[4524];              // 0xE54-0x2000
+    struct genet_dma dma_rx;            // 0x2000-0x30B0
+    uint8_t unused3[3920];              // 0x30B0-0x4000
+    struct genet_dma dma_tx;            // 0x4000
+};
+
+#define MBOX_REQUEST    0
+#define MBOX_TAG_HARDWARE_GET_MAC_ADDRESS  0x00010003
+#define MBOX_TAG_HARDWARE_GET_CLK_RATE     0x00030002
+#define MBOX_TAG_HARDWARE_SET_CLK_RATE     0x00038002
+#define MBOX_TAG_LAST           0
+#define MBOX_ADDR       0x08000000
+#define MBOX_RESPONSE   0x80000000
+#define MBOX_FULL       0x80000000
+#define MBOX_EMPTY      0x40000000
+
+struct mbox_regs {
+    uint32_t read;                   // 0x00
+    uint32_t unused1[3];             // 0x04-0x10
+    uint32_t poll;                   // 0x10
+    uint32_t sender;                 // 0x14
+    uint32_t status;                 // 0x18
+    uint32_t config;                 // 0x1C
+    uint32_t write;                  // 0x20
+};

--- a/examples/echo_server/echo.mk
+++ b/examples/echo_server/echo.mk
@@ -23,7 +23,8 @@ SUPPORTED_BOARDS := \
 		    qemu_virt_riscv64 \
 			rock3b \
 			star64 \
-			x86_64_generic
+			x86_64_generic \
+			rpi4b_1gb
 
 TOOLCHAIN ?= clang
 MICROKIT_CONFIG ?= debug

--- a/examples/echo_server/meta.py
+++ b/examples/echo_server/meta.py
@@ -195,7 +195,7 @@ def generate(
         assert timer_node is not None
 
     timer_driver = ProtectionDomain(
-        "timer_driver", "timer_driver.elf", priority=101, cpu=get_core("timer_driver")
+        "timer_driver", "timer_driver.elf", priority=102, cpu=get_core("timer_driver")
     )
     timer_system = Sddf.Timer(sdf, timer_node, timer_driver)
 
@@ -273,6 +273,13 @@ def generate(
         ethernet_driver.add_map(
             Map(clock_controller, 0x3000000, perms="rw", cached=False)
         )
+    elif board.name == "rpi4b_1gb":
+        # Ethernet driver requires timer access to wait for reconfiguration
+        timer_system.add_client(ethernet_driver)
+
+        mbox = MemoryRegion(sdf, "mbox", 0x10_000, paddr=0xFE00B000)
+        sdf.add_mr(mbox)
+        ethernet_driver.add_map(Map(mbox, 0x3000000, perms="rw", cached=False))
 
     if board.arch == SystemDescription.Arch.X86_64:
         hw_net_rings = SystemDescription.MemoryRegion(
@@ -482,6 +489,11 @@ def generate(
     assert client0_lib_sddf_lwip.serialise_config(output_dir)
     assert client1_lib_sddf_lwip.connect()
     assert client1_lib_sddf_lwip.serialise_config(output_dir)
+
+    if board.name == "rpi4b_1gb":
+        update_elf_section(
+            "eth_driver.elf", "timer_client_config", "timer_client_ethernet_driver"
+        )
 
     with open(f"{output_dir}/benchmark_client_config.data", "wb+") as f:
         f.write(bench_client_config.serialise())

--- a/tools/make/board/rpi4b_1gb.mk
+++ b/tools/make/board/rpi4b_1gb.mk
@@ -5,8 +5,8 @@
 #
 # Set up variables for Raspberry Pi 4b ith 1Gb RAM
 # Should be included _before_ toolchain makefile.
-# NET_DRIV_DIR :=
-# ETH_DRIV := eth_driver_dwmac-5.10a.elf
+NET_DRIV_DIR := genet
+ETH_DRIV := eth_driver_genet.elf
 UART_DRIV_DIR := ns16550a
 TIMER_DRIV_DIR := bcm2835
 #I2C_DRIV_DIR := ${PLATFORM}

--- a/tools/meta/board.py
+++ b/tools/meta/board.py
@@ -137,6 +137,7 @@ BOARDS: List[Board] = [
         paddr_top=0x2_000_000,
         serial="soc/serial@7e215040",
         timer="soc/timer@7e003000",
+        ethernet="scb/ethernet@7d580000",
     ),
     Board(
         name="serengeti",


### PR DESCRIPTION
Given that the pseudo checksum feature of rpi4 GENET NIC breaks the current sddf lwip design, this PR contains only GENET driver without hardware checksum enabled.

More discussion is here: #650.