### PR TITLE
ci: increase echo server DHCP timeout

### DIFF
--- a/ci/examples/echo_server.py
+++ b/ci/examples/echo_server.py
@@ -43,7 +43,12 @@ def backend_fn(test_config: common.TestConfig, loader_img: Path) -> HardwareBack
 
 
 async def test(backend: HardwareBackend, test_config: common.TestConfig):
-    async with asyncio.timeout(20):
+    timeout = 20
+    if test_config.board.startswith("rpi4b"):
+        # See https://github.com/au-ts/sddf/issues/698 for details
+        timeout = 30
+
+    async with asyncio.timeout(timeout):
         await wait_for_output(backend, b"DHCP request finished")
         dhcp_client1 = await wait_for_output(backend, b"\r\n")
         await wait_for_output(backend, b"DHCP request finished")


### PR DESCRIPTION
We have seen on the Raspberry Pi 4B that the DHCP takes longer, around 25 seconds from boot.

This is a bit concerning, I don't know why it takes longer than other platforms, we need to investigate.