### PR TITLE
Network: Move unused etharp definitions to ARP component

### DIFF
--- a/include/sddf/network/constants.h
+++ b/include/sddf/network/constants.h
@@ -8,11 +8,7 @@
 #include <os/sddf.h>
 #include <stdint.h>
 
-#define ETH_TYPE_ARP 0x0806U
-#define ETH_TYPE_IP 0x0800U
 #define ETH_HWADDR_LEN 6
-#define ETHARP_OPCODE_REQUEST 1
-#define ETHARP_OPCODE_REPLY 2
 
 #define NET_BUFFER_SIZE 2048
 

--- a/network/components/arp.c
+++ b/network/components/arp.c
@@ -20,6 +20,11 @@
 #define LWIP_IANA_HWTYPE_ETHERNET 1
 #define NUM_ARP_CLIENTS (NUM_NETWORK_CLIENTS - 1)
 
+#define ETH_TYPE_ARP 0x0806U
+#define ETH_TYPE_IP 0x0800U
+#define ETHARP_OPCODE_REQUEST 1
+#define ETHARP_OPCODE_REPLY 2
+
 net_queue_handle_t rx_queue;
 net_queue_handle_t tx_queue;
 


### PR DESCRIPTION
This PR removes unused Ethernet/ARP constants to the [depreciated] ARP component, which it was agreed upon to keep in the sDDF repo for the time being.