### PR TITLE
Fix ZCU board.py paddr_top constant.

### DIFF
--- a/tools/meta/board.py
+++ b/tools/meta/board.py
@@ -183,7 +183,7 @@ BOARDS: List[Board] = [
     Board(
         name="zcu102",
         arch=SystemDescription.Arch.AARCH64,
-        paddr_top=0xA0000000,
+        paddr_top=0x80000000,
         timer="axi/timer@ff140000",
         serial="axi/serial@ff000000",
     ),


### PR DESCRIPTION
See line 2115 in zcu102.dts

PS. Why do we not parse the dts to retrieve information like this?