### PR TITLE
dts: fixup string lists to be lists not \0-separated string

### DIFF
--- a/dts/maaxboard.dts
+++ b/dts/maaxboard.dts
@@ -41,7 +41,7 @@
 	#address-cells = <0x02>;
 	#size-cells = <0x02>;
 	model = "Avnet Maaxboard";
-	compatible = "avnet/embest,maaxboard\0fsl,imx8mq";
+	compatible = "avnet/embest,maaxboard", "fsl,imx8mq";
 
 	aliases {
 		csi0 = "/soc@0/bus@30800000/mipi_csi1@30a70000";
@@ -317,9 +317,9 @@
 	busfreq {
 		compatible = "fsl,imx_busfreq";
 		clocks = <0x02 0xea 0x02 0x76 0x02 0x77 0x02 0x77 0x02 0xfc 0x02 0xfb 0x02 0x46 0x02 0x4d 0x02 0x48 0x02 0x4e 0x02 0x71 0x02 0x67 0x02 0x74 0x02 0x02 0x02 0x55 0x02 0x49>;
-		clock-names = "dram_pll\0dram_alt_src\0dram_apb_src\0dram_apb_pre_div\0dram_core\0dram_alt_root\0sys1_pll_40m\0sys1_pll_400m\0sys1_pll_100m\0sys1_pll_800m\0noc_div\0main_axi_src\0ahb_div\0osc_25m\0sys2_pll_333m\0sys1_pll_133m";
+		clock-names = "dram_pll", "dram_alt_src", "dram_apb_src", "dram_apb_pre_div", "dram_core", "dram_alt_root", "sys1_pll_40m", "sys1_pll_400m", "sys1_pll_100m", "sys1_pll_800m", "noc_div", "main_axi_src", "ahb_div", "osc_25m", "sys2_pll_333m", "sys1_pll_133m";
 		interrupts = <0x00 0x66 0x04 0x00 0x6d 0x04 0x00 0x6e 0x04 0x00 0x6f 0x04>;
-		interrupt-name = "irq_busfreq_0\0irq_busfreq_1\0irq_busfreq_2\0irq_busfreq_3";
+		interrupt-name = "irq_busfreq_0", "irq_busfreq_1", "irq_busfreq_2", "irq_busfreq_3";
 	};
 
 	soc@0 {
@@ -335,56 +335,56 @@
 		};
 
 		bus@30000000 {
-			compatible = "fsl,imx8mq-aips-bus\0simple-bus";
+			compatible = "fsl,imx8mq-aips-bus", "simple-bus";
 			#address-cells = <0x01>;
 			#size-cells = <0x01>;
 			ranges = <0x30000000 0x30000000 0x400000>;
 
 			sai@30010000 {
-				compatible = "fsl,imx8mq-sai\0fsl,imx6sx-sai";
+				compatible = "fsl,imx8mq-sai", "fsl,imx6sx-sai";
 				reg = <0x30010000 0x10000>;
 				interrupts = <0x00 0x5f 0x04>;
 				clocks = <0x02 0xee 0x02 0x00 0x02 0xc4 0x02 0x00 0x02 0x00>;
-				clock-names = "bus\0mclk0\0mclk1\0mclk2\0mclk3";
+				clock-names = "bus", "mclk0", "mclk1", "mclk2", "mclk3";
 				dmas = <0x10 0x08 0x01 0x00 0x10 0x09 0x01 0x00>;
-				dma-names = "rx\0tx";
+				dma-names = "rx", "tx";
 				fsl,dataline = <0x00 0xff 0xff>;
 				status = "disabled";
 			};
 
 			sai@30030000 {
-				compatible = "fsl,imx8mq-sai\0fsl,imx6sx-sai";
+				compatible = "fsl,imx8mq-sai", "fsl,imx6sx-sai";
 				reg = <0x30030000 0x10000>;
 				interrupts = <0x00 0x5a 0x04>;
 				clocks = <0x02 0xf3 0x02 0x00 0x02 0xc9 0x02 0x00 0x02 0x00>;
-				clock-names = "bus\0mclk0\0mclk1\0mclk2\0mclk3";
+				clock-names = "bus", "mclk0", "mclk1", "mclk2", "mclk3";
 				dmas = <0x10 0x04 0x18 0x00 0x10 0x05 0x18 0x00>;
-				dma-names = "rx\0tx";
+				dma-names = "rx", "tx";
 				fsl,shared-interrupt;
 				status = "disabled";
 			};
 
 			sai@30040000 {
-				compatible = "fsl,imx8mq-sai\0fsl,imx6sx-sai";
+				compatible = "fsl,imx8mq-sai", "fsl,imx6sx-sai";
 				reg = <0x30040000 0x10000>;
 				interrupts = <0x00 0x5a 0x04>;
 				clocks = <0x02 0xf2 0x02 0x00 0x02 0xc8 0x02 0x00 0x02 0x00>;
-				clock-names = "bus\0mclk0\0mclk1\0mclk2\0mclk3";
+				clock-names = "bus", "mclk0", "mclk1", "mclk2", "mclk3";
 				dmas = <0x10 0x02 0x18 0x00 0x10 0x03 0x18 0x00>;
-				dma-names = "rx\0tx";
+				dma-names = "rx", "tx";
 				fsl,shared-interrupt;
 				fsl,dataline = <0x00 0x0f 0x0f>;
 				status = "disabled";
 			};
 
 			sai@30050000 {
-				compatible = "fsl,imx8mq-sai\0fsl,imx6sx-sai";
+				compatible = "fsl,imx8mq-sai", "fsl,imx6sx-sai";
 				reg = <0x30050000 0x10000>;
 				interrupts = <0x00 0x64 0x04>;
 				clocks = <0x02 0xf1 0x02 0x00 0x02 0xc7 0x02 0x00 0x02 0x00 0x02 0x1b 0x02 0x20>;
-				clock-names = "bus\0mclk0\0mclk1\0mclk2\0mclk3\0pll8k\0pll11k";
+				clock-names = "bus", "mclk0", "mclk1", "mclk2", "mclk3", "pll8k", "pll11k";
 				dmas = <0x10 0x00 0x18 0x00 0x10 0x01 0x18 0x00>;
-				dma-names = "rx\0tx";
+				dma-names = "rx", "tx";
 				fsl,dataline = <0x00 0x00 0x0f>;
 				status = "okay";
 				assigned-clocks = <0x02 0x84>;
@@ -394,7 +394,7 @@
 			};
 
 			gpio@30200000 {
-				compatible = "fsl,imx8mq-gpio\0fsl,imx35-gpio";
+				compatible = "fsl,imx8mq-gpio", "fsl,imx35-gpio";
 				reg = <0x30200000 0x10000>;
 				interrupts = <0x00 0x40 0x04 0x00 0x41 0x04>;
 				clocks = <0x02 0x103>;
@@ -407,7 +407,7 @@
 			};
 
 			gpio@30210000 {
-				compatible = "fsl,imx8mq-gpio\0fsl,imx35-gpio";
+				compatible = "fsl,imx8mq-gpio", "fsl,imx35-gpio";
 				reg = <0x30210000 0x10000>;
 				interrupts = <0x00 0x42 0x04 0x00 0x43 0x04>;
 				clocks = <0x02 0x104>;
@@ -420,7 +420,7 @@
 			};
 
 			gpio@30220000 {
-				compatible = "fsl,imx8mq-gpio\0fsl,imx35-gpio";
+				compatible = "fsl,imx8mq-gpio", "fsl,imx35-gpio";
 				reg = <0x30220000 0x10000>;
 				interrupts = <0x00 0x44 0x04 0x00 0x45 0x04>;
 				clocks = <0x02 0x105>;
@@ -433,7 +433,7 @@
 			};
 
 			gpio@30230000 {
-				compatible = "fsl,imx8mq-gpio\0fsl,imx35-gpio";
+				compatible = "fsl,imx8mq-gpio", "fsl,imx35-gpio";
 				reg = <0x30230000 0x10000>;
 				interrupts = <0x00 0x46 0x04 0x00 0x47 0x04>;
 				clocks = <0x02 0x106>;
@@ -445,7 +445,7 @@
 			};
 
 			gpio@30240000 {
-				compatible = "fsl,imx8mq-gpio\0fsl,imx35-gpio";
+				compatible = "fsl,imx8mq-gpio", "fsl,imx35-gpio";
 				reg = <0x30240000 0x10000>;
 				interrupts = <0x00 0x48 0x04 0x00 0x49 0x04>;
 				clocks = <0x02 0x107>;
@@ -479,7 +479,7 @@
 			};
 
 			watchdog@30280000 {
-				compatible = "fsl,imx8mq-wdt\0fsl,imx21-wdt";
+				compatible = "fsl,imx8mq-wdt", "fsl,imx21-wdt";
 				reg = <0x30280000 0x10000>;
 				interrupts = <0x00 0x4e 0x04>;
 				clocks = <0x02 0xd4>;
@@ -490,7 +490,7 @@
 			};
 
 			watchdog@30290000 {
-				compatible = "fsl,imx8mq-wdt\0fsl,imx21-wdt";
+				compatible = "fsl,imx8mq-wdt", "fsl,imx21-wdt";
 				reg = <0x30290000 0x10000>;
 				interrupts = <0x00 0x4f 0x04>;
 				clocks = <0x02 0xd5>;
@@ -498,7 +498,7 @@
 			};
 
 			watchdog@302a0000 {
-				compatible = "fsl,imx8mq-wdt\0fsl,imx21-wdt";
+				compatible = "fsl,imx8mq-wdt", "fsl,imx21-wdt";
 				reg = <0x302a0000 0x10000>;
 				interrupts = <0x00 0x0a 0x04>;
 				clocks = <0x02 0xd6>;
@@ -506,11 +506,11 @@
 			};
 
 			sdma@302c0000 {
-				compatible = "fsl,imx8mq-sdma\0fsl,imx7d-sdma";
+				compatible = "fsl,imx8mq-sdma", "fsl,imx7d-sdma";
 				reg = <0x302c0000 0x10000>;
 				interrupts = <0x00 0x67 0x04>;
 				clocks = <0x02 0xe4 0x02 0xe4>;
-				clock-names = "ipg\0ahb";
+				clock-names = "ipg", "ahb";
 				#dma-cells = <0x03>;
 				fsl,sdma-ram-script-name = "imx/sdma/sdma-imx7d.bin";
 				phandle = <0x10>;
@@ -523,7 +523,7 @@
 			};
 
 			lcdif@30320000 {
-				compatible = "fsl,imx8mq-lcdif\0fsl,imx28-lcdif";
+				compatible = "fsl,imx8mq-lcdif", "fsl,imx28-lcdif";
 				reg = <0x30320000 0x10000>;
 				clocks = <0x02 0x80>;
 				clock-names = "pix";
@@ -665,7 +665,7 @@
 			};
 
 			syscon@30340000 {
-				compatible = "fsl,imx8mq-iomuxc-gpr\0fsl,imx6q-iomuxc-gpr\0syscon\0simple-mfd";
+				compatible = "fsl,imx8mq-iomuxc-gpr", "fsl,imx6q-iomuxc-gpr", "syscon", "simple-mfd";
 				reg = <0x30340000 0x10000>;
 				phandle = <0x39>;
 
@@ -678,7 +678,7 @@
 			};
 
 			ocotp-ctrl@30350000 {
-				compatible = "fsl,imx8mq-ocotp\0syscon";
+				compatible = "fsl,imx8mq-ocotp", "syscon";
 				reg = <0x30350000 0x10000>;
 				clocks = <0x02 0xfa>;
 				#address-cells = <0x01>;
@@ -696,7 +696,7 @@
 			};
 
 			syscon@30360000 {
-				compatible = "fsl,imx8mq-anatop\0syscon";
+				compatible = "fsl,imx8mq-anatop", "syscon";
 				reg = <0x30360000 0x10000>;
 				interrupts = <0x00 0x31 0x04>;
 			};
@@ -716,7 +716,7 @@
 			};
 
 			snvs@30370000 {
-				compatible = "fsl,sec-v4.0-mon\0syscon\0simple-mfd";
+				compatible = "fsl,sec-v4.0-mon", "syscon", "simple-mfd";
 				reg = <0x30370000 0x10000>;
 				phandle = <0x14>;
 
@@ -747,7 +747,7 @@
 				interrupts = <0x00 0x55 0x04 0x00 0x56 0x04>;
 				#clock-cells = <0x01>;
 				clocks = <0x15 0x16 0x17 0x18 0x19 0x1a 0x1b>;
-				clock-names = "ckil\0osc_25m\0osc_27m\0clk_ext1\0clk_ext2\0clk_ext3\0clk_ext4";
+				clock-names = "ckil", "osc_25m", "osc_27m", "clk_ext1", "clk_ext2", "clk_ext3", "clk_ext4";
 				assigned-clocks = <0x02 0x69 0x02 0x75 0x02 0x19 0x02 0x1e>;
 				assigned-clock-parents = <0x02 0x4c 0x02 0x56>;
 				assigned-clock-rates = <0x00 0x00 0x2ee00000 0x2b110000>;
@@ -755,7 +755,7 @@
 			};
 
 			reset-controller@30390000 {
-				compatible = "fsl,imx8mq-src\0syscon";
+				compatible = "fsl,imx8mq-src", "syscon";
 				reg = <0x30390000 0x10000>;
 				#reset-cells = <0x01>;
 				phandle = <0x28>;
@@ -845,27 +845,27 @@
 		};
 
 		bus@30400000 {
-			compatible = "fsl,imx8mq-aips-bus\0simple-bus";
+			compatible = "fsl,imx8mq-aips-bus", "simple-bus";
 			#address-cells = <0x01>;
 			#size-cells = <0x01>;
 			ranges = <0x30400000 0x30400000 0x400000>;
 
 			pwm@30660000 {
-				compatible = "fsl,imx8mq-pwm\0fsl,imx27-pwm";
+				compatible = "fsl,imx8mq-pwm", "fsl,imx27-pwm";
 				reg = <0x30660000 0x10000>;
 				interrupts = <0x00 0x51 0x04>;
 				clocks = <0x02 0xbf 0x02 0xbf>;
-				clock-names = "ipg\0per";
+				clock-names = "ipg", "per";
 				#pwm-cells = <0x02>;
 				status = "disabled";
 			};
 
 			pwm@30670000 {
-				compatible = "fsl,imx8mq-pwm\0fsl,imx27-pwm";
+				compatible = "fsl,imx8mq-pwm", "fsl,imx27-pwm";
 				reg = <0x30670000 0x10000>;
 				interrupts = <0x00 0x52 0x04>;
 				clocks = <0x02 0xc0 0x02 0xc0>;
-				clock-names = "ipg\0per";
+				clock-names = "ipg", "per";
 				#pwm-cells = <0x02>;
 				status = "okay";
 				pinctrl-names = "default";
@@ -873,21 +873,21 @@
 			};
 
 			pwm@30680000 {
-				compatible = "fsl,imx8mq-pwm\0fsl,imx27-pwm";
+				compatible = "fsl,imx8mq-pwm", "fsl,imx27-pwm";
 				reg = <0x30680000 0x10000>;
 				interrupts = <0x00 0x53 0x04>;
 				clocks = <0x02 0xc1 0x02 0xc1>;
-				clock-names = "ipg\0per";
+				clock-names = "ipg", "per";
 				#pwm-cells = <0x02>;
 				status = "disabled";
 			};
 
 			pwm@30690000 {
-				compatible = "fsl,imx8mq-pwm\0fsl,imx27-pwm";
+				compatible = "fsl,imx8mq-pwm", "fsl,imx27-pwm";
 				reg = <0x30690000 0x10000>;
 				interrupts = <0x00 0x54 0x04>;
 				clocks = <0x02 0xc2 0x02 0xc2>;
-				clock-names = "ipg\0per";
+				clock-names = "ipg", "per";
 				#pwm-cells = <0x02>;
 				status = "okay";
 				pinctrl-names = "default";
@@ -904,30 +904,30 @@
 		};
 
 		bus@30800000 {
-			compatible = "fsl,imx8mq-aips-bus\0simple-bus";
+			compatible = "fsl,imx8mq-aips-bus", "simple-bus";
 			#address-cells = <0x01>;
 			#size-cells = <0x01>;
 			ranges = <0x30800000 0x30800000 0x400000 0x8000000 0x8000000 0x10000000>;
 
 			spdif@30810000 {
-				compatible = "fsl,imx8mm-spdif\0fsl,imx35-spdif";
+				compatible = "fsl,imx8mm-spdif", "fsl,imx35-spdif";
 				reg = <0x30810000 0x10000>;
 				interrupts = <0x00 0x06 0x04>;
 				clocks = <0x02 0xec 0x02 0x02 0x02 0x87 0x02 0x00 0x02 0x00 0x02 0x00 0x02 0xec 0x02 0x00 0x02 0x00 0x02 0x00>;
-				clock-names = "core\0rxtx0\0rxtx1\0rxtx2\0rxtx3\0rxtx4\0rxtx5\0rxtx6\0rxtx7\0spba";
+				clock-names = "core", "rxtx0", "rxtx1", "rxtx2", "rxtx3", "rxtx4", "rxtx5", "rxtx6", "rxtx7", "spba";
 				dmas = <0x21 0x08 0x12 0x00 0x21 0x09 0x12 0x00>;
-				dma-names = "rx\0tx";
+				dma-names = "rx", "tx";
 				status = "disabled";
 			};
 
 			spi@30820000 {
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
-				compatible = "fsl,imx8mq-ecspi\0fsl,imx51-ecspi";
+				compatible = "fsl,imx8mq-ecspi", "fsl,imx51-ecspi";
 				reg = <0x30820000 0x10000>;
 				interrupts = <0x00 0x1f 0x04>;
 				clocks = <0x02 0xb3 0x02 0xb3>;
-				clock-names = "ipg\0per";
+				clock-names = "ipg", "per";
 				status = "okay";
 				pinctrl-names = "default";
 				pinctrl-0 = <0x22>;
@@ -935,7 +935,7 @@
 				cs-gpios = <0x23 0x09 0x00>;
 
 				spidev@0 {
-					compatible = "fsl,spidev\0semtech,sx1301";
+					compatible = "fsl,spidev", "semtech,sx1301";
 					reg = <0x00>;
 					spi-max-frequency = <0x1e8480>;
 				};
@@ -944,31 +944,31 @@
 			spi@30830000 {
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
-				compatible = "fsl,imx8mq-ecspi\0fsl,imx51-ecspi";
+				compatible = "fsl,imx8mq-ecspi", "fsl,imx51-ecspi";
 				reg = <0x30830000 0x10000>;
 				interrupts = <0x00 0x20 0x04>;
 				clocks = <0x02 0xb4 0x02 0xb4>;
-				clock-names = "ipg\0per";
+				clock-names = "ipg", "per";
 				status = "disabled";
 			};
 
 			spi@30840000 {
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
-				compatible = "fsl,imx8mq-ecspi\0fsl,imx51-ecspi";
+				compatible = "fsl,imx8mq-ecspi", "fsl,imx51-ecspi";
 				reg = <0x30840000 0x10000>;
 				interrupts = <0x00 0x21 0x04>;
 				clocks = <0x02 0xb5 0x02 0xb5>;
-				clock-names = "ipg\0per";
+				clock-names = "ipg", "per";
 				status = "disabled";
 			};
 
 			serial@30860000 {
-				compatible = "fsl,imx8mq-uart\0fsl,imx6q-uart";
+				compatible = "fsl,imx8mq-uart", "fsl,imx6q-uart";
 				reg = <0x30860000 0x10000>;
 				interrupts = <0x00 0x1a 0x04>;
 				clocks = <0x02 0xca 0x02 0xca>;
-				clock-names = "ipg\0per";
+				clock-names = "ipg", "per";
 				status = "okay";
 				pinctrl-names = "default";
 				pinctrl-0 = <0x24>;
@@ -977,20 +977,20 @@
 			};
 
 			serial@30880000 {
-				compatible = "fsl,imx8mq-uart\0fsl,imx6q-uart";
+				compatible = "fsl,imx8mq-uart", "fsl,imx6q-uart";
 				reg = <0x30880000 0x10000>;
 				interrupts = <0x00 0x1c 0x04>;
 				clocks = <0x02 0xcc 0x02 0xcc>;
-				clock-names = "ipg\0per";
+				clock-names = "ipg", "per";
 				status = "disabled";
 			};
 
 			serial@30890000 {
-				compatible = "fsl,imx8mq-uart\0fsl,imx6q-uart";
+				compatible = "fsl,imx8mq-uart", "fsl,imx6q-uart";
 				reg = <0x30890000 0x10000>;
 				interrupts = <0x00 0x1b 0x04>;
 				clocks = <0x02 0xcb 0x02 0xcb>;
-				clock-names = "ipg\0per";
+				clock-names = "ipg", "per";
 				status = "okay";
 				pinctrl-names = "default";
 				pinctrl-0 = <0x25>;
@@ -999,13 +999,13 @@
 			};
 
 			spdif@308a0000 {
-				compatible = "fsl,imx8mm-spdif\0fsl,imx35-spdif";
+				compatible = "fsl,imx8mm-spdif", "fsl,imx35-spdif";
 				reg = <0x308a0000 0x10000>;
 				interrupts = <0x00 0x0d 0x04>;
 				clocks = <0x02 0xec 0x02 0x02 0x02 0x88 0x02 0x00 0x02 0x00 0x02 0x00 0x02 0xec 0x02 0x00 0x02 0x00 0x02 0x00>;
-				clock-names = "core\0rxtx0\0rxtx1\0rxtx2\0rxtx3\0rxtx4\0rxtx5\0rxtx6\0rxtx7\0spba";
+				clock-names = "core", "rxtx0", "rxtx1", "rxtx2", "rxtx3", "rxtx4", "rxtx5", "rxtx6", "rxtx7", "spba";
 				dmas = <0x21 0x10 0x12 0x00 0x21 0x11 0x12 0x00>;
-				dma-names = "rx\0tx";
+				dma-names = "rx", "tx";
 				status = "disabled";
 			};
 
@@ -1015,9 +1015,9 @@
 				reg = <0x308b0000 0x10000>;
 				interrupts = <0x00 0x60 0x04>;
 				clocks = <0x02 0xef 0x02 0x00 0x02 0xc5 0x02 0x00 0x02 0x00>;
-				clock-names = "bus\0mclk0\0mclk1\0mclk2\0mclk3";
+				clock-names = "bus", "mclk0", "mclk1", "mclk2", "mclk3";
 				dmas = <0x21 0x0a 0x18 0x00 0x21 0x0b 0x18 0x00>;
-				dma-names = "rx\0tx";
+				dma-names = "rx", "tx";
 				status = "okay";
 				pinctrl-names = "default";
 				pinctrl-0 = <0x26>;
@@ -1028,13 +1028,13 @@
 			};
 
 			sai@308c0000 {
-				compatible = "fsl,imx8mq-sai\0fsl,imx6sx-sai";
+				compatible = "fsl,imx8mq-sai", "fsl,imx6sx-sai";
 				reg = <0x308c0000 0x10000>;
 				interrupts = <0x00 0x32 0x04>;
 				clocks = <0x02 0xf0 0x02 0x00 0x02 0xc6 0x02 0x00 0x02 0x00>;
-				clock-names = "bus\0mclk0\0mclk1\0mclk2\0mclk3";
+				clock-names = "bus", "mclk0", "mclk1", "mclk2", "mclk3";
 				dmas = <0x21 0x0c 0x18 0x00 0x21 0x0d 0x18 0x00>;
-				dma-names = "rx\0tx";
+				dma-names = "rx", "tx";
 				status = "disabled";
 			};
 
@@ -1046,7 +1046,7 @@
 				ranges = <0x00 0x30900000 0x40000>;
 				interrupts = <0x00 0x5b 0x04>;
 				clocks = <0x02 0x74 0x02 0xec>;
-				clock-names = "aclk\0ipg";
+				clock-names = "aclk", "ipg";
 
 				jr@1000 {
 					compatible = "fsl,sec-v4.0-job-ring";
@@ -1087,14 +1087,14 @@
 				compatible = "fsl,imx8mq-nwl-dsi";
 				reg = <0x30a00000 0x300>;
 				clocks = <0x02 0xa3 0x02 0xf4 0x02 0xf5 0x02 0xa4 0x02 0x23 0x02 0x80>;
-				clock-names = "core\0rx_esc\0tx_esc\0phy_ref\0video_pll\0lcdif";
+				clock-names = "core", "rx_esc", "tx_esc", "phy_ref", "video_pll", "lcdif";
 				assigned-clocks = <0x02 0xa4 0x02 0xa3 0x02 0xf4 0x02 0xf5>;
 				assigned-clock-parents = <0x02 0x25 0x02 0x4c 0x02 0x47>;
 				assigned-clock-rates = <0x19bfcc0 0xfdad680 0x4c4b400 0x1312d00>;
 				interrupts = <0x00 0x22 0x04>;
 				power-domains = <0x27>;
 				resets = <0x28 0x15 0x28 0x17 0x28 0x18 0x28 0x19>;
-				reset-names = "byte\0dpi\0esc\0pclk";
+				reset-names = "byte", "dpi", "esc", "pclk";
 				mux-controls = <0x29 0x00>;
 				phys = <0x2a>;
 				phy-names = "dphy";
@@ -1102,7 +1102,7 @@
 			};
 
 			i2c@30a20000 {
-				compatible = "fsl,imx8mq-i2c\0fsl,imx21-i2c";
+				compatible = "fsl,imx8mq-i2c", "fsl,imx21-i2c";
 				reg = <0x30a20000 0x10000>;
 				interrupts = <0x00 0x23 0x04>;
 				clocks = <0x02 0xb8>;
@@ -1137,7 +1137,7 @@
 							regulator-ramp-delay = <0x4e2>;
 							rohm,dvs-run-voltage = <0xdbba0>;
 							rohm,dvs-idle-voltage = <0xcf850>;
-							rohm,dvs-suspend-voltage = <0xc3500>;
+							rohm,dvs-suspend-voltage = "", "\f5";
 						};
 
 						BUCK2 {
@@ -1286,7 +1286,7 @@
 			};
 
 			i2c@30a30000 {
-				compatible = "fsl,imx8mq-i2c\0fsl,imx21-i2c";
+				compatible = "fsl,imx8mq-i2c", "fsl,imx21-i2c";
 				reg = <0x30a30000 0x10000>;
 				interrupts = <0x00 0x24 0x04>;
 				clocks = <0x02 0xb9>;
@@ -1309,7 +1309,7 @@
 			};
 
 			i2c@30a40000 {
-				compatible = "fsl,imx8mq-i2c\0fsl,imx21-i2c";
+				compatible = "fsl,imx8mq-i2c", "fsl,imx21-i2c";
 				reg = <0x30a40000 0x10000>;
 				interrupts = <0x00 0x25 0x04>;
 				clocks = <0x02 0xba>;
@@ -1322,7 +1322,7 @@
 			};
 
 			i2c@30a50000 {
-				compatible = "fsl,imx8mq-i2c\0fsl,imx21-i2c";
+				compatible = "fsl,imx8mq-i2c", "fsl,imx21-i2c";
 				reg = <0x30a50000 0x10000>;
 				interrupts = <0x00 0x26 0x04>;
 				clocks = <0x02 0xbb>;
@@ -1335,11 +1335,11 @@
 			};
 
 			serial@30a60000 {
-				compatible = "fsl,imx8mq-uart\0fsl,imx6q-uart";
+				compatible = "fsl,imx8mq-uart", "fsl,imx6q-uart";
 				reg = <0x30a60000 0x10000>;
 				interrupts = <0x00 0x1d 0x04>;
 				clocks = <0x02 0xcd 0x02 0xcd>;
-				clock-names = "ipg\0per";
+				clock-names = "ipg", "per";
 				status = "okay";
 				pinctrl-names = "default";
 				pinctrl-0 = <0x36>;
@@ -1354,7 +1354,7 @@
 				reg = <0x30a70000 0x1000>;
 				interrupts = <0x00 0x2c 0x04>;
 				clocks = <0x02 0xa7 0x02 0xa9 0x02 0xa8>;
-				clock-names = "clk_core\0clk_esc\0clk_pxl";
+				clock-names = "clk_core", "clk_esc", "clk_pxl";
 				assigned-clocks = <0x02 0xa7 0x02 0xa8 0x02 0xa9>;
 				assigned-clock-rates = <0x7ed6b40 0x5f5e100 0x3ef1480>;
 				power-domains = <0x38>;
@@ -1381,11 +1381,11 @@
 			};
 
 			csi1_bridge@30a90000 {
-				compatible = "fsl,imx8mq-csi\0fsl,imx6s-csi";
+				compatible = "fsl,imx8mq-csi", "fsl,imx6s-csi";
 				reg = <0x30a90000 0x10000>;
 				interrupts = <0x00 0x2a 0x04>;
 				clocks = <0x02 0x00 0x02 0xe0 0x02 0x00>;
-				clock-names = "disp-axi\0csi_mclk\0disp_dcic";
+				clock-names = "disp-axi", "csi_mclk", "disp_dcic";
 				status = "okay";
 				fsl,mipi-mode;
 				fsl,two-8bit-sensor-mode;
@@ -1400,7 +1400,7 @@
 			};
 
 			mu@30aa0000 {
-				compatible = "fsl,imx8mq-mu\0fsl,imx6sx-mu";
+				compatible = "fsl,imx8mq-mu", "fsl,imx6sx-mu";
 				reg = <0x30aa0000 0x10000>;
 				interrupts = <0x00 0x58 0x04>;
 				clocks = <0x02 0xfd>;
@@ -1410,18 +1410,18 @@
 			};
 
 			mmc@30b40000 {
-				compatible = "fsl,imx8mq-usdhc\0fsl,imx7d-usdhc";
+				compatible = "fsl,imx8mq-usdhc", "fsl,imx7d-usdhc";
 				reg = <0x30b40000 0x10000>;
 				interrupts = <0x00 0x16 0x04>;
 				clocks = <0x02 0xec 0x02 0x69 0x02 0xd2>;
-				clock-names = "ipg\0ahb\0per";
+				clock-names = "ipg", "ahb", "per";
 				assigned-clocks = <0x02 0x8e>;
 				assigned-clock-rates = <0x17d78400>;
 				fsl,tuning-start-tap = <0x14>;
 				fsl,tuning-step = <0x02>;
 				bus-width = <0x04>;
 				status = "okay";
-				pinctrl-names = "default\0state_100mhz\0state_200mhz";
+				pinctrl-names = "default", "state_100mhz", "state_200mhz";
 				pinctrl-0 = <0x3d>;
 				pinctrl-1 = <0x3e>;
 				pinctrl-2 = <0x3f>;
@@ -1431,11 +1431,11 @@
 			};
 
 			mmc@30b50000 {
-				compatible = "fsl,imx8mq-usdhc\0fsl,imx7d-usdhc";
+				compatible = "fsl,imx8mq-usdhc", "fsl,imx7d-usdhc";
 				reg = <0x30b50000 0x10000>;
 				interrupts = <0x00 0x17 0x04>;
 				clocks = <0x02 0xec 0x02 0x69 0x02 0xd3>;
-				clock-names = "ipg\0ahb\0per";
+				clock-names = "ipg", "ahb", "per";
 				fsl,tuning-start-tap = <0x14>;
 				fsl,tuning-step = <0x02>;
 				bus-width = <0x04>;
@@ -1465,7 +1465,7 @@
 				reg = <0x30b60000 0x1000>;
 				interrupts = <0x00 0x2d 0x04>;
 				clocks = <0x02 0xaa 0x02 0xac 0x02 0xab>;
-				clock-names = "clk_core\0clk_esc\0clk_pxl";
+				clock-names = "clk_core", "clk_esc", "clk_pxl";
 				assigned-clocks = <0x02 0xaa 0x02 0xab 0x02 0xac>;
 				assigned-clock-rates = <0x7ed6b40 0x5f5e100 0x3ef1480>;
 				power-domains = <0x44>;
@@ -1475,43 +1475,43 @@
 			};
 
 			csi2_bridge@30b80000 {
-				compatible = "fsl,imx8mq-csi\0fsl,imx6s-csi";
+				compatible = "fsl,imx8mq-csi", "fsl,imx6s-csi";
 				reg = <0x30b80000 0x10000>;
 				interrupts = <0x00 0x2b 0x04>;
 				clocks = <0x02 0x00 0x02 0xe1 0x02 0x00>;
-				clock-names = "disp-axi\0csi_mclk\0disp_dcic";
+				clock-names = "disp-axi", "csi_mclk", "disp_dcic";
 				status = "disabled";
 			};
 
 			spi@30bb0000 {
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
-				compatible = "fsl,imx8mq-qspi\0fsl,imx7d-qspi";
+				compatible = "fsl,imx8mq-qspi", "fsl,imx7d-qspi";
 				reg = <0x30bb0000 0x10000 0x8000000 0x10000000>;
-				reg-names = "QuadSPI\0QuadSPI-memory";
+				reg-names = "QuadSPI", "QuadSPI-memory";
 				interrupts = <0x00 0x6b 0x04>;
 				clocks = <0x02 0xc3 0x02 0xc3>;
-				clock-names = "qspi_en\0qspi";
+				clock-names = "qspi_en", "qspi";
 				status = "disabled";
 			};
 
 			sdma@30bd0000 {
-				compatible = "fsl,imx8mq-sdma\0fsl,imx7d-sdma";
+				compatible = "fsl,imx8mq-sdma", "fsl,imx7d-sdma";
 				reg = <0x30bd0000 0x10000>;
 				interrupts = <0x00 0x02 0x04>;
 				clocks = <0x02 0xe3 0x02 0x74>;
-				clock-names = "ipg\0ahb";
+				clock-names = "ipg", "ahb";
 				#dma-cells = <0x03>;
 				fsl,sdma-ram-script-name = "imx/sdma/sdma-imx7d.bin";
 				phandle = <0x21>;
 			};
 
 			ethernet@30be0000 {
-				compatible = "fsl,imx8mq-fec\0fsl,imx6sx-fec";
+				compatible = "fsl,imx8mq-fec", "fsl,imx6sx-fec";
 				reg = <0x30be0000 0x10000>;
 				interrupts = <0x00 0x76 0x04 0x00 0x77 0x04 0x00 0x78 0x04>;
 				clocks = <0x02 0xb6 0x02 0xb6 0x02 0x8a 0x02 0x89 0x02 0x8b>;
-				clock-names = "ipg\0ahb\0ptp\0enet_clk_ref\0enet_out";
+				clock-names = "ipg", "ahb", "ptp", "enet_clk_ref", "enet_out";
 				fsl,num-tx-queues = <0x03>;
 				fsl,num-rx-queues = <0x03>;
 				nvmem-cells = <0x45>;
@@ -1542,7 +1542,7 @@
 		};
 
 		bus@32c00000 {
-			compatible = "fsl,imx8mq-aips-bus\0simple-bus";
+			compatible = "fsl,imx8mq-aips-bus", "simple-bus";
 			#address-cells = <0x01>;
 			#size-cells = <0x01>;
 			ranges = <0x32c00000 0x32c00000 0x400000>;
@@ -1550,7 +1550,7 @@
 			hdmi@32c00000 {
 				reg = <0x32c00000 0x100000 0x32e40000 0x40000>;
 				interrupts = <0x00 0x10 0x04 0x00 0x19 0x04>;
-				interrupt-names = "plug_in\0plug_out";
+				interrupt-names = "plug_in", "plug_out";
 				compatible = "cdn,imx8mq-hdmi";
 				lane-mapping = <0xe4>;
 				status = "okay";
@@ -1565,7 +1565,7 @@
 			};
 
 			interrupt-controller@32e2d000 {
-				compatible = "fsl,imx8m-irqsteer\0fsl,imx-irqsteer";
+				compatible = "fsl,imx8m-irqsteer", "fsl,imx-irqsteer";
 				reg = <0x32e2d000 0x1000>;
 				interrupts = <0x00 0x12 0x04>;
 				clocks = <0x02 0xf8>;
@@ -1584,10 +1584,10 @@
 				compatible = "nxp,imx8mq-dcss";
 				reg = <0x32e00000 0x2d000 0x32e2f000 0x1000>;
 				interrupts = <0x06 0x08 0x09 0x10 0x11>;
-				interrupt-names = "ctx_ld\0ctxld_kick\0vblank\0dtrc_ch1\0dtrc_ch2";
+				interrupt-names = "ctx_ld", "ctxld_kick", "vblank", "dtrc_ch1", "dtrc_ch2";
 				interrupt-parent = <0x49>;
 				clocks = <0x02 0xf8 0x02 0xf7 0x02 0xf9 0x02 0xfe 0x02 0x7a 0x02 0x10a 0x02 0x10b>;
-				clock-names = "apb\0axi\0rtrm\0pix\0dtrc\0pll_src\0pll_phy_ref";
+				clock-names = "apb", "axi", "rtrm", "pix", "dtrc", "pll_src", "pll_phy_ref";
 				assigned-clocks = <0x02 0x6b 0x02 0x6d 0x02 0x10a>;
 				assigned-clock-parents = <0x02 0x4e 0x02 0x4e 0x02 0x03>;
 				assigned-clock-rates = <0x2faf0800 0x17d78400>;
@@ -1608,7 +1608,7 @@
 			reg = <0x38000000 0x40000>;
 			interrupts = <0x00 0x03 0x04>;
 			clocks = <0x02 0xd7 0x02 0x66 0x02 0x6f 0x02 0x70>;
-			clock-names = "core\0shader\0bus\0reg";
+			clock-names = "core", "shader", "bus", "reg";
 			assigned-clocks = <0x02 0x61 0x02 0x64 0x02 0x6f 0x02 0x70 0x02 0x10>;
 			assigned-clock-parents = <0x02 0x11 0x02 0x11 0x02 0x11 0x02 0x11 0x02 0x0f>;
 			assigned-clock-rates = <0x2faf0800 0x2faf0800 0x2faf0800 0x2faf0800 0x00>;
@@ -1617,16 +1617,16 @@
 		};
 
 		usb@38100000 {
-			compatible = "fsl,imx8mq-dwc3\0snps,dwc3";
+			compatible = "fsl,imx8mq-dwc3", "snps,dwc3";
 			reg = <0x38100000 0x10000>;
 			clocks = <0x02 0xce 0x02 0x98 0x02 0x01>;
-			clock-names = "bus_early\0ref\0suspend";
+			clock-names = "bus_early", "ref", "suspend";
 			assigned-clocks = <0x02 0x6e 0x02 0x98>;
 			assigned-clock-parents = <0x02 0x56 0x02 0x48>;
 			assigned-clock-rates = <0x1dcd6500 0x5f5e100>;
 			interrupts = <0x00 0x28 0x04>;
 			phys = <0x4c 0x4c>;
-			phy-names = "usb2-phy\0usb3-phy";
+			phy-names = "usb2-phy", "usb3-phy";
 			usb3-resume-missing-cas;
 			snps,power-down-scale = <0x02>;
 			status = "okay";
@@ -1647,16 +1647,16 @@
 		};
 
 		usb@38200000 {
-			compatible = "fsl,imx8mq-dwc3\0snps,dwc3";
+			compatible = "fsl,imx8mq-dwc3", "snps,dwc3";
 			reg = <0x38200000 0x10000>;
 			clocks = <0x02 0xcf 0x02 0x98 0x02 0x01>;
-			clock-names = "bus_early\0ref\0suspend";
+			clock-names = "bus_early", "ref", "suspend";
 			assigned-clocks = <0x02 0x6e 0x02 0x98>;
 			assigned-clock-parents = <0x02 0x56 0x02 0x48>;
 			assigned-clock-rates = <0x1dcd6500 0x5f5e100>;
 			interrupts = <0x00 0x29 0x04>;
 			phys = <0x4d 0x4d>;
-			phy-names = "usb2-phy\0usb3-phy";
+			phy-names = "usb2-phy", "usb3-phy";
 			power-domains = <0x4e>;
 			usb3-resume-missing-cas;
 			snps,power-down-scale = <0x02>;
@@ -1678,10 +1678,10 @@
 		};
 
 		dma-apbh@33000000 {
-			compatible = "fsl,imx7d-dma-apbh\0fsl,imx28-dma-apbh";
+			compatible = "fsl,imx7d-dma-apbh", "fsl,imx28-dma-apbh";
 			reg = <0x33000000 0x2000>;
 			interrupts = <0x00 0x0c 0x04 0x00 0x0c 0x04 0x00 0x0c 0x04 0x00 0x0c 0x04>;
-			interrupt-names = "gpmi0\0gpmi1\0gpmi2\0gpmi3";
+			interrupt-names = "gpmi0", "gpmi1", "gpmi2", "gpmi3";
 			#dma-cells = <0x01>;
 			dma-channels = <0x04>;
 			clocks = <0x02 0x100>;
@@ -1693,11 +1693,11 @@
 			#address-cells = <0x01>;
 			#size-cells = <0x01>;
 			reg = <0x33002000 0x2000 0x33004000 0x4000>;
-			reg-names = "gpmi-nand\0bch";
+			reg-names = "gpmi-nand", "bch";
 			interrupts = <0x00 0x0e 0x04>;
 			interrupt-names = "bch";
 			clocks = <0x02 0xe2 0x02 0x100>;
-			clock-names = "gpmi_io\0gpmi_bch_apb";
+			clock-names = "gpmi_io", "gpmi_bch_apb";
 			dmas = <0x4f 0x00>;
 			dma-names = "rx-tx";
 			status = "disabled";
@@ -1706,7 +1706,7 @@
 		pcie@33800000 {
 			compatible = "fsl,imx8mq-pcie";
 			reg = <0x33800000 0x400000 0x1ff00000 0x80000>;
-			reg-names = "dbi\0config";
+			reg-names = "dbi", "config";
 			#address-cells = <0x03>;
 			#size-cells = <0x02>;
 			device_type = "pci";
@@ -1715,21 +1715,21 @@
 			num-lanes = <0x01>;
 			num-viewport = <0x04>;
 			interrupts = <0x00 0x7a 0x04 0x00 0x7f 0x04>;
-			interrupt-names = "msi\0dma";
+			interrupt-names = "msi", "dma";
 			#interrupt-cells = <0x01>;
 			interrupt-map-mask = <0x00 0x00 0x00 0x07>;
 			interrupt-map = <0x00 0x00 0x00 0x01 0x07 0x00 0x7d 0x04 0x00 0x00 0x00 0x02 0x07 0x00 0x7c 0x04 0x00 0x00 0x00 0x03 0x07 0x00 0x7b 0x04 0x00 0x00 0x00 0x04 0x07 0x00 0x7a 0x04>;
 			fsl,max-link-speed = <0x02>;
 			power-domains = <0x50>;
 			resets = <0x28 0x1a 0x28 0x1c 0x28 0x1d>;
-			reset-names = "pciephy\0apps\0turnoff";
+			reset-names = "pciephy", "apps", "turnoff";
 			status = "disabled";
 		};
 
 		pcie@33c00000 {
 			compatible = "fsl,imx8mq-pcie";
 			reg = <0x33c00000 0x400000 0x27f00000 0x80000>;
-			reg-names = "dbi\0config";
+			reg-names = "dbi", "config";
 			#address-cells = <0x03>;
 			#size-cells = <0x02>;
 			device_type = "pci";
@@ -1737,14 +1737,14 @@
 			num-lanes = <0x01>;
 			num-viewport = <0x04>;
 			interrupts = <0x00 0x4a 0x04 0x00 0x50 0x04>;
-			interrupt-names = "msi\0dma";
+			interrupt-names = "msi", "dma";
 			#interrupt-cells = <0x01>;
 			interrupt-map-mask = <0x00 0x00 0x00 0x07>;
 			interrupt-map = <0x00 0x00 0x00 0x01 0x07 0x00 0x4d 0x04 0x00 0x00 0x00 0x02 0x07 0x00 0x4c 0x04 0x00 0x00 0x00 0x03 0x07 0x00 0x4b 0x04 0x00 0x00 0x00 0x04 0x07 0x00 0x4a 0x04>;
 			fsl,max-link-speed = <0x02>;
 			power-domains = <0x50>;
 			resets = <0x28 0x22 0x28 0x24 0x28 0x25>;
-			reset-names = "pciephy\0apps\0turnoff";
+			reset-names = "pciephy", "apps", "turnoff";
 			status = "disabled";
 		};
 
@@ -1759,7 +1759,7 @@
 		};
 
 		ddr-pmu@3d800000 {
-			compatible = "fsl,imx8mq-ddr-pmu\0fsl,imx8m-ddr-pmu";
+			compatible = "fsl,imx8mq-ddr-pmu", "fsl,imx8m-ddr-pmu";
 			reg = <0x3d800000 0x400000>;
 			interrupt-parent = <0x07>;
 			interrupts = <0x00 0x62 0x04>;
@@ -1770,9 +1770,9 @@
 			reg = <0x38300000 0x200000>;
 			reg-names = "regs_hantro";
 			interrupts = <0x00 0x07 0x04 0x00 0x08 0x04>;
-			interrupt-names = "irq_hantro_g1\0irq_hantro_g2";
+			interrupt-names = "irq_hantro_g1", "irq_hantro_g2";
 			clocks = <0x02 0xe5 0x02 0xe6 0x02 0xdf>;
-			clock-names = "clk_hantro_g1\0clk_hantro_g2\0clk_hantro_bus";
+			clock-names = "clk_hantro_g1", "clk_hantro_g2", "clk_hantro_bus";
 			assigned-clocks = <0x02 0x78 0x02 0x79 0x02 0x6a>;
 			assigned-clock-parents = <0x02 0x16 0x02 0x16 0x02 0x4e>;
 			assigned-clock-rates = <0x23c34600 0x23c34600 0x2faf0800>;
@@ -1782,13 +1782,13 @@
 	};
 
 	gpu3d@38000000 {
-		compatible = "fsl,imx8mq-gpu\0fsl,imx6q-gpu";
+		compatible = "fsl,imx8mq-gpu", "fsl,imx6q-gpu";
 		reg = <0x00 0x38000000 0x00 0x40000 0x00 0x40000000 0x00 0xc0000000 0x00 0x00 0x00 0x10000000>;
-		reg-names = "iobase_3d\0phys_baseaddr\0contiguous_mem";
+		reg-names = "iobase_3d", "phys_baseaddr", "contiguous_mem";
 		interrupts = <0x00 0x03 0x04>;
 		interrupt-names = "irq_3d";
 		clocks = <0x02 0xd7 0x02 0x66 0x02 0x6f 0x02 0x70>;
-		clock-names = "gpu3d_clk\0gpu3d_shader_clk\0gpu3d_axi_clk\0gpu3d_ahb_clk";
+		clock-names = "gpu3d_clk", "gpu3d_shader_clk", "gpu3d_axi_clk", "gpu3d_ahb_clk";
 		assigned-clocks = <0x02 0x61 0x02 0x64 0x02 0x6f 0x02 0x70>;
 		assigned-clock-parents = <0x02 0x11 0x02 0x11 0x02 0x11 0x02 0x11>;
 		assigned-clock-rates = <0x2faf0800 0x2faf0800 0x2faf0800 0x2faf0800>;
@@ -1798,7 +1798,7 @@
 
 	rpmsg {
 		compatible = "fsl,imx8mq-rpmsg";
-		mbox-names = "tx\0rx\0rxdb";
+		mbox-names = "tx", "rx", "rxdb";
 		mboxes = <0x52 0x00 0x01 0x52 0x01 0x01 0x52 0x03 0x01>;
 		status = "disabled";
 	};
@@ -1871,7 +1871,7 @@
 	};
 
 	sound-hdmi {
-		compatible = "fsl,imx8mq-evk-cdnhdmi\0fsl,imx-audio-cdnhdmi";
+		compatible = "fsl,imx8mq-evk-cdnhdmi", "fsl,imx-audio-cdnhdmi";
 		model = "imx-audio-hdmi";
 		audio-cpu = <0x55>;
 		protocol = <0x01>;
@@ -1932,8 +1932,8 @@
 		simple-audio-card,frame-master = <0x58>;
 		simple-audio-card,format = "i2s";
 		status = "okay";
-		simple-audio-card,widgets = "Microphone\0Mic Jack\0Line\0Line In\0Line\0Line Out\0Speaker\0Speaker\0Headphone\0Headphone Jack";
-		simple-audio-card,routing = "Headphone Jack\0HP_L\0Headphone Jack\0HP_R\0Speaker\0SPK_LP\0Speaker\0SPK_LN\0Speaker\0SPK_RP\0Speaker\0SPK_RN\0LINPUT1\0Mic Jack\0LINPUT3\0Mic Jack\0RINPUT1\0Mic Jack\0RINPUT2\0Mic Jack\0Mic Jack\0MICB";
+		simple-audio-card,widgets = "Microphone", "Mic Jack", "Line", "Line In", "Line", "Line Out", "Speaker", "Speaker", "Headphone", "Headphone Jack";
+		simple-audio-card,routing = "Headphone Jack", "HP_L", "Headphone Jack", "HP_R", "Speaker", "SPK_LP", "Speaker", "SPK_LN", "Speaker", "SPK_RP", "Speaker", "SPK_RN", "LINPUT1", "Mic Jack", "LINPUT3", "Mic Jack", "RINPUT1", "Mic Jack", "RINPUT2", "Mic Jack", "Mic Jack", "MICB";
 
 		simple-audio-card,cpu {
 			sound-dai = <0x59>;

--- a/dts/odroidc4.dts
+++ b/dts/odroidc4.dts
@@ -13,7 +13,7 @@
 	interrupt-parent = <0x01>;
 	#address-cells = <0x02>;
 	#size-cells = <0x02>;
-	compatible = "hardkernel,odroid-c4\0amlogic,sm1";
+	compatible = "hardkernel,odroid-c4", "amlogic,sm1";
 	model = "Hardkernel ODROID-C4";
 
 	aliases {
@@ -28,14 +28,14 @@
 		#address-cells = <0x02>;
 		#size-cells = <0x02>;
 		ranges;
-        linux,stdout-path = "/soc/bus@ff800000/serial@3000";
-        stdout-path = "/soc/bus@ff800000/serial@3000";
-		linux,initrd-end = <0x00000000 0x2e000000>;
-        linux,initrd-start = <0x00000000 0x2d700000>;
-        bootargs = "console=ttyAML0,115200n8 root=/dev/ram0 nosmp rw debug loglevel=8 pci=nomsi earlyprintk=serial maxcpus=1";
+		linux,stdout-path = "/soc/bus@ff800000/serial@3000";
+		stdout-path = "/soc/bus@ff800000/serial@3000";
+		linux,initrd-end = <0x00 0x2e000000>;
+		linux,initrd-start = <0x00 0x2d700000>;
+		bootargs = "console=ttyAML0,115200n8 root=/dev/ram0 nosmp rw debug loglevel=8 pci=nomsi earlyprintk=serial maxcpus=1";
 
 		framebuffer-cvbs {
-			compatible = "amlogic,simple-framebuffer\0simple-framebuffer";
+			compatible = "amlogic,simple-framebuffer", "simple-framebuffer";
 			amlogic,pipeline = "vpu-cvbs";
 			clocks = <0x02 0xa8 0x02 0x35 0x02 0x3a>;
 			status = "disabled";
@@ -43,7 +43,7 @@
 		};
 
 		framebuffer-hdmi {
-			compatible = "amlogic,simple-framebuffer\0simple-framebuffer";
+			compatible = "amlogic,simple-framebuffer", "simple-framebuffer";
 			amlogic,pipeline = "vpu-hdmi";
 			clocks = <0x02 0xa8 0x02 0x35 0x02 0x3a>;
 			status = "disabled";
@@ -143,9 +143,9 @@
 		ranges;
 
 		pcie@fc000000 {
-			compatible = "amlogic,g12a-pcie\0snps,dw-pcie";
+			compatible = "amlogic,g12a-pcie", "snps,dw-pcie";
 			reg = <0x00 0xfc000000 0x00 0x400000 0x00 0xff648000 0x00 0x2000 0x00 0xfc400000 0x00 0x200000>;
-			reg-names = "elbi\0cfg\0config";
+			reg-names = "elbi", "cfg", "config";
 			interrupts = <0x00 0xdd 0x04>;
 			#interrupt-cells = <0x01>;
 			interrupt-map-mask = <0x00 0x00 0x00 0x00>;
@@ -156,9 +156,9 @@
 			device_type = "pci";
 			ranges = <0x81000000 0x00 0x00 0x00 0xfc600000 0x00 0x100000 0x82000000 0x00 0xfc700000 0x00 0xfc700000 0x00 0x1900000>;
 			clocks = <0x02 0x30 0x02 0x2d 0x02 0xc9>;
-			clock-names = "general\0pclk\0port";
+			clock-names = "general", "pclk", "port";
 			resets = <0x05 0x0c 0x05 0x0f>;
-			reset-names = "port\0apb";
+			reset-names = "port", "apb";
 			num-lanes = <0x01>;
 			phys = <0x06 0x02>;
 			phy-names = "pcie";
@@ -167,12 +167,12 @@
 		};
 
 		ethernet@ff3f0000 {
-			compatible = "amlogic,meson-g12a-dwmac\0snps,dwmac-3.70a\0snps,dwmac";
+			compatible = "amlogic,meson-g12a-dwmac", "snps,dwmac-3.70a", "snps,dwmac";
 			reg = <0x00 0xff3f0000 0x00 0x10000 0x00 0xff634540 0x00 0x08>;
 			interrupts = <0x00 0x08 0x04>;
 			interrupt-names = "macirq";
 			clocks = <0x02 0x26 0x02 0x02 0x02 0x0d 0x02 0x02>;
-			clock-names = "stmmaceth\0clkin0\0clkin1\0timing-adjustment";
+			clock-names = "stmmaceth", "clkin0", "clkin1", "timing-adjustment";
 			rx-fifo-depth = <0x1000>;
 			tx-fifo-depth = <0x800>;
 			status = "okay";
@@ -203,9 +203,9 @@
 				reg = <0x00 0x00 0x00 0x10000>;
 				interrupts = <0x00 0x39 0x01>;
 				resets = <0x05 0x13 0x05 0x42 0x05 0x4f>;
-				reset-names = "hdmitx_apb\0hdmitx\0hdmitx_phy";
+				reset-names = "hdmitx_apb", "hdmitx", "hdmitx_phy";
 				clocks = <0x02 0xa8 0x02 0x35 0x02 0x3a>;
-				clock-names = "isfr\0iahb\0venci";
+				clock-names = "isfr", "iahb", "venci";
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
 				#sound-dai-cells = <0x00>;
@@ -276,11 +276,11 @@
 
 					bank@40 {
 						reg = <0x00 0x40 0x00 0x4c 0x00 0xe8 0x00 0x18 0x00 0x120 0x00 0x18 0x00 0x2c0 0x00 0x40 0x00 0x340 0x00 0x1c>;
-						reg-names = "gpio\0pull\0pull-enable\0mux\0ds";
+						reg-names = "gpio", "pull", "pull-enable", "mux", "ds";
 						gpio-controller;
 						#gpio-cells = <0x02>;
 						gpio-ranges = <0x0f 0x00 0x00 0x56>;
-						gpio-line-names = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0PIN_36\0PIN_26\0PIN_32\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0PIN_27\0PIN_28\0PIN_16\0PIN_18\0PIN_22\0PIN_11\0PIN_13\0PIN_7\0PIN_33\0PIN_15\0PIN_19\0PIN_21\0PIN_24\0PIN_23\0PIN_8\0PIN_10\0PIN_29\0PIN_31\0PIN_12\0PIN_3\0PIN_5\0PIN_35";
+						gpio-line-names = "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "PIN_36", "PIN_26", "PIN_32", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "PIN_27", "PIN_28", "PIN_16", "PIN_18", "PIN_22", "PIN_11", "PIN_13", "PIN_7", "PIN_33", "PIN_15", "PIN_19", "PIN_21", "PIN_24", "PIN_23", "PIN_8", "PIN_10", "PIN_29", "PIN_31", "PIN_12", "PIN_3", "PIN_5", "PIN_35";
 						phandle = <0x14>;
 
 						hog-0 {
@@ -332,7 +332,7 @@
 					emmc-data-4b {
 
 						mux-0 {
-							groups = "emmc_nand_d0\0emmc_nand_d1\0emmc_nand_d2\0emmc_nand_d3";
+							groups = "emmc_nand_d0", "emmc_nand_d1", "emmc_nand_d2", "emmc_nand_d3";
 							function = "emmc";
 							bias-pull-up;
 							drive-strength-microamp = <0xfa0>;
@@ -343,7 +343,7 @@
 						phandle = <0x27>;
 
 						mux-0 {
-							groups = "emmc_nand_d0\0emmc_nand_d1\0emmc_nand_d2\0emmc_nand_d3\0emmc_nand_d4\0emmc_nand_d5\0emmc_nand_d6\0emmc_nand_d7";
+							groups = "emmc_nand_d0", "emmc_nand_d1", "emmc_nand_d2", "emmc_nand_d3", "emmc_nand_d4", "emmc_nand_d5", "emmc_nand_d6", "emmc_nand_d7";
 							function = "emmc";
 							bias-pull-up;
 							drive-strength-microamp = <0xfa0>;
@@ -376,7 +376,7 @@
 						phandle = <0x0b>;
 
 						mux {
-							groups = "hdmitx_sda\0hdmitx_sck";
+							groups = "hdmitx_sda", "hdmitx_sck";
 							function = "hdmitx";
 							bias-disable;
 							drive-strength-microamp = <0xfa0>;
@@ -636,7 +636,7 @@
 					nor {
 
 						mux {
-							groups = "nor_d\0nor_q\0nor_c\0nor_cs";
+							groups = "nor_d", "nor_q", "nor_c", "nor_cs";
 							function = "nor";
 							bias-disable;
 						};
@@ -947,7 +947,7 @@
 						phandle = <0x22>;
 
 						mux-0 {
-							groups = "sdcard_d0_c\0sdcard_d1_c\0sdcard_d2_c\0sdcard_d3_c\0sdcard_cmd_c";
+							groups = "sdcard_d0_c", "sdcard_d1_c", "sdcard_d2_c", "sdcard_d3_c", "sdcard_cmd_c";
 							function = "sdcard";
 							bias-pull-up;
 							drive-strength-microamp = <0xfa0>;
@@ -975,7 +975,7 @@
 					sdcard_z {
 
 						mux-0 {
-							groups = "sdcard_d0_z\0sdcard_d1_z\0sdcard_d2_z\0sdcard_d3_z\0sdcard_cmd_z";
+							groups = "sdcard_d0_z", "sdcard_d1_z", "sdcard_d2_z", "sdcard_d3_z", "sdcard_cmd_z";
 							function = "sdcard";
 							bias-pull-up;
 							drive-strength-microamp = <0xfa0>;
@@ -1002,7 +1002,7 @@
 					sdio {
 
 						mux {
-							groups = "sdio_d0\0sdio_d1\0sdio_d2\0sdio_d3\0sdio_clk\0sdio_cmd";
+							groups = "sdio_d0", "sdio_d1", "sdio_d2", "sdio_d3", "sdio_clk", "sdio_cmd";
 							function = "sdio";
 							bias-disable;
 							drive-strength-microamp = <0xfa0>;
@@ -1079,7 +1079,7 @@
 					spicc0-x {
 
 						mux {
-							groups = "spi0_mosi_x\0spi0_miso_x\0spi0_clk_x";
+							groups = "spi0_mosi_x", "spi0_miso_x", "spi0_clk_x";
 							function = "spi0";
 							drive-strength-microamp = <0xfa0>;
 							bias-disable;
@@ -1099,7 +1099,7 @@
 					spicc0-c {
 
 						mux {
-							groups = "spi0_mosi_c\0spi0_miso_c\0spi0_ss0_c\0spi0_clk_c";
+							groups = "spi0_mosi_c", "spi0_miso_c", "spi0_ss0_c", "spi0_clk_c";
 							function = "spi0";
 							drive-strength-microamp = <0xfa0>;
 							bias-disable;
@@ -1109,7 +1109,7 @@
 					spicc1 {
 
 						mux {
-							groups = "spi1_mosi\0spi1_miso\0spi1_clk";
+							groups = "spi1_mosi", "spi1_miso", "spi1_clk";
 							function = "spi1";
 							drive-strength-microamp = <0xfa0>;
 						};
@@ -1382,7 +1382,7 @@
 					eth-leds {
 
 						mux {
-							groups = "eth_link_led\0eth_act_led";
+							groups = "eth_link_led", "eth_act_led";
 							function = "eth";
 							bias-disable;
 						};
@@ -1392,7 +1392,7 @@
 						phandle = <0x07>;
 
 						mux {
-							groups = "eth_mdio\0eth_mdc\0eth_rgmii_rx_clk\0eth_rx_dv\0eth_rxd0\0eth_rxd1\0eth_txen\0eth_txd0\0eth_txd1";
+							groups = "eth_mdio", "eth_mdc", "eth_rgmii_rx_clk", "eth_rx_dv", "eth_rxd0", "eth_rxd1", "eth_txen", "eth_txd0", "eth_txd1";
 							function = "eth";
 							drive-strength-microamp = <0xfa0>;
 							bias-disable;
@@ -1403,7 +1403,7 @@
 						phandle = <0x08>;
 
 						mux {
-							groups = "eth_rxd2_rgmii\0eth_rxd3_rgmii\0eth_rgmii_tx_clk\0eth_txd2_rgmii\0eth_txd3_rgmii";
+							groups = "eth_rxd2_rgmii", "eth_rxd3_rgmii", "eth_rgmii_tx_clk", "eth_txd2_rgmii", "eth_txd3_rgmii";
 							function = "eth";
 							drive-strength-microamp = <0xfa0>;
 							bias-disable;
@@ -1596,7 +1596,7 @@
 					uart-a {
 
 						mux {
-							groups = "uart_a_tx\0uart_a_rx";
+							groups = "uart_a_tx", "uart_a_rx";
 							function = "uart_a";
 							bias-disable;
 						};
@@ -1605,7 +1605,7 @@
 					uart-a-cts-rts {
 
 						mux {
-							groups = "uart_a_cts\0uart_a_rts";
+							groups = "uart_a_cts", "uart_a_rts";
 							function = "uart_a";
 							bias-disable;
 						};
@@ -1614,7 +1614,7 @@
 					uart-b {
 
 						mux {
-							groups = "uart_b_tx\0uart_b_rx";
+							groups = "uart_b_tx", "uart_b_rx";
 							function = "uart_b";
 							bias-disable;
 						};
@@ -1623,7 +1623,7 @@
 					uart-c {
 
 						mux {
-							groups = "uart_c_tx\0uart_c_rx";
+							groups = "uart_c_tx", "uart_c_rx";
 							function = "uart_c";
 							bias-disable;
 						};
@@ -1632,7 +1632,7 @@
 					uart-c-cts-rts {
 
 						mux {
-							groups = "uart_c_cts\0uart_c_rts";
+							groups = "uart_c_cts", "uart_c_rts";
 							function = "uart_c";
 							bias-disable;
 						};
@@ -1641,7 +1641,7 @@
 			};
 
 			temperature-sensor@34800 {
-				compatible = "amlogic,g12a-cpu-thermal\0amlogic,g12a-thermal";
+				compatible = "amlogic,g12a-cpu-thermal", "amlogic,g12a-thermal";
 				reg = <0x00 0x34800 0x00 0x50>;
 				interrupts = <0x00 0x23 0x01>;
 				clocks = <0x02 0xd4>;
@@ -1651,7 +1651,7 @@
 			};
 
 			temperature-sensor@34c00 {
-				compatible = "amlogic,g12a-ddr-thermal\0amlogic,g12a-thermal";
+				compatible = "amlogic,g12a-ddr-thermal", "amlogic,g12a-thermal";
 				reg = <0x00 0x34c00 0x00 0x50>;
 				interrupts = <0x00 0x24 0x01>;
 				clocks = <0x02 0xd4>;
@@ -1705,7 +1705,7 @@
 				ranges = <0x00 0x00 0x00 0x3c000 0x00 0x1400>;
 
 				system-controller@0 {
-					compatible = "amlogic,meson-gx-hhi-sysctrl\0simple-mfd\0syscon";
+					compatible = "amlogic,meson-gx-hhi-sysctrl", "simple-mfd", "syscon";
 					reg = <0x00 0x00 0x00 0x400>;
 
 					clock-controller {
@@ -1721,9 +1721,9 @@
 						#power-domain-cells = <0x01>;
 						amlogic,ao-sysctrl = <0x12>;
 						resets = <0x05 0x05 0x05 0x0a 0x05 0x0d 0x05 0x25 0x05 0x85 0x05 0x86 0x05 0x87 0x05 0x89 0x05 0x8c 0x05 0x8d 0x05 0xe7>;
-						reset-names = "viu\0venc\0vcbus\0bt656\0rdma\0venci\0vencp\0vdac\0vdi6\0vencl\0vid_lock";
+						reset-names = "viu", "venc", "vcbus", "bt656", "rdma", "venci", "vencp", "vdac", "vdi6", "vencl", "vid_lock";
 						clocks = <0x02 0x74 0x02 0x7c>;
-						clock-names = "vpu\0vapb";
+						clock-names = "vpu", "vapb";
 						assigned-clocks = <0x02 0x6e 0x02 0x70 0x02 0x74 0x02 0x75 0x02 0x77 0x02 0x7b>;
 						assigned-clock-parents = <0x02 0x03 0x00 0x02 0x70 0x02 0x04 0x00 0x02 0x77>;
 						assigned-clock-rates = <0x00 0x27bc86aa 0x00 0x00 0xee6b280 0x00>;
@@ -1749,7 +1749,7 @@
 				compatible = "amlogic,g12a-mdio-mux";
 				reg = <0x00 0x4c000 0x00 0xa4>;
 				clocks = <0x02 0x13 0x11 0x02 0xb1>;
-				clock-names = "pclk\0clkin0\0clkin1";
+				clock-names = "pclk", "clkin0", "clkin1";
 				mdio-parent-bus = <0x13>;
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
@@ -1777,7 +1777,7 @@
 					#size-cells = <0x00>;
 
 					ethernet_phy@8 {
-						compatible = "ethernet-phy-id0180.3301\0ethernet-phy-ieee802.3-c22";
+						compatible = "ethernet-phy-id0180.3301", "ethernet-phy-ieee802.3-c22";
 						interrupts = <0x00 0x09 0x04>;
 						reg = <0x08>;
 						max-speed = <0x64>;
@@ -1799,87 +1799,87 @@
 					#clock-cells = <0x01>;
 					#reset-cells = <0x01>;
 					clocks = <0x02 0x25 0x02 0x0b 0x02 0x0c 0x02 0x0d 0x02 0x0e 0x02 0x4a 0x02 0x03 0x02 0x04 0x02 0x05>;
-					clock-names = "pclk\0mst_in0\0mst_in1\0mst_in2\0mst_in3\0mst_in4\0mst_in5\0mst_in6\0mst_in7";
+					clock-names = "pclk", "mst_in0", "mst_in1", "mst_in2", "mst_in3", "mst_in4", "mst_in5", "mst_in6", "mst_in7";
 					resets = <0x05 0x41>;
 					phandle = <0x16>;
 				};
 
 				audio-controller@100 {
-					compatible = "amlogic,sm1-toddr\0amlogic,axg-toddr";
+					compatible = "amlogic,sm1-toddr", "amlogic,axg-toddr";
 					reg = <0x00 0x100 0x00 0x2c>;
 					#sound-dai-cells = <0x00>;
 					sound-name-prefix = "TODDR_A";
 					interrupts = <0x00 0x94 0x01>;
 					clocks = <0x16 0x29>;
 					resets = <0x17 0x00 0x16 0x06>;
-					reset-names = "arb\0rst";
+					reset-names = "arb", "rst";
 					amlogic,fifo-depth = <0x2000>;
 					status = "disabled";
 				};
 
 				audio-controller@140 {
-					compatible = "amlogic,sm1-toddr\0amlogic,axg-toddr";
+					compatible = "amlogic,sm1-toddr", "amlogic,axg-toddr";
 					reg = <0x00 0x140 0x00 0x2c>;
 					#sound-dai-cells = <0x00>;
 					sound-name-prefix = "TODDR_B";
 					interrupts = <0x00 0x95 0x01>;
 					clocks = <0x16 0x2a>;
 					resets = <0x17 0x01 0x16 0x07>;
-					reset-names = "arb\0rst";
+					reset-names = "arb", "rst";
 					amlogic,fifo-depth = <0x100>;
 					status = "disabled";
 				};
 
 				audio-controller@180 {
-					compatible = "amlogic,sm1-toddr\0amlogic,axg-toddr";
+					compatible = "amlogic,sm1-toddr", "amlogic,axg-toddr";
 					reg = <0x00 0x180 0x00 0x2c>;
 					#sound-dai-cells = <0x00>;
 					sound-name-prefix = "TODDR_C";
 					interrupts = <0x00 0x96 0x01>;
 					clocks = <0x16 0x2b>;
 					resets = <0x17 0x02 0x16 0x08>;
-					reset-names = "arb\0rst";
+					reset-names = "arb", "rst";
 					amlogic,fifo-depth = <0x100>;
 					status = "disabled";
 				};
 
 				audio-controller@1c0 {
-					compatible = "amlogic,sm1-frddr\0amlogic,axg-frddr";
+					compatible = "amlogic,sm1-frddr", "amlogic,axg-frddr";
 					reg = <0x00 0x1c0 0x00 0x2c>;
 					#sound-dai-cells = <0x00>;
 					sound-name-prefix = "FRDDR_A";
 					interrupts = <0x00 0x98 0x01>;
 					clocks = <0x16 0x26>;
 					resets = <0x17 0x03 0x16 0x09>;
-					reset-names = "arb\0rst";
+					reset-names = "arb", "rst";
 					amlogic,fifo-depth = <0x200>;
 					status = "okay";
 					phandle = <0x44>;
 				};
 
 				audio-controller@200 {
-					compatible = "amlogic,sm1-frddr\0amlogic,axg-frddr";
+					compatible = "amlogic,sm1-frddr", "amlogic,axg-frddr";
 					reg = <0x00 0x200 0x00 0x2c>;
 					#sound-dai-cells = <0x00>;
 					sound-name-prefix = "FRDDR_B";
 					interrupts = <0x00 0x99 0x01>;
 					clocks = <0x16 0x27>;
 					resets = <0x17 0x04 0x16 0x0a>;
-					reset-names = "arb\0rst";
+					reset-names = "arb", "rst";
 					amlogic,fifo-depth = <0x100>;
 					status = "okay";
 					phandle = <0x45>;
 				};
 
 				audio-controller@240 {
-					compatible = "amlogic,sm1-frddr\0amlogic,axg-frddr";
+					compatible = "amlogic,sm1-frddr", "amlogic,axg-frddr";
 					reg = <0x00 0x240 0x00 0x2c>;
 					#sound-dai-cells = <0x00>;
 					sound-name-prefix = "FRDDR_C";
 					interrupts = <0x00 0x9a 0x01>;
 					clocks = <0x16 0x28>;
 					resets = <0x17 0x05 0x16 0x0b>;
-					reset-names = "arb\0rst";
+					reset-names = "arb", "rst";
 					amlogic,fifo-depth = <0x100>;
 					status = "okay";
 					phandle = <0x46>;
@@ -1895,64 +1895,64 @@
 				};
 
 				audio-controller@300 {
-					compatible = "amlogic,sm1-tdmin\0amlogic,axg-tdmin";
+					compatible = "amlogic,sm1-tdmin", "amlogic,axg-tdmin";
 					reg = <0x00 0x300 0x00 0x40>;
 					sound-name-prefix = "TDMIN_A";
 					resets = <0x16 0x01>;
 					clocks = <0x16 0x1f 0x16 0x7b 0x16 0x74 0x16 0x82 0x16 0x82>;
-					clock-names = "pclk\0sclk\0sclk_sel\0lrclk\0lrclk_sel";
+					clock-names = "pclk", "sclk", "sclk_sel", "lrclk", "lrclk_sel";
 					status = "disabled";
 				};
 
 				audio-controller@340 {
-					compatible = "amlogic,sm1-tdmin\0amlogic,axg-tdmin";
+					compatible = "amlogic,sm1-tdmin", "amlogic,axg-tdmin";
 					reg = <0x00 0x340 0x00 0x40>;
 					sound-name-prefix = "TDMIN_B";
 					resets = <0x16 0x02>;
 					clocks = <0x16 0x20 0x16 0x7c 0x16 0x75 0x16 0x83 0x16 0x83>;
-					clock-names = "pclk\0sclk\0sclk_sel\0lrclk\0lrclk_sel";
+					clock-names = "pclk", "sclk", "sclk_sel", "lrclk", "lrclk_sel";
 					status = "disabled";
 				};
 
 				audio-controller@380 {
-					compatible = "amlogic,sm1-tdmin\0amlogic,axg-tdmin";
+					compatible = "amlogic,sm1-tdmin", "amlogic,axg-tdmin";
 					reg = <0x00 0x380 0x00 0x40>;
 					sound-name-prefix = "TDMIN_C";
 					resets = <0x16 0x03>;
 					clocks = <0x16 0x21 0x16 0x7d 0x16 0x76 0x16 0x84 0x16 0x84>;
-					clock-names = "pclk\0sclk\0sclk_sel\0lrclk\0lrclk_sel";
+					clock-names = "pclk", "sclk", "sclk_sel", "lrclk", "lrclk_sel";
 					status = "disabled";
 				};
 
 				audio-controller@3c0 {
-					compatible = "amlogic,sm1-tdmin\0amlogic,axg-tdmin";
+					compatible = "amlogic,sm1-tdmin", "amlogic,axg-tdmin";
 					reg = <0x00 0x3c0 0x00 0x40>;
 					sound-name-prefix = "TDMIN_LB";
 					resets = <0x16 0x04>;
 					clocks = <0x16 0x22 0x16 0x7e 0x16 0x77 0x16 0x85 0x16 0x85>;
-					clock-names = "pclk\0sclk\0sclk_sel\0lrclk\0lrclk_sel";
+					clock-names = "pclk", "sclk", "sclk_sel", "lrclk", "lrclk_sel";
 					status = "disabled";
 				};
 
 				audio-controller@400 {
-					compatible = "amlogic,g12a-spdifin\0amlogic,axg-spdifin";
+					compatible = "amlogic,g12a-spdifin", "amlogic,axg-spdifin";
 					reg = <0x00 0x400 0x00 0x30>;
 					#sound-dai-cells = <0x00>;
 					sound-name-prefix = "SPDIFIN";
 					interrupts = <0x00 0x97 0x01>;
 					clocks = <0x16 0x2d 0x16 0x38>;
-					clock-names = "pclk\0refclk";
+					clock-names = "pclk", "refclk";
 					resets = <0x16 0x11>;
 					status = "disabled";
 				};
 
 				audio-controller@480 {
-					compatible = "amlogic,g12a-spdifout\0amlogic,axg-spdifout";
+					compatible = "amlogic,g12a-spdifout", "amlogic,axg-spdifout";
 					reg = <0x00 0x480 0x00 0x50>;
 					#sound-dai-cells = <0x00>;
 					sound-name-prefix = "SPDIFOUT_A";
 					clocks = <0x16 0x2e 0x16 0x37>;
-					clock-names = "pclk\0mclk";
+					clock-names = "pclk", "mclk";
 					resets = <0x16 0x0f>;
 					status = "disabled";
 				};
@@ -1963,7 +1963,7 @@
 					sound-name-prefix = "TDMOUT_A";
 					resets = <0x16 0x0c>;
 					clocks = <0x16 0x23 0x16 0x7f 0x16 0x78 0x16 0x86 0x16 0x86>;
-					clock-names = "pclk\0sclk\0sclk_sel\0lrclk\0lrclk_sel";
+					clock-names = "pclk", "sclk", "sclk_sel", "lrclk", "lrclk_sel";
 					status = "disabled";
 				};
 
@@ -1973,7 +1973,7 @@
 					sound-name-prefix = "TDMOUT_B";
 					resets = <0x16 0x0d>;
 					clocks = <0x16 0x24 0x16 0x80 0x16 0x79 0x16 0x87 0x16 0x87>;
-					clock-names = "pclk\0sclk\0sclk_sel\0lrclk\0lrclk_sel";
+					clock-names = "pclk", "sclk", "sclk_sel", "lrclk", "lrclk_sel";
 					status = "okay";
 					phandle = <0x43>;
 				};
@@ -1984,12 +1984,12 @@
 					sound-name-prefix = "TDMOUT_C";
 					resets = <0x16 0x0e>;
 					clocks = <0x16 0x25 0x16 0x81 0x16 0x7a 0x16 0x88 0x16 0x88>;
-					clock-names = "pclk\0sclk\0sclk_sel\0lrclk\0lrclk_sel";
+					clock-names = "pclk", "sclk", "sclk_sel", "lrclk", "lrclk_sel";
 					status = "disabled";
 				};
 
 				audio-controller@740 {
-					compatible = "amlogic,sm1-toacodec\0amlogic,g12a-toacodec";
+					compatible = "amlogic,sm1-toacodec", "amlogic,g12a-toacodec";
 					reg = <0x00 0x740 0x00 0x04>;
 					#sound-dai-cells = <0x01>;
 					sound-name-prefix = "TOACODEC";
@@ -1998,7 +1998,7 @@
 				};
 
 				audio-controller@744 {
-					compatible = "amlogic,sm1-tohdmitx\0amlogic,g12a-tohdmitx";
+					compatible = "amlogic,sm1-tohdmitx", "amlogic,g12a-tohdmitx";
 					reg = <0x00 0x744 0x00 0x04>;
 					#sound-dai-cells = <0x01>;
 					sound-name-prefix = "TOHDMITX";
@@ -2008,39 +2008,39 @@
 				};
 
 				audio-controller@840 {
-					compatible = "amlogic,sm1-toddr\0amlogic,axg-toddr";
+					compatible = "amlogic,sm1-toddr", "amlogic,axg-toddr";
 					reg = <0x00 0x840 0x00 0x2c>;
 					#sound-dai-cells = <0x00>;
 					sound-name-prefix = "TODDR_D";
 					interrupts = <0x00 0x31 0x01>;
 					clocks = <0x16 0xab>;
 					resets = <0x17 0x06 0x16 0x21>;
-					reset-names = "arb\0rst";
+					reset-names = "arb", "rst";
 					amlogic,fifo-depth = <0x100>;
 					status = "disabled";
 				};
 
 				audio-controller@880 {
-					compatible = "amlogic,sm1-frddr\0amlogic,axg-frddr";
+					compatible = "amlogic,sm1-frddr", "amlogic,axg-frddr";
 					reg = <0x00 0x880 0x00 0x2c>;
 					#sound-dai-cells = <0x00>;
 					sound-name-prefix = "FRDDR_D";
 					interrupts = <0x00 0x32 0x01>;
 					clocks = <0x16 0xaa>;
 					resets = <0x17 0x07 0x16 0x20>;
-					reset-names = "arb\0rst";
+					reset-names = "arb", "rst";
 					amlogic,fifo-depth = <0x100>;
 					status = "disabled";
 				};
 			};
 
 			audio-controller@61000 {
-				compatible = "amlogic,sm1-pdm\0amlogic,axg-pdm";
+				compatible = "amlogic,sm1-pdm", "amlogic,axg-pdm";
 				reg = <0x00 0x61000 0x00 0x34>;
 				#sound-dai-cells = <0x00>;
 				sound-name-prefix = "PDM";
 				clocks = <0x16 0x1e 0x16 0x39 0x16 0x3a>;
-				clock-names = "pclk\0dclk\0sysclk";
+				clock-names = "pclk", "dclk", "sysclk";
 				resets = <0x16 0x00>;
 				status = "disabled";
 			};
@@ -2054,7 +2054,7 @@
 			ranges = <0x00 0x00 0x00 0xff800000 0x00 0x100000>;
 
 			sys-ctrl@0 {
-				compatible = "amlogic,meson-gx-ao-sysctrl\0simple-mfd\0syscon";
+				compatible = "amlogic,meson-gx-ao-sysctrl", "simple-mfd", "syscon";
 				reg = <0x00 0x00 0x00 0x100>;
 				#address-cells = <0x02>;
 				#size-cells = <0x02>;
@@ -2066,7 +2066,7 @@
 					#clock-cells = <0x01>;
 					#reset-cells = <0x01>;
 					clocks = <0x11 0x02 0x0a>;
-					clock-names = "xtal\0mpeg-clk";
+					clock-names = "xtal", "mpeg-clk";
 					phandle = <0x19>;
 				};
 
@@ -2079,11 +2079,11 @@
 
 					bank@14 {
 						reg = <0x00 0x14 0x00 0x08 0x00 0x1c 0x00 0x08 0x00 0x24 0x00 0x14>;
-						reg-names = "mux\0ds\0gpio";
+						reg-names = "mux", "ds", "gpio";
 						gpio-controller;
 						#gpio-cells = <0x02>;
 						gpio-ranges = <0x18 0x00 0x00 0x0f>;
-						gpio-line-names = "\0\0\0\0PIN_47\0\0\0PIN_45\0PIN_46\0PIN_44\0PIN_42\0\0\0\0";
+						gpio-line-names = "", "", "", "", "PIN_47", "", "", "PIN_45", "PIN_46", "PIN_44", "PIN_42", "", "", "", "";
 						phandle = <0x3e>;
 					};
 
@@ -2246,7 +2246,7 @@
 						phandle = <0x1e>;
 
 						mux {
-							groups = "uart_ao_a_tx\0uart_ao_a_rx";
+							groups = "uart_ao_a_tx", "uart_ao_a_rx";
 							function = "uart_ao_a";
 							bias-disable;
 						};
@@ -2255,7 +2255,7 @@
 					uart-ao-a-cts-rts {
 
 						mux {
-							groups = "uart_ao_a_cts\0uart_ao_a_rts";
+							groups = "uart_ao_a_cts", "uart_ao_a_rts";
 							function = "uart_ao_a";
 							bias-disable;
 						};
@@ -2264,7 +2264,7 @@
 					uart-ao-b-2-3 {
 
 						mux {
-							groups = "uart_ao_b_tx_2\0uart_ao_b_rx_3";
+							groups = "uart_ao_b_tx_2", "uart_ao_b_rx_3";
 							function = "uart_ao_b";
 							bias-disable;
 						};
@@ -2273,7 +2273,7 @@
 					uart-ao-b-8-9 {
 
 						mux {
-							groups = "uart_ao_b_tx_8\0uart_ao_b_rx_9";
+							groups = "uart_ao_b_tx_8", "uart_ao_b_rx_9";
 							function = "uart_ao_b";
 							bias-disable;
 						};
@@ -2282,7 +2282,7 @@
 					uart-ao-b-cts-rts {
 
 						mux {
-							groups = "uart_ao_b_cts\0uart_ao_b_rts";
+							groups = "uart_ao_b_cts", "uart_ao_b_rts";
 							function = "uart_ao_b";
 							bias-disable;
 						};
@@ -2390,7 +2390,7 @@
 			};
 
 			ao-secure@140 {
-				compatible = "amlogic,meson-gx-ao-secure\0syscon";
+				compatible = "amlogic,meson-gx-ao-secure", "syscon";
 				reg = <0x00 0x140 0x00 0x140>;
 				amlogic,has-chip-id;
 				phandle = <0x10>;
@@ -2422,22 +2422,22 @@
 			};
 
 			serial@3000 {
-				compatible = "amlogic,meson-gx-uart\0amlogic,meson-ao-uart";
+				compatible = "amlogic,meson-gx-uart", "amlogic,meson-ao-uart";
 				reg = <0x00 0x3000 0x00 0x18>;
 				interrupts = <0x00 0xc1 0x01>;
 				clocks = <0x11 0x19 0x04 0x11>;
-				clock-names = "xtal\0pclk\0baud";
+				clock-names = "xtal", "pclk", "baud";
 				status = "okay";
 				pinctrl-0 = <0x1e>;
 				pinctrl-names = "default";
 			};
 
 			serial@4000 {
-				compatible = "amlogic,meson-gx-uart\0amlogic,meson-ao-uart";
+				compatible = "amlogic,meson-gx-uart", "amlogic,meson-ao-uart";
 				reg = <0x00 0x4000 0x00 0x18>;
 				interrupts = <0x00 0xc5 0x01>;
 				clocks = <0x11 0x19 0x06 0x11>;
-				clock-names = "xtal\0pclk\0baud";
+				clock-names = "xtal", "pclk", "baud";
 				status = "disabled";
 			};
 
@@ -2469,12 +2469,12 @@
 			};
 
 			adc@9000 {
-				compatible = "amlogic,meson-g12a-saradc\0amlogic,meson-saradc";
+				compatible = "amlogic,meson-g12a-saradc", "amlogic,meson-saradc";
 				reg = <0x00 0x9000 0x00 0x48>;
 				#io-channel-cells = <0x01>;
 				interrupts = <0x00 0xc8 0x01>;
 				clocks = <0x11 0x19 0x08 0x19 0x12 0x19 0x10>;
-				clock-names = "clkin\0core\0adc_clk\0adc_sel";
+				clock-names = "clkin", "core", "adc_clk", "adc_sel";
 				status = "disabled";
 			};
 		};
@@ -2482,13 +2482,13 @@
 		video-decoder@ff620000 {
 			compatible = "amlogic,sm1-vdec";
 			reg = <0x00 0xff620000 0x00 0x10000 0x00 0xffd0e180 0x00 0xe4>;
-			reg-names = "dos\0esparser";
+			reg-names = "dos", "esparser";
 			interrupts = <0x00 0x2c 0x01 0x00 0x20 0x01>;
-			interrupt-names = "vdec\0esparser";
+			interrupt-names = "vdec", "esparser";
 			amlogic,ao-sysctrl = <0x12>;
 			amlogic,canvas = <0x20>;
 			clocks = <0x02 0x2e 0x02 0x10 0x02 0xcc 0x02 0xcf 0x02 0xd2>;
-			clock-names = "dos_parser\0dos\0vdec_1\0vdec_hevc\0vdec_hevcf";
+			clock-names = "dos_parser", "dos", "vdec_1", "vdec_hevc", "vdec_hevcf";
 			resets = <0x05 0x28>;
 			reset-names = "esparser";
 		};
@@ -2496,7 +2496,7 @@
 		vpu@ff900000 {
 			compatible = "amlogic,meson-g12a-vpu";
 			reg = <0x00 0xff900000 0x00 0x100000 0x00 0xff63c000 0x00 0x1000>;
-			reg-names = "vpu\0hhi";
+			reg-names = "vpu", "hhi";
 			interrupts = <0x00 0x03 0x01>;
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
@@ -2543,7 +2543,7 @@
 			};
 
 			interrupt-controller@f080 {
-				compatible = "amlogic,meson-sm1-gpio-intc\0amlogic,meson-gpio-intc";
+				compatible = "amlogic,meson-sm1-gpio-intc", "amlogic,meson-gpio-intc";
 				reg = <0x00 0xf080 0x00 0x10>;
 				interrupt-controller;
 				#interrupt-cells = <0x02>;
@@ -2563,7 +2563,7 @@
 				reg = <0x00 0x13000 0x00 0x44>;
 				interrupts = <0x00 0x51 0x04>;
 				clocks = <0x02 0x17 0x02 0x102>;
-				clock-names = "core\0pclk";
+				clock-names = "core", "pclk";
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
 				status = "disabled";
@@ -2574,7 +2574,7 @@
 				reg = <0x00 0x15000 0x00 0x44>;
 				interrupts = <0x00 0x5a 0x04>;
 				clocks = <0x02 0x1d 0x02 0x105>;
-				clock-names = "core\0pclk";
+				clock-names = "core", "pclk";
 				#address-cells = <0x01>;
 				#size-cells = <0x00>;
 				status = "disabled";
@@ -2660,7 +2660,7 @@
 				reg = <0x00 0x22000 0x00 0x18>;
 				interrupts = <0x00 0x5d 0x01>;
 				clocks = <0x11 0x02 0x39 0x11>;
-				clock-names = "xtal\0pclk\0baud";
+				clock-names = "xtal", "pclk", "baud";
 				status = "disabled";
 			};
 
@@ -2669,7 +2669,7 @@
 				reg = <0x00 0x23000 0x00 0x18>;
 				interrupts = <0x00 0x4b 0x01>;
 				clocks = <0x11 0x02 0x2a 0x11>;
-				clock-names = "xtal\0pclk\0baud";
+				clock-names = "xtal", "pclk", "baud";
 				status = "disabled";
 			};
 
@@ -2678,7 +2678,7 @@
 				reg = <0x00 0x24000 0x00 0x18>;
 				interrupts = <0x00 0x1a 0x01>;
 				clocks = <0x11 0x02 0x1c 0x11>;
-				clock-names = "xtal\0pclk\0baud";
+				clock-names = "xtal", "pclk", "baud";
 				status = "disabled";
 				fifo-size = <0x80>;
 			};
@@ -2690,7 +2690,7 @@
 			interrupts = <0x00 0xbd 0x01>;
 			status = "disabled";
 			clocks = <0x02 0x21 0x02 0x3c 0x02 0x02>;
-			clock-names = "core\0clkin0\0clkin1";
+			clock-names = "core", "clkin0", "clkin1";
 			resets = <0x05 0x2c>;
 		};
 
@@ -2700,11 +2700,11 @@
 			interrupts = <0x00 0xbe 0x01>;
 			status = "okay";
 			clocks = <0x02 0x22 0x02 0x3d 0x02 0x02>;
-			clock-names = "core\0clkin0\0clkin1";
+			clock-names = "core", "clkin0", "clkin1";
 			resets = <0x05 0x2d>;
 			pinctrl-0 = <0x22>;
 			pinctrl-1 = <0x23>;
-			pinctrl-names = "default\0clk-gate";
+			pinctrl-names = "default", "clk-gate";
 			bus-width = <0x04>;
 			cap-sd-highspeed;
 			max-frequency = <0xbebc200>;
@@ -2724,11 +2724,11 @@
 			interrupts = <0x00 0xbf 0x01>;
 			status = "okay";
 			clocks = <0x02 0x23 0x02 0x3e 0x02 0x02>;
-			clock-names = "core\0clkin0\0clkin1";
+			clock-names = "core", "clkin0", "clkin1";
 			resets = <0x05 0x2e>;
 			pinctrl-0 = <0x26 0x27 0x28>;
 			pinctrl-1 = <0x29>;
-			pinctrl-names = "default\0clk-gate";
+			pinctrl-names = "default", "clk-gate";
 			bus-width = <0x08>;
 			cap-mmc-highspeed;
 			mmc-ddr-1_8v;
@@ -2752,12 +2752,12 @@
 			resets = <0x05 0x22>;
 			dr_mode = "otg";
 			phys = <0x2d 0x2e 0x06 0x04>;
-			phy-names = "usb2-phy0\0usb2-phy1\0usb3-phy0";
+			phy-names = "usb2-phy0", "usb2-phy1", "usb3-phy0";
 			power-domains = <0x03 0x02>;
 			vbus-supply = <0x2f>;
 
 			usb@ff400000 {
-				compatible = "amlogic,meson-g12a-usb\0snps,dwc2";
+				compatible = "amlogic,meson-g12a-usb", "snps,dwc2";
 				reg = <0x00 0xff400000 0x00 0x40000>;
 				interrupts = <0x00 0x1f 0x04>;
 				clocks = <0x02 0x37>;
@@ -2782,11 +2782,11 @@
 		};
 
 		gpu@ffe40000 {
-			compatible = "amlogic,meson-g12a-mali\0arm,mali-bifrost";
+			compatible = "amlogic,meson-g12a-mali", "arm,mali-bifrost";
 			reg = <0x00 0xffe40000 0x00 0x40000>;
 			interrupt-parent = <0x01>;
 			interrupts = <0x00 0xa2 0x04 0x00 0xa1 0x04 0x00 0xa0 0x04>;
-			interrupt-names = "job\0mmu\0gpu";
+			interrupt-names = "job", "mmu", "gpu";
 			clocks = <0x02 0xaf>;
 			resets = <0x05 0x14 0x05 0x4e>;
 			operating-points-v2 = <0x30>;
@@ -2889,7 +2889,7 @@
 		#sound-dai-cells = <0x00>;
 		sound-name-prefix = "TDM_A";
 		clocks = <0x16 0x31 0x16 0x4f 0x16 0x56>;
-		clock-names = "mclk\0sclk\0lrclk";
+		clock-names = "mclk", "sclk", "lrclk";
 		status = "disabled";
 	};
 
@@ -2898,7 +2898,7 @@
 		#sound-dai-cells = <0x00>;
 		sound-name-prefix = "TDM_B";
 		clocks = <0x16 0x32 0x16 0x50 0x16 0x57>;
-		clock-names = "mclk\0sclk\0lrclk";
+		clock-names = "mclk", "sclk", "lrclk";
 		status = "okay";
 		phandle = <0x47>;
 	};
@@ -2908,7 +2908,7 @@
 		#sound-dai-cells = <0x00>;
 		sound-name-prefix = "TDM_C";
 		clocks = <0x16 0x33 0x16 0x51 0x16 0x58>;
-		clock-names = "mclk\0sclk\0lrclk";
+		clock-names = "mclk", "sclk", "lrclk";
 		status = "disabled";
 	};
 
@@ -3170,7 +3170,7 @@
 	sound {
 		compatible = "amlogic,axg-sound-card";
 		audio-aux-devs = <0x43>;
-		audio-routing = "TDMOUT_B IN 0\0FRDDR_A OUT 1\0TDMOUT_B IN 1\0FRDDR_B OUT 1\0TDMOUT_B IN 2\0FRDDR_C OUT 1\0TDM_B Playback\0TDMOUT_B OUT";
+		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1", "TDMOUT_B IN 1", "FRDDR_B OUT 1", "TDMOUT_B IN 2", "FRDDR_C OUT 1", "TDM_B Playback", "TDMOUT_B OUT";
 		assigned-clocks = <0x02 0x0d 0x02 0x0b 0x02 0x0c>;
 		assigned-clock-parents = <0x00 0x00 0x00>;
 		assigned-clock-rates = <0x11940000 0x10266000 0x17700000>;

--- a/dts/rpi4b_1gb.dts
+++ b/dts/rpi4b_1gb.dts
@@ -12,7 +12,7 @@
 
 /memreserve/	0x0000000000000000 0x0000000000001000;
 / {
-	compatible = "raspberrypi,4-model-b\0brcm,bcm2711";
+	compatible = "raspberrypi,4-model-b", "brcm,bcm2711";
 	model = "Raspberry Pi 4 Model B";
 	#address-cells = <0x02>;
 	#size-cells = <0x01>;
@@ -111,7 +111,7 @@
 			interrupt-controller;
 			#interrupt-cells = <0x02>;
 			pinctrl-names = "default";
-			gpio-line-names = "ID_SDA\0ID_SCL\0SDA1\0SCL1\0GPIO_GCLK\0GPIO5\0GPIO6\0SPI_CE1_N\0SPI_CE0_N\0SPI_MISO\0SPI_MOSI\0SPI_SCLK\0GPIO12\0GPIO13\0TXD1\0RXD1\0GPIO16\0GPIO17\0GPIO18\0GPIO19\0GPIO20\0GPIO21\0GPIO22\0GPIO23\0GPIO24\0GPIO25\0GPIO26\0GPIO27\0RGMII_MDIO\0RGMIO_MDC\0CTS0\0RTS0\0TXD0\0RXD0\0SD1_CLK\0SD1_CMD\0SD1_DATA0\0SD1_DATA1\0SD1_DATA2\0SD1_DATA3\0PWM0_MISO\0PWM1_MOSI\0STATUS_LED_G_CLK\0SPIFLASH_CE_N\0SDA0\0SCL0\0RGMII_RXCLK\0RGMII_RXCTL\0RGMII_RXD0\0RGMII_RXD1\0RGMII_RXD2\0RGMII_RXD3\0RGMII_TXCLK\0RGMII_TXCTL\0RGMII_TXD0\0RGMII_TXD1\0RGMII_TXD2\0RGMII_TXD3";
+			gpio-line-names = "ID_SDA", "ID_SCL", "SDA1", "SCL1", "GPIO_GCLK", "GPIO5", "GPIO6", "SPI_CE1_N", "SPI_CE0_N", "SPI_MISO", "SPI_MOSI", "SPI_SCLK", "GPIO12", "GPIO13", "TXD1", "RXD1", "GPIO16", "GPIO17", "GPIO18", "GPIO19", "GPIO20", "GPIO21", "GPIO22", "GPIO23", "GPIO24", "GPIO25", "GPIO26", "GPIO27", "RGMII_MDIO", "RGMIO_MDC", "CTS0", "RTS0", "TXD0", "RXD0", "SD1_CLK", "SD1_CMD", "SD1_DATA0", "SD1_DATA1", "SD1_DATA2", "SD1_DATA3", "PWM0_MISO", "PWM1_MOSI", "STATUS_LED_G_CLK", "SPIFLASH_CE_N", "SDA0", "SCL0", "RGMII_RXCLK", "RGMII_RXCTL", "RGMII_RXD0", "RGMII_RXD1", "RGMII_RXD2", "RGMII_RXD3", "RGMII_TXCLK", "RGMII_TXCTL", "RGMII_TXD0", "RGMII_TXD1", "RGMII_TXD2", "RGMII_TXD3";
 			phandle = <0x27>;
 
 			dpi_gpio0 {
@@ -479,7 +479,7 @@
 			i2c_slave_gpio8 {
 
 				pins-i2c-slave {
-					pins = "gpio8\0gpio9\0gpio10\0gpio11";
+					pins = "gpio8", "gpio9", "gpio10", "gpio11";
 					function = "alt3";
 				};
 			};
@@ -487,7 +487,7 @@
 			jtag_gpio48 {
 
 				pins-jtag {
-					pins = "gpio48\0gpio49\0gpio50\0gpio51\0gpio52\0gpio53";
+					pins = "gpio48", "gpio49", "gpio50", "gpio51", "gpio52", "gpio53";
 					function = "alt4";
 				};
 			};
@@ -495,7 +495,7 @@
 			mii_gpio28 {
 
 				pins-mii {
-					pins = "gpio28\0gpio29\0gpio30\0gpio31";
+					pins = "gpio28", "gpio29", "gpio30", "gpio31";
 					function = "alt4";
 				};
 			};
@@ -503,7 +503,7 @@
 			mii_gpio36 {
 
 				pins-mii {
-					pins = "gpio36\0gpio37\0gpio38\0gpio39";
+					pins = "gpio36", "gpio37", "gpio38", "gpio39";
 					function = "alt5";
 				};
 			};
@@ -511,7 +511,7 @@
 			pcm_gpio50 {
 
 				pins-pcm {
-					pins = "gpio50\0gpio51\0gpio52\0gpio53";
+					pins = "gpio50", "gpio51", "gpio52", "gpio53";
 					function = "alt2";
 				};
 			};
@@ -631,7 +631,7 @@
 			rgmii_mdio_gpio28 {
 
 				pins-mdio {
-					pins = "gpio28\0gpio29";
+					pins = "gpio28", "gpio29";
 					function = "alt5";
 				};
 			};
@@ -639,7 +639,7 @@
 			rgmii_mdio_gpio37 {
 
 				pins-mdio {
-					pins = "gpio37\0gpio38";
+					pins = "gpio37", "gpio38";
 					function = "alt4";
 				};
 			};
@@ -647,7 +647,7 @@
 			spi0_gpio46 {
 
 				pins-spi {
-					pins = "gpio46\0gpio47\0gpio48\0gpio49";
+					pins = "gpio46", "gpio47", "gpio48", "gpio49";
 					function = "alt2";
 				};
 			};
@@ -655,7 +655,7 @@
 			spi2_gpio46 {
 
 				pins-spi {
-					pins = "gpio46\0gpio47\0gpio48\0gpio49\0gpio50";
+					pins = "gpio46", "gpio47", "gpio48", "gpio49", "gpio50";
 					function = "alt5";
 				};
 			};
@@ -663,7 +663,7 @@
 			spi3_gpio0 {
 
 				pins-spi {
-					pins = "gpio0\0gpio1\0gpio2\0gpio3";
+					pins = "gpio0", "gpio1", "gpio2", "gpio3";
 					function = "alt3";
 				};
 			};
@@ -671,7 +671,7 @@
 			spi4_gpio4 {
 
 				pins-spi {
-					pins = "gpio4\0gpio5\0gpio6\0gpio7";
+					pins = "gpio4", "gpio5", "gpio6", "gpio7";
 					function = "alt3";
 				};
 			};
@@ -679,7 +679,7 @@
 			spi5_gpio12 {
 
 				pins-spi {
-					pins = "gpio12\0gpio13\0gpio14\0gpio15";
+					pins = "gpio12", "gpio13", "gpio14", "gpio15";
 					function = "alt3";
 				};
 			};
@@ -687,7 +687,7 @@
 			spi6_gpio18 {
 
 				pins-spi {
-					pins = "gpio18\0gpio19\0gpio20\0gpio21";
+					pins = "gpio18", "gpio19", "gpio20", "gpio21";
 					function = "alt3";
 				};
 			};
@@ -824,11 +824,11 @@
 		};
 
 		serial@7e201000 {
-			compatible = "arm,pl011\0arm,primecell";
+			compatible = "arm,pl011", "arm,primecell";
 			reg = <0x7e201000 0x200>;
 			interrupts = <0x00 0x79 0x04>;
 			clocks = <0x06 0x13 0x06 0x14>;
-			clock-names = "uartclk\0apb_pclk";
+			clock-names = "uartclk", "apb_pclk";
 			arm,primecell-periphid = <0x241011>;
 			pinctrl-names = "default";
 			pinctrl-0 = <0x07 0x08>;
@@ -868,7 +868,7 @@
 		};
 
 		i2c@7e205000 {
-			compatible = "brcm,bcm2711-i2c\0brcm,bcm2835-i2c";
+			compatible = "brcm,bcm2711-i2c", "brcm,bcm2835-i2c";
 			reg = <0x7e205000 0x200>;
 			interrupts = <0x00 0x75 0x04>;
 			clocks = <0x06 0x14>;
@@ -884,7 +884,7 @@
 			compatible = "brcm,bcm2835-dpi";
 			reg = <0x7e208000 0x8c>;
 			clocks = <0x06 0x14 0x06 0x2c>;
-			clock-names = "core\0pixel";
+			clock-names = "core", "pixel";
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
 			status = "disabled";
@@ -898,8 +898,8 @@
 			#size-cells = <0x00>;
 			#clock-cells = <0x01>;
 			clocks = <0x06 0x20 0x06 0x2f 0x06 0x31>;
-			clock-names = "phy\0escape\0pixel";
-			clock-output-names = "dsi0_byte\0dsi0_ddr2\0dsi0_ddr";
+			clock-names = "phy", "escape", "pixel";
+			clock-output-names = "dsi0_byte", "dsi0_ddr2", "dsi0_ddr";
 			status = "disabled";
 			power-domains = <0x0b 0x11>;
 			phandle = <0x04>;
@@ -986,15 +986,15 @@
 			#size-cells = <0x00>;
 			#clock-cells = <0x01>;
 			clocks = <0x06 0x23 0x06 0x30 0x06 0x32>;
-			clock-names = "phy\0escape\0pixel";
-			clock-output-names = "dsi1_byte\0dsi1_ddr2\0dsi1_ddr";
+			clock-names = "phy", "escape", "pixel";
+			clock-output-names = "dsi1_byte", "dsi1_ddr2", "dsi1_ddr";
 			status = "disabled";
 			power-domains = <0x0b 0x12>;
 			phandle = <0x05>;
 		};
 
 		i2c@7e804000 {
-			compatible = "brcm,bcm2711-i2c\0brcm,bcm2835-i2c";
+			compatible = "brcm,bcm2711-i2c", "brcm,bcm2835-i2c";
 			reg = <0x7e804000 0x1000>;
 			interrupts = <0x00 0x75 0x04>;
 			clocks = <0x06 0x14>;
@@ -1047,7 +1047,7 @@
 		};
 
 		avs-monitor@7d5d2000 {
-			compatible = "brcm,bcm2711-avs-monitor\0syscon\0simple-mfd";
+			compatible = "brcm,bcm2711-avs-monitor", "syscon", "simple-mfd";
 			reg = <0x7d5d2000 0xf00>;
 
 			thermal {
@@ -1061,19 +1061,19 @@
 			compatible = "brcm,bcm2835-dma";
 			reg = <0x7e007000 0xb00>;
 			interrupts = <0x00 0x50 0x04 0x00 0x51 0x04 0x00 0x52 0x04 0x00 0x53 0x04 0x00 0x54 0x04 0x00 0x55 0x04 0x00 0x56 0x04 0x00 0x57 0x04 0x00 0x57 0x04 0x00 0x58 0x04 0x00 0x58 0x04>;
-			interrupt-names = "dma0\0dma1\0dma2\0dma3\0dma4\0dma5\0dma6\0dma7\0dma8\0dma9\0dma10";
+			interrupt-names = "dma0", "dma1", "dma2", "dma3", "dma4", "dma5", "dma6", "dma7", "dma8", "dma9", "dma10";
 			#dma-cells = <0x01>;
 			brcm,dma-channel-mask = <0x7f5>;
 			phandle = <0x19>;
 		};
 
 		watchdog@7e100000 {
-			compatible = "brcm,bcm2835-pm\0brcm,bcm2835-pm-wdt";
+			compatible = "brcm,bcm2835-pm", "brcm,bcm2835-pm-wdt";
 			#power-domain-cells = <0x01>;
 			#reset-cells = <0x01>;
 			reg = <0x7e100000 0x114 0x7e00a000 0x24 0x7ec11000 0x20>;
 			clocks = <0x06 0x15 0x06 0x1d 0x06 0x17 0x06 0x16>;
-			clock-names = "v3d\0peri_image\0h264\0isp";
+			clock-names = "v3d", "peri_image", "h264", "isp";
 			system-power-controller;
 		};
 
@@ -1083,41 +1083,41 @@
 		};
 
 		serial@7e201400 {
-			compatible = "arm,pl011\0arm,primecell";
+			compatible = "arm,pl011", "arm,primecell";
 			reg = <0x7e201400 0x200>;
 			interrupts = <0x00 0x79 0x04>;
 			clocks = <0x06 0x13 0x06 0x14>;
-			clock-names = "uartclk\0apb_pclk";
+			clock-names = "uartclk", "apb_pclk";
 			arm,primecell-periphid = <0x241011>;
 			status = "disabled";
 		};
 
 		serial@7e201600 {
-			compatible = "arm,pl011\0arm,primecell";
+			compatible = "arm,pl011", "arm,primecell";
 			reg = <0x7e201600 0x200>;
 			interrupts = <0x00 0x79 0x04>;
 			clocks = <0x06 0x13 0x06 0x14>;
-			clock-names = "uartclk\0apb_pclk";
+			clock-names = "uartclk", "apb_pclk";
 			arm,primecell-periphid = <0x241011>;
 			status = "disabled";
 		};
 
 		serial@7e201800 {
-			compatible = "arm,pl011\0arm,primecell";
+			compatible = "arm,pl011", "arm,primecell";
 			reg = <0x7e201800 0x200>;
 			interrupts = <0x00 0x79 0x04>;
 			clocks = <0x06 0x13 0x06 0x14>;
-			clock-names = "uartclk\0apb_pclk";
+			clock-names = "uartclk", "apb_pclk";
 			arm,primecell-periphid = <0x241011>;
 			status = "disabled";
 		};
 
 		serial@7e201a00 {
-			compatible = "arm,pl011\0arm,primecell";
+			compatible = "arm,pl011", "arm,primecell";
 			reg = <0x7e201a00 0x200>;
 			interrupts = <0x00 0x79 0x04>;
 			clocks = <0x06 0x13 0x06 0x14>;
-			clock-names = "uartclk\0apb_pclk";
+			clock-names = "uartclk", "apb_pclk";
 			arm,primecell-periphid = <0x241011>;
 			status = "disabled";
 		};
@@ -1163,7 +1163,7 @@
 		};
 
 		i2c@7e205600 {
-			compatible = "brcm,bcm2711-i2c\0brcm,bcm2835-i2c";
+			compatible = "brcm,bcm2711-i2c", "brcm,bcm2835-i2c";
 			reg = <0x7e205600 0x200>;
 			interrupts = <0x00 0x75 0x04>;
 			clocks = <0x06 0x14>;
@@ -1173,7 +1173,7 @@
 		};
 
 		i2c@7e205800 {
-			compatible = "brcm,bcm2711-i2c\0brcm,bcm2835-i2c";
+			compatible = "brcm,bcm2711-i2c", "brcm,bcm2835-i2c";
 			reg = <0x7e205800 0x200>;
 			interrupts = <0x00 0x75 0x04>;
 			clocks = <0x06 0x14>;
@@ -1183,7 +1183,7 @@
 		};
 
 		i2c@7e205a00 {
-			compatible = "brcm,bcm2711-i2c\0brcm,bcm2835-i2c";
+			compatible = "brcm,bcm2711-i2c", "brcm,bcm2835-i2c";
 			reg = <0x7e205a00 0x200>;
 			interrupts = <0x00 0x75 0x04>;
 			clocks = <0x06 0x14>;
@@ -1193,7 +1193,7 @@
 		};
 
 		i2c@7e205c00 {
-			compatible = "brcm,bcm2711-i2c\0brcm,bcm2835-i2c";
+			compatible = "brcm,bcm2711-i2c", "brcm,bcm2835-i2c";
 			reg = <0x7e205c00 0x200>;
 			interrupts = <0x00 0x75 0x04>;
 			clocks = <0x06 0x14>;
@@ -1261,8 +1261,8 @@
 		hdmi@7ef00700 {
 			compatible = "brcm,bcm2711-hdmi0";
 			reg = <0x7ef00700 0x300 0x7ef00300 0x200 0x7ef00f00 0x80 0x7ef00f80 0x80 0x7ef01b00 0x200 0x7ef01f00 0x400 0x7ef00200 0x80 0x7ef04300 0x100 0x7ef20000 0x100>;
-			reg-names = "hdmi\0dvp\0phy\0rm\0packet\0metadata\0csc\0cec\0hd";
-			clock-names = "hdmi\0bvb\0audio\0cec";
+			reg-names = "hdmi", "dvp", "phy", "rm", "packet", "metadata", "csc", "cec", "hd";
+			clock-names = "hdmi", "bvb", "audio", "cec";
 			resets = <0x17 0x00>;
 			ddc = <0x18>;
 			dmas = <0x19 0x0a>;
@@ -1274,7 +1274,7 @@
 		i2c@7ef04500 {
 			compatible = "brcm,bcm2711-hdmi-i2c";
 			reg = <0x7ef04500 0x100 0x7ef00b00 0x300>;
-			reg-names = "bsc\0auto-i2c";
+			reg-names = "bsc", "auto-i2c";
 			clock-frequency = <0x17cdc>;
 			status = "okay";
 			phandle = <0x18>;
@@ -1283,9 +1283,9 @@
 		hdmi@7ef05700 {
 			compatible = "brcm,bcm2711-hdmi1";
 			reg = <0x7ef05700 0x300 0x7ef05300 0x200 0x7ef05f00 0x80 0x7ef05f80 0x80 0x7ef06b00 0x200 0x7ef06f00 0x400 0x7ef00280 0x80 0x7ef09300 0x100 0x7ef20000 0x100>;
-			reg-names = "hdmi\0dvp\0phy\0rm\0packet\0metadata\0csc\0cec\0hd";
+			reg-names = "hdmi", "dvp", "phy", "rm", "packet", "metadata", "csc", "cec", "hd";
 			ddc = <0x1b>;
-			clock-names = "hdmi\0bvb\0audio\0cec";
+			clock-names = "hdmi", "bvb", "audio", "cec";
 			resets = <0x17 0x01>;
 			dmas = <0x19 0x11>;
 			dma-names = "audio-rx";
@@ -1296,14 +1296,14 @@
 		i2c@7ef09500 {
 			compatible = "brcm,bcm2711-hdmi-i2c";
 			reg = <0x7ef09500 0x100 0x7ef05b00 0x300>;
-			reg-names = "bsc\0auto-i2c";
+			reg-names = "bsc", "auto-i2c";
 			clock-frequency = <0x17cdc>;
 			status = "okay";
 			phandle = <0x1b>;
 		};
 
 		firmware {
-			compatible = "raspberrypi,bcm2835-firmware\0simple-mfd";
+			compatible = "raspberrypi,bcm2835-firmware", "simple-mfd";
 			#address-cells = <0x01>;
 			#size-cells = <0x01>;
 			mboxes = <0x1c>;
@@ -1320,7 +1320,7 @@
 				compatible = "raspberrypi,firmware-gpio";
 				gpio-controller;
 				#gpio-cells = <0x02>;
-				gpio-line-names = "BT_ON\0WL_ON\0PWR_LED_OFF\0GLOBAL_RESET\0VDD_SD_IO_SEL\0CAM_GPIO\0SD_PWR_ON\0";
+				gpio-line-names = "BT_ON", "WL_ON", "PWR_LED_OFF", "GLOBAL_RESET", "VDD_SD_IO_SEL", "CAM_GPIO", "SD_PWR_ON", "";
 				status = "okay";
 				phandle = <0x09>;
 			};
@@ -1412,7 +1412,7 @@
 	};
 
 	arm-pmu {
-		compatible = "arm,cortex-a72-pmu\0arm,armv8-pmuv3";
+		compatible = "arm,cortex-a72-pmu", "arm,armv8-pmuv3";
 		interrupts = <0x00 0x10 0x04 0x00 0x11 0x04 0x00 0x12 0x04 0x00 0x13 0x04>;
 		interrupt-affinity = <0x20 0x21 0x22 0x23>;
 	};
@@ -1479,7 +1479,7 @@
 			#interrupt-cells = <0x01>;
 			#size-cells = <0x02>;
 			interrupts = <0x00 0x94 0x04 0x00 0x94 0x04>;
-			interrupt-names = "pcie\0msi";
+			interrupt-names = "pcie", "msi";
 			interrupt-map-mask = <0x00 0x00 0x00 0x07>;
 			interrupt-map = <0x00 0x00 0x00 0x01 0x01 0x00 0x8f 0x04>;
 			msi-controller;

--- a/dts/star64.dts
+++ b/dts/star64.dts
@@ -1194,7 +1194,7 @@
 			compatible = "starfive,jh7110-timer";
 			reg = <0x00 0x13050000 0x00 0x10000>;
 			interrupts = <0x45 0x46 0x47 0x48>;
-			interrupt-names = "timer0\0timer1\0timer2\0timer3";
+			interrupt-names = "timer0", "timer1", "timer2", "timer3";
 			status = "okay";
 		};
 


### PR DESCRIPTION
This has confused people before as it looks like a string you can't represent in C, when it is actually multiple strings.