### PR TITLE
treewide: update Zig to 0.16.0 for Xcode 26.4

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -23,7 +23,7 @@ env:
   MICROKIT_VERSION: 2.2.0
   MICROKIT_URL: https://github.com/seL4/microkit/releases/download/2.2.0/
   SDFGEN_VERSION: 0.29.0
-  ZIG_VERSION: 0.15.1
+  ZIG_VERSION: 0.16.0
 
 jobs:
   build_linux_x86_64:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ name: PR
 on: [pull_request]
 
 env:
-  ZIG_VERSION: 0.15.1
+  ZIG_VERSION: 0.16.0
 
 jobs:
   whitespace:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ website [here](https://trustworthy.systems/projects/drivers/).
 
 sDDF is primarily compiled via Makefiles, but the [Zig](https://ziglang.org)
 build system is also available. If you are intending on using Zig instead of
-Make, please see https://ziglang.org/download/.
+Make, please see https://ziglang.org/download/. The version to use is 0.16.0.
 
 See the instructions below for installing the rest of the dependencies based on
 your machine:

--- a/build.zig
+++ b/build.zig
@@ -147,14 +147,14 @@ fn addSerialDriver(
     };
     const source = b.fmt("drivers/serial/{s}/{s}", .{ @tagName(class), source_name });
     const driver_include = b.fmt("drivers/serial/{s}/include", .{@tagName(class)});
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path(source),
     });
-    driver.addIncludePath(b.path("include"));
-    driver.addIncludePath(b.path("include/sddf/util/custom_libc"));
-    driver.addIncludePath(b.path("include/microkit"));
-    driver.addIncludePath(b.path(driver_include));
-    driver.linkLibrary(util);
+    driver.root_module.addIncludePath(b.path("include"));
+    driver.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+    driver.root_module.addIncludePath(b.path("include/microkit"));
+    driver.root_module.addIncludePath(b.path(driver_include));
+    driver.root_module.linkLibrary(util);
 
     return driver;
 }
@@ -175,13 +175,13 @@ fn addTimerDriver(
         }),
     });
     const source = b.fmt("drivers/timer/{s}/timer.c", .{@tagName(class)});
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path(source),
     });
-    driver.addIncludePath(b.path("include"));
-    driver.addIncludePath(b.path("include/sddf/util/custom_libc"));
-    driver.addIncludePath(b.path("include/microkit"));
-    driver.linkLibrary(util);
+    driver.root_module.addIncludePath(b.path("include"));
+    driver.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+    driver.root_module.addIncludePath(b.path("include/microkit"));
+    driver.root_module.linkLibrary(util);
 
     return driver;
 }
@@ -202,18 +202,18 @@ fn addI2cDriverDevice(
             .strip = false,
         }),
     });
-    driver.addIncludePath(libmicrokit_include);
+    driver.root_module.addIncludePath(libmicrokit_include);
     const source = b.fmt("i2c/devices/{s}/{s}.c", .{ @tagName(device), @tagName(device) });
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path(source),
         .flags = &.{"-DLIBI2C_RAW"},
     });
-    driver.addIncludePath(b.path(b.fmt("i2c/devices/{s}/", .{@tagName(device)})));
-    driver.addIncludePath(b.path("include"));
-    driver.addIncludePath(b.path("include/sddf/util/custom_libc"));
-    driver.addIncludePath(b.path("include/microkit"));
-    driver.linkLibrary(util);
-    driver.addIncludePath(b.path("libco"));
+    driver.root_module.addIncludePath(b.path(b.fmt("i2c/devices/{s}/", .{@tagName(device)})));
+    driver.root_module.addIncludePath(b.path("include"));
+    driver.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+    driver.root_module.addIncludePath(b.path("include/microkit"));
+    driver.root_module.linkLibrary(util);
+    driver.root_module.addIncludePath(b.path("libco"));
 
     return driver;
 }
@@ -234,19 +234,19 @@ fn addI2cDriverHost(
         }),
     });
     const source = b.fmt("drivers/i2c/{s}/i2c.c", .{@tagName(class)});
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path(source),
         // Note: the I2C_BUS_NUM flag is temporary
         .flags = &.{"-DI2C_BUS_NUM=2"},
     });
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path("drivers/i2c/i2c_common.c"),
     });
-    driver.addIncludePath(b.path(b.fmt("drivers/i2c/{s}/", .{@tagName(class)})));
-    driver.addIncludePath(b.path("include"));
-    driver.addIncludePath(b.path("include/sddf/util/custom_libc"));
-    driver.addIncludePath(b.path("include/microkit"));
-    driver.linkLibrary(util);
+    driver.root_module.addIncludePath(b.path(b.fmt("drivers/i2c/{s}/", .{@tagName(class)})));
+    driver.root_module.addIncludePath(b.path("include"));
+    driver.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+    driver.root_module.addIncludePath(b.path("include/microkit"));
+    driver.root_module.linkLibrary(util);
 
     return driver;
 }
@@ -270,10 +270,10 @@ fn addBlockDriver(
     driver.addCSourceFile(.{
         .file = b.path(source),
     });
-    driver.addIncludePath(b.path(b.fmt("drivers/blk/{s}/", .{@tagName(class)})));
-    driver.addIncludePath(b.path("include"));
-    driver.addIncludePath(b.path("include/sddf/util/custom_libc"));
-    driver.addIncludePath(b.path("include/microkit"));
+    driver.root_module.addIncludePath(b.path(b.fmt("drivers/blk/{s}/", .{@tagName(class)})));
+    driver.root_module.addIncludePath(b.path("include"));
+    driver.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+    driver.root_module.addIncludePath(b.path("include/microkit"));
     driver.linkLibrary(util);
 
     return driver;
@@ -295,17 +295,17 @@ fn addVirtioBlockDriver(
         }),
     });
 
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path("drivers/blk/virtio/block.c"),
     });
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path(b.fmt("virtio/transport/{s}.c", .{@tagName(class)})),
     });
-    driver.addIncludePath(b.path(b.fmt("drivers/blk/{s}/", .{@tagName(class)})));
-    driver.addIncludePath(b.path("include"));
-    driver.addIncludePath(b.path("include/sddf/util/custom_libc"));
-    driver.addIncludePath(b.path("include/microkit"));
-    driver.linkLibrary(util);
+    driver.root_module.addIncludePath(b.path(b.fmt("drivers/blk/{s}/", .{@tagName(class)})));
+    driver.root_module.addIncludePath(b.path("include"));
+    driver.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+    driver.root_module.addIncludePath(b.path("include/microkit"));
+    driver.root_module.linkLibrary(util);
 
     return driver;
 }
@@ -325,14 +325,14 @@ fn addNvmeBlockDriver(
             .strip = false,
         }),
     });
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path("drivers/blk/nvme/nvme.c"),
     });
-    driver.addIncludePath(b.path("drivers/blk/nvme"));
-    driver.addIncludePath(b.path("include"));
-    driver.addIncludePath(b.path("include/sddf/util/custom_libc"));
-    driver.addIncludePath(b.path("include/microkit"));
-    driver.linkLibrary(util);
+    driver.root_module.addIncludePath(b.path("drivers/blk/nvme"));
+    driver.root_module.addIncludePath(b.path("include"));
+    driver.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+    driver.root_module.addIncludePath(b.path("include/microkit"));
+    driver.root_module.linkLibrary(util);
 
     return driver;
 }
@@ -353,14 +353,14 @@ fn addMmcDriver(
         }),
     });
     const source = b.fmt("drivers/blk/mmc/{s}/usdhc.c", .{@tagName(class)});
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path(source),
     });
-    driver.addIncludePath(b.path(b.fmt("drivers/blk/mmc/{s}/", .{@tagName(class)})));
-    driver.addIncludePath(b.path("include"));
-    driver.addIncludePath(b.path("include/sddf/util/custom_libc"));
-    driver.addIncludePath(b.path("include/microkit"));
-    driver.linkLibrary(util);
+    driver.root_module.addIncludePath(b.path(b.fmt("drivers/blk/mmc/{s}/", .{@tagName(class)})));
+    driver.root_module.addIncludePath(b.path("include"));
+    driver.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+    driver.root_module.addIncludePath(b.path("include/microkit"));
+    driver.root_module.linkLibrary(util);
 
     return driver;
 }
@@ -381,14 +381,14 @@ fn addNetworkDriver(
         }),
     });
     const source = b.fmt("drivers/network/{s}/ethernet.c", .{@tagName(class)});
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path(source),
     });
-    driver.addIncludePath(b.path(b.fmt("drivers/network/{s}/", .{@tagName(class)})));
-    driver.addIncludePath(b.path("include"));
-    driver.addIncludePath(b.path("include/sddf/util/custom_libc"));
-    driver.addIncludePath(b.path("include/microkit"));
-    driver.linkLibrary(util);
+    driver.root_module.addIncludePath(b.path(b.fmt("drivers/network/{s}/", .{@tagName(class)})));
+    driver.root_module.addIncludePath(b.path("include"));
+    driver.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+    driver.root_module.addIncludePath(b.path("include/microkit"));
+    driver.root_module.linkLibrary(util);
 
     return driver;
 }
@@ -409,17 +409,17 @@ fn addVirtioNetworkDriver(
         }),
     });
 
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path("drivers/network/virtio/common/ethernet.c"),
     });
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path(b.fmt("virtio/transport/{s}.c", .{@tagName(class)})),
     });
-    driver.addIncludePath(b.path(b.fmt("drivers/network/{s}/", .{@tagName(class)})));
-    driver.addIncludePath(b.path("include"));
-    driver.addIncludePath(b.path("include/sddf/util/custom_libc"));
-    driver.addIncludePath(b.path("include/microkit"));
-    driver.linkLibrary(util);
+    driver.root_module.addIncludePath(b.path(b.fmt("drivers/network/{s}/", .{@tagName(class)})));
+    driver.root_module.addIncludePath(b.path("include"));
+    driver.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+    driver.root_module.addIncludePath(b.path("include/microkit"));
+    driver.root_module.linkLibrary(util);
 
     return driver;
 }
@@ -441,24 +441,24 @@ fn addGpuDriver(
         }),
     });
     const source = b.fmt("drivers/gpu/{s}/gpu.c", .{@tagName(class)});
-    driver.addCSourceFile(.{
+    driver.root_module.addCSourceFile(.{
         .file = b.path(source),
     });
-    driver.addIncludePath(gpu_config_include);
-    driver.addIncludePath(b.path(b.fmt("drivers/gpu/{s}/", .{@tagName(class)})));
-    driver.addIncludePath(b.path("include"));
-    driver.addIncludePath(b.path("include/sddf/util/custom_libc"));
-    driver.addIncludePath(b.path("include/microkit"));
-    driver.linkLibrary(util);
+    driver.root_module.addIncludePath(gpu_config_include);
+    driver.root_module.addIncludePath(b.path(b.fmt("drivers/gpu/{s}/", .{@tagName(class)})));
+    driver.root_module.addIncludePath(b.path("include"));
+    driver.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+    driver.root_module.addIncludePath(b.path("include/microkit"));
+    driver.root_module.linkLibrary(util);
 
     return driver;
 }
 
 fn addPd(b: *std.Build, options: std.Build.ExecutableOptions) *std.Build.Step.Compile {
     const pd = b.addExecutable(options);
-    pd.addObjectFile(libmicrokit);
+    pd.root_module.addObjectFile(libmicrokit);
     pd.setLinkerScript(libmicrokit_linker_script);
-    pd.addIncludePath(libmicrokit_include);
+    pd.root_module.addIncludePath(libmicrokit_include);
 
     return pd;
 }
@@ -491,33 +491,33 @@ pub fn build(b: *std.Build) !void {
                 .optimize = optimize,
             }),
         });
-        util.addCSourceFiles(.{
+        util.root_module.addCSourceFiles(.{
             .files = &util_src,
         });
         switch (target.result.cpu.arch) {
             .aarch64 => {
-                util.addCSourceFiles(.{
+                util.root_module.addCSourceFiles(.{
                     .files = &util_src_aarch64,
                 });
             },
             .riscv64 => {
-                util.addCSourceFiles(.{
+                util.root_module.addCSourceFiles(.{
                     .files = &util_src_riscv64,
                 });
-                util.addIncludePath(b.path("util/custom_libc/riscv64"));
+                util.root_module.addIncludePath(b.path("util/custom_libc/riscv64"));
             },
             .x86_64 => {
-                util.addCSourceFiles(.{
+                util.root_module.addCSourceFiles(.{
                     .files = &util_src_x86_64,
                 });
-                util.addIncludePath(b.path("util/custom_libc/x86_64"));
+                util.root_module.addIncludePath(b.path("util/custom_libc/x86_64"));
             },
             else => unreachable,
         }
-        util.addIncludePath(b.path("include"));
-        util.addIncludePath(b.path("include/sddf/util/custom_libc"));
-        util.addIncludePath(b.path("include/microkit"));
-        util.addIncludePath(libmicrokit_include);
+        util.root_module.addIncludePath(b.path("include"));
+        util.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+        util.root_module.addIncludePath(b.path("include/microkit"));
+        util.root_module.addIncludePath(libmicrokit_include);
         util.installHeadersDirectory(b.path("include"), "", .{});
         util.installHeadersDirectory(b.path("include/sddf/util/custom_libc"), "", .{});
         b.installArtifact(util);
@@ -530,13 +530,13 @@ pub fn build(b: *std.Build) !void {
                 .optimize = optimize,
             }),
         });
-        util_putchar_serial.addCSourceFiles(.{
+        util_putchar_serial.root_module.addCSourceFiles(.{
             .files = &util_putchar_serial_src,
         });
-        util_putchar_serial.addIncludePath(b.path("include"));
-        util_putchar_serial.addIncludePath(b.path("include/sddf/util/custom_libc"));
-        util_putchar_serial.addIncludePath(b.path("include/microkit"));
-        util_putchar_serial.addIncludePath(libmicrokit_include);
+        util_putchar_serial.root_module.addIncludePath(b.path("include"));
+        util_putchar_serial.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+        util_putchar_serial.root_module.addIncludePath(b.path("include/microkit"));
+        util_putchar_serial.root_module.addIncludePath(libmicrokit_include);
         util_putchar_serial.installHeadersDirectory(b.path("include"), "", .{});
         util_putchar_serial.installHeadersDirectory(b.path("include/sddf/util/custom_libc"), "", .{});
         b.installArtifact(util_putchar_serial);
@@ -549,13 +549,13 @@ pub fn build(b: *std.Build) !void {
                 .optimize = optimize,
             }),
         });
-        util_putchar_debug.addCSourceFiles(.{
+        util_putchar_debug.root_module.addCSourceFiles(.{
             .files = &util_putchar_debug_src,
         });
-        util_putchar_debug.addIncludePath(b.path("include"));
-        util_putchar_debug.addIncludePath(b.path("include/sddf/util/custom_libc"));
-        util_putchar_debug.addIncludePath(b.path("include/microkit"));
-        util_putchar_debug.addIncludePath(libmicrokit_include);
+        util_putchar_debug.root_module.addIncludePath(b.path("include"));
+        util_putchar_debug.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+        util_putchar_debug.root_module.addIncludePath(b.path("include/microkit"));
+        util_putchar_debug.root_module.addIncludePath(libmicrokit_include);
         util_putchar_debug.installHeadersDirectory(b.path("include"), "", .{});
         util_putchar_debug.installHeadersDirectory(b.path("include/sddf/util/custom_libc"), "", .{});
         b.installArtifact(util_putchar_debug);
@@ -569,35 +569,35 @@ pub fn build(b: *std.Build) !void {
                 .strip = false,
             }),
         });
-        blk_virt.addCSourceFiles(.{
+        blk_virt.root_module.addCSourceFiles(.{
             .files = &.{ "blk/components/virt.c", "blk/components/partitioning.c" },
         });
-        blk_virt.addIncludePath(b.path("include"));
-        blk_virt.addIncludePath(b.path("include/sddf/util/custom_libc"));
-        blk_virt.addIncludePath(b.path("include/microkit"));
-        blk_virt.linkLibrary(util);
-        blk_virt.linkLibrary(util_putchar_debug);
+        blk_virt.root_module.addIncludePath(b.path("include"));
+        blk_virt.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+        blk_virt.root_module.addIncludePath(b.path("include/microkit"));
+        blk_virt.root_module.linkLibrary(util);
+        blk_virt.root_module.linkLibrary(util_putchar_debug);
         b.installArtifact(blk_virt);
 
         // Block drivers
         inline for (std.meta.fields(DriverClass.Block)) |class| {
             const driver = addBlockDriver(b, util, @enumFromInt(class.value), target, optimize);
-            driver.linkLibrary(util_putchar_debug);
+            driver.root_module.linkLibrary(util_putchar_debug);
             b.installArtifact(driver);
         }
         inline for (std.meta.fields(DriverClass.Mmc)) |class| {
             const driver = addMmcDriver(b, util, @enumFromInt(class.value), target, optimize);
-            driver.linkLibrary(util_putchar_debug);
+            driver.root_module.linkLibrary(util_putchar_debug);
             b.installArtifact(driver);
         }
         inline for (std.meta.fields(DriverClass.Block.Virtio)) |class| {
             const driver = addVirtioBlockDriver(b, util, @enumFromInt(class.value), target, optimize);
-            driver.linkLibrary(util_putchar_debug);
+            driver.root_module.linkLibrary(util_putchar_debug);
             b.installArtifact(driver);
         }
         inline for (std.meta.fields(DriverClass.Block.Nvme)) |class| {
             const driver = addNvmeBlockDriver(b, util, @enumFromInt(class.value), target, optimize);
-            driver.linkLibrary(util_putchar_debug);
+            driver.root_module.linkLibrary(util_putchar_debug);
             b.installArtifact(driver);
         }
 
@@ -610,14 +610,14 @@ pub fn build(b: *std.Build) !void {
                 .strip = false,
             }),
         });
-        serial_virt_rx.addCSourceFile(.{
+        serial_virt_rx.root_module.addCSourceFile(.{
             .file = b.path("serial/components/virt_rx.c"),
         });
-        serial_virt_rx.addIncludePath(b.path("include"));
-        serial_virt_rx.addIncludePath(b.path("include/sddf/util/custom_libc"));
-        serial_virt_rx.addIncludePath(b.path("include/microkit"));
-        serial_virt_rx.linkLibrary(util);
-        serial_virt_rx.linkLibrary(util_putchar_debug);
+        serial_virt_rx.root_module.addIncludePath(b.path("include"));
+        serial_virt_rx.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+        serial_virt_rx.root_module.addIncludePath(b.path("include/microkit"));
+        serial_virt_rx.root_module.linkLibrary(util);
+        serial_virt_rx.root_module.linkLibrary(util_putchar_debug);
         b.installArtifact(serial_virt_rx);
 
         const serial_virt_tx = addPd(b, .{
@@ -628,20 +628,20 @@ pub fn build(b: *std.Build) !void {
                 .strip = false,
             }),
         });
-        serial_virt_tx.addCSourceFile(.{
+        serial_virt_tx.root_module.addCSourceFile(.{
             .file = b.path("serial/components/virt_tx.c"),
         });
-        serial_virt_tx.addIncludePath(b.path("include"));
-        serial_virt_tx.addIncludePath(b.path("include/sddf/util/custom_libc"));
-        serial_virt_tx.addIncludePath(b.path("include/microkit"));
-        serial_virt_tx.linkLibrary(util);
-        serial_virt_tx.linkLibrary(util_putchar_debug);
+        serial_virt_tx.root_module.addIncludePath(b.path("include"));
+        serial_virt_tx.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+        serial_virt_tx.root_module.addIncludePath(b.path("include/microkit"));
+        serial_virt_tx.root_module.linkLibrary(util);
+        serial_virt_tx.root_module.linkLibrary(util_putchar_debug);
         b.installArtifact(serial_virt_tx);
 
         // Serial drivers
         inline for (std.meta.fields(DriverClass.Serial)) |class| {
             const driver = addSerialDriver(b, util, @enumFromInt(class.value), target, optimize);
-            driver.linkLibrary(util_putchar_debug);
+            driver.root_module.linkLibrary(util_putchar_debug);
             b.installArtifact(driver);
         }
 
@@ -654,28 +654,28 @@ pub fn build(b: *std.Build) !void {
                 .strip = false,
             }),
         });
-        gpu_virt.addCSourceFile(.{
+        gpu_virt.root_module.addCSourceFile(.{
             .file = b.path("gpu/components/virt.c"),
         });
-        gpu_virt.addIncludePath(gpu_config_include);
-        gpu_virt.addIncludePath(b.path("include"));
-        gpu_virt.addIncludePath(b.path("include/sddf/util/custom_libc"));
-        gpu_virt.addIncludePath(b.path("include/microkit"));
-        gpu_virt.linkLibrary(util);
-        gpu_virt.linkLibrary(util_putchar_debug);
+        gpu_virt.root_module.addIncludePath(gpu_config_include);
+        gpu_virt.root_module.addIncludePath(b.path("include"));
+        gpu_virt.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+        gpu_virt.root_module.addIncludePath(b.path("include/microkit"));
+        gpu_virt.root_module.linkLibrary(util);
+        gpu_virt.root_module.linkLibrary(util_putchar_debug);
         b.installArtifact(gpu_virt);
 
         // Gpu drivers
         inline for (std.meta.fields(DriverClass.Gpu)) |class| {
             const driver = addGpuDriver(b, gpu_config_include, util, @enumFromInt(class.value), target, optimize);
-            driver.linkLibrary(util_putchar_debug);
+            driver.root_module.linkLibrary(util_putchar_debug);
             b.installArtifact(driver);
         }
 
         // Timer drivers
         inline for (std.meta.fields(DriverClass.Timer)) |class| {
             const driver = addTimerDriver(b, util, @enumFromInt(class.value), target, optimize);
-            driver.linkLibrary(util_putchar_debug);
+            driver.root_module.linkLibrary(util_putchar_debug);
             b.installArtifact(driver);
         }
 
@@ -687,16 +687,16 @@ pub fn build(b: *std.Build) !void {
                 .optimize = optimize,
             }),
         });
-        libi2c_raw.addCSourceFile(.{
+        libi2c_raw.root_module.addCSourceFile(.{
             .file = b.path("i2c/libi2c.c"),
             .flags = &.{"-DLIBI2C_RAW"},
         });
-        libi2c_raw.addIncludePath(b.path("include"));
-        libi2c_raw.addIncludePath(b.path("include/sddf/util/custom_libc"));
-        libi2c_raw.addIncludePath(b.path("include/microkit"));
-        libi2c_raw.addIncludePath(b.path("libco"));
-        libi2c_raw.addIncludePath(libmicrokit_include);
-        libi2c_raw.linkLibrary(util);
+        libi2c_raw.root_module.addIncludePath(b.path("include"));
+        libi2c_raw.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+        libi2c_raw.root_module.addIncludePath(b.path("include/microkit"));
+        libi2c_raw.root_module.addIncludePath(b.path("libco"));
+        libi2c_raw.root_module.addIncludePath(libmicrokit_include);
+        libi2c_raw.root_module.linkLibrary(util);
         b.installArtifact(libi2c_raw);
 
         // I2C components
@@ -708,38 +708,38 @@ pub fn build(b: *std.Build) !void {
                 .strip = false,
             }),
         });
-        i2c_virt.addCSourceFile(.{
+        i2c_virt.root_module.addCSourceFile(.{
             .file = b.path("i2c/components/virt.c"),
         });
-        i2c_virt.addIncludePath(b.path("include"));
-        i2c_virt.addIncludePath(b.path("include/sddf/util/custom_libc"));
-        i2c_virt.addIncludePath(b.path("include/microkit"));
-        i2c_virt.linkLibrary(util);
-        i2c_virt.linkLibrary(util_putchar_debug);
+        i2c_virt.root_module.addIncludePath(b.path("include"));
+        i2c_virt.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+        i2c_virt.root_module.addIncludePath(b.path("include/microkit"));
+        i2c_virt.root_module.linkLibrary(util);
+        i2c_virt.root_module.linkLibrary(util_putchar_debug);
         b.installArtifact(i2c_virt);
 
         // I2C drivers
         inline for (std.meta.fields(DriverClass.I2cHost)) |class| {
             const driver = addI2cDriverHost(b, util, @enumFromInt(class.value), target, optimize);
-            driver.linkLibrary(util_putchar_debug);
+            driver.root_module.linkLibrary(util_putchar_debug);
             b.installArtifact(driver);
         }
 
         inline for (std.meta.fields(DriverClass.I2cDevice)) |device| {
             const driver = addI2cDriverDevice(b, util, @enumFromInt(device.value), target, optimize);
-            driver.linkLibrary(util_putchar_debug);
+            driver.root_module.linkLibrary(util_putchar_debug);
             b.installArtifact(driver);
         }
 
         // Network drivers
         inline for (std.meta.fields(DriverClass.Network)) |class| {
             const driver = addNetworkDriver(b, util, @enumFromInt(class.value), target, optimize);
-            driver.linkLibrary(util_putchar_debug);
+            driver.root_module.linkLibrary(util_putchar_debug);
             b.installArtifact(driver);
         }
         inline for (std.meta.fields(DriverClass.Network.Virtio)) |class| {
             const driver = addVirtioNetworkDriver(b, util, @enumFromInt(class.value), target, optimize);
-            driver.linkLibrary(util_putchar_debug);
+            driver.root_module.linkLibrary(util_putchar_debug);
             b.installArtifact(driver);
         }
 
@@ -752,14 +752,14 @@ pub fn build(b: *std.Build) !void {
                 .strip = false,
             }),
         });
-        net_virt_rx.addCSourceFile(.{
+        net_virt_rx.root_module.addCSourceFile(.{
             .file = b.path("network/components/virt_rx.c"),
         });
-        net_virt_rx.addIncludePath(b.path("include"));
-        net_virt_rx.addIncludePath(b.path("include/sddf/util/custom_libc"));
-        net_virt_rx.addIncludePath(b.path("include/microkit"));
-        net_virt_rx.linkLibrary(util);
-        net_virt_rx.linkLibrary(util_putchar_debug);
+        net_virt_rx.root_module.addIncludePath(b.path("include"));
+        net_virt_rx.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+        net_virt_rx.root_module.addIncludePath(b.path("include/microkit"));
+        net_virt_rx.root_module.linkLibrary(util);
+        net_virt_rx.root_module.linkLibrary(util_putchar_debug);
         b.installArtifact(net_virt_rx);
 
         const net_virt_tx = addPd(b, .{
@@ -770,14 +770,14 @@ pub fn build(b: *std.Build) !void {
                 .strip = false,
             }),
         });
-        net_virt_tx.addCSourceFile(.{
+        net_virt_tx.root_module.addCSourceFile(.{
             .file = b.path("network/components/virt_tx.c"),
         });
-        net_virt_tx.addIncludePath(b.path("include"));
-        net_virt_tx.addIncludePath(b.path("include/sddf/util/custom_libc"));
-        net_virt_tx.addIncludePath(b.path("include/microkit"));
-        net_virt_tx.linkLibrary(util);
-        net_virt_tx.linkLibrary(util_putchar_debug);
+        net_virt_tx.root_module.addIncludePath(b.path("include"));
+        net_virt_tx.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+        net_virt_tx.root_module.addIncludePath(b.path("include/microkit"));
+        net_virt_tx.root_module.linkLibrary(util);
+        net_virt_tx.root_module.linkLibrary(util_putchar_debug);
         b.installArtifact(net_virt_tx);
 
         const net_copy = addPd(b, .{
@@ -788,14 +788,14 @@ pub fn build(b: *std.Build) !void {
                 .strip = false,
             }),
         });
-        net_copy.addCSourceFile(.{
+        net_copy.root_module.addCSourceFile(.{
             .file = b.path("network/components/copy.c"),
         });
-        net_copy.addIncludePath(b.path("include"));
-        net_copy.addIncludePath(b.path("include/sddf/util/custom_libc"));
-        net_copy.addIncludePath(b.path("include/microkit"));
-        net_copy.linkLibrary(util);
-        net_copy.linkLibrary(util_putchar_debug);
+        net_copy.root_module.addIncludePath(b.path("include"));
+        net_copy.root_module.addIncludePath(b.path("include/sddf/util/custom_libc"));
+        net_copy.root_module.addIncludePath(b.path("include/microkit"));
+        net_copy.root_module.linkLibrary(util);
+        net_copy.root_module.linkLibrary(util_putchar_debug);
         b.installArtifact(net_copy);
     }
 }

--- a/ci/build.py
+++ b/ci/build.py
@@ -59,19 +59,24 @@ def build_zig(args: argparse.Namespace, test_config: common.TestConfig):
     }
     zig_optimize = zig_optimize_table[test_config.config]
 
+    zig_cmd = [
+        "zig",
+        "build",
+        f"-Dsdk={args.microkit_sdk}",
+        f"-Dboard={test_config.board}",
+        f"-Dconfig={test_config.config}",
+        f"-Doptimize={zig_optimize}",
+        "-p",
+        build_dir,
+        f"-j{args.num_jobs}",
+    ]
+
+    if "PYTHON" in os.environ:
+        zig_cmd.append(f"-Dpython={os.getenv('PYTHON')}")
+
     with contextlib.chdir(example_dir):
         subprocess.run(
-            [
-                "zig",
-                "build",
-                f"-Dsdk={args.microkit_sdk}",
-                f"-Dboard={test_config.board}",
-                f"-Dconfig={test_config.config}",
-                f"-Doptimize={zig_optimize}",
-                "-p",
-                build_dir,
-                f"-j{args.num_jobs}",
-            ],
+            zig_cmd,
             check=True,
             env=zig_env,
         )

--- a/examples/blk/build.zig
+++ b/examples/blk/build.zig
@@ -67,7 +67,7 @@ fn findTarget(board: MicrokitBoard) std.Target.Query {
     }
 
     std.log.err("Board '{}' is not supported\n", .{board});
-    std.posix.exit(1);
+    std.process.exit(1);
 }
 
 const ConfigOptions = enum { debug, release, benchmark };
@@ -90,7 +90,7 @@ fn updateSectionObjcopy(b: *std.Build, section: []const u8, data_output: std.Bui
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
-    const default_python = if (std.posix.getenv("PYTHON")) |p| p else "python3";
+    const default_python = "python3";
     const python = b.option([]const u8, "python", "Path to Python to use") orelse default_python;
 
     const partition = b.option(usize, "partition", "Block device partition for client to use") orelse null;
@@ -161,17 +161,17 @@ pub fn build(b: *std.Build) !void {
         }),
     });
 
-    client.addCSourceFiles(.{
+    client.root_module.addCSourceFiles(.{
         .files = &.{"client.c"},
     });
 
-    client.addIncludePath(sddf_dep.path("include"));
-    client.addIncludePath(sddf_dep.path("include/microkit"));
-    client.linkLibrary(sddf_dep.artifact("util"));
-    client.linkLibrary(sddf_dep.artifact("util_putchar_serial"));
+    client.root_module.addIncludePath(sddf_dep.path("include"));
+    client.root_module.addIncludePath(sddf_dep.path("include/microkit"));
+    client.root_module.linkLibrary(sddf_dep.artifact("util"));
+    client.root_module.linkLibrary(sddf_dep.artifact("util_putchar_serial"));
 
-    client.addIncludePath(libmicrokit_include);
-    client.addObjectFile(libmicrokit);
+    client.root_module.addIncludePath(libmicrokit_include);
+    client.root_module.addObjectFile(libmicrokit);
     client.setLinkerScript(libmicrokit_linker_script);
 
     const blk_driver = sddf_dep.artifact(b.fmt("driver_blk_{s}.elf", .{blk_driver_class}));
@@ -194,7 +194,7 @@ pub fn build(b: *std.Build) !void {
             const dtc_cmd = b.addSystemCommand(&[_][]const u8{ "dtc", "-q", "-I", "dts", "-O", "dtb" });
             dtc_cmd.addFileInput(dts);
             dtc_cmd.addFileArg(dts);
-            break :blk dtc_cmd.captureStdOut();
+            break :blk dtc_cmd.captureStdOut(.{});
         } else {
             break :blk null;
         }

--- a/examples/i2c/build.zig
+++ b/examples/i2c/build.zig
@@ -34,7 +34,7 @@ fn findTarget(board: MicrokitBoard) std.Target.Query {
     }
 
     std.log.err("Board '{}' is not supported\n", .{board});
-    std.posix.exit(1);
+    std.process.exit(1);
 }
 
 const ConfigOptions = enum { debug, release, benchmark };
@@ -57,7 +57,7 @@ fn updateSectionObjcopy(b: *std.Build, section: []const u8, data_output: std.Bui
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
-    const default_python = if (std.posix.getenv("PYTHON")) |p| p else "python3";
+    const default_python = "python3";
     const python = b.option([]const u8, "python", "Path to Python to use") orelse default_python;
 
     const microkit_sdk = b.option(LazyPath, "sdk", "Path to Microkit SDK") orelse {
@@ -126,16 +126,16 @@ pub fn build(b: *std.Build) !void {
         }),
     });
 
-    client_pn532.addCSourceFiles(.{
+    client_pn532.root_module.addCSourceFiles(.{
         .files = &.{"client_pn532.c"},
         .flags = &.{"-DLIBI2C_RAW"},
     });
-    client_pn532.addIncludePath(sddf_dep.path("include"));
-    client_pn532.addIncludePath(sddf_dep.path("include/microkit"));
-    client_pn532.linkLibrary(sddf_dep.artifact("util"));
-    client_pn532.linkLibrary(sddf_dep.artifact("util_putchar_serial"));
-    client_pn532.linkLibrary(pn532_driver);
-    client_pn532.linkLibrary(sddf_dep.artifact("libi2c_raw"));
+    client_pn532.root_module.addIncludePath(sddf_dep.path("include"));
+    client_pn532.root_module.addIncludePath(sddf_dep.path("include/microkit"));
+    client_pn532.root_module.linkLibrary(sddf_dep.artifact("util"));
+    client_pn532.root_module.linkLibrary(sddf_dep.artifact("util_putchar_serial"));
+    client_pn532.root_module.linkLibrary(pn532_driver);
+    client_pn532.root_module.linkLibrary(sddf_dep.artifact("libi2c_raw"));
 
     const client_ds3231 = b.addExecutable(.{
         .name = "client_ds3231.elf",
@@ -146,31 +146,31 @@ pub fn build(b: *std.Build) !void {
         }),
     });
 
-    client_ds3231.addCSourceFiles(.{
+    client_ds3231.root_module.addCSourceFiles(.{
         .files = &.{"client_ds3231.c"},
         .flags = &.{"-DLIBI2C_RAW"},
     });
-    client_ds3231.addIncludePath(sddf_dep.path("include"));
-    client_ds3231.addIncludePath(sddf_dep.path("include/microkit"));
-    client_ds3231.linkLibrary(sddf_dep.artifact("util"));
-    client_ds3231.linkLibrary(sddf_dep.artifact("util_putchar_serial"));
-    client_ds3231.linkLibrary(ds3231_driver);
-    client_ds3231.linkLibrary(sddf_dep.artifact("libi2c_raw"));
+    client_ds3231.root_module.addIncludePath(sddf_dep.path("include"));
+    client_ds3231.root_module.addIncludePath(sddf_dep.path("include/microkit"));
+    client_ds3231.root_module.linkLibrary(sddf_dep.artifact("util"));
+    client_ds3231.root_module.linkLibrary(sddf_dep.artifact("util_putchar_serial"));
+    client_ds3231.root_module.linkLibrary(ds3231_driver);
+    client_ds3231.root_module.linkLibrary(sddf_dep.artifact("libi2c_raw"));
 
     // Here we compile libco. Right now this is the only example that uses libco and so
     // we just compile it here instead of in a separate build.zig
-    client_pn532.addIncludePath(sddf_dep.path("libco"));
-    client_pn532.addCSourceFile(.{ .file = sddf_dep.path("libco/libco.c") });
+    client_pn532.root_module.addIncludePath(sddf_dep.path("libco"));
+    client_pn532.root_module.addCSourceFile(.{ .file = sddf_dep.path("libco/libco.c") });
 
-    client_pn532.addIncludePath(libmicrokit_include);
-    client_pn532.addObjectFile(libmicrokit);
+    client_pn532.root_module.addIncludePath(libmicrokit_include);
+    client_pn532.root_module.addObjectFile(libmicrokit);
     client_pn532.setLinkerScript(libmicrokit_linker_script);
 
-    client_ds3231.addIncludePath(sddf_dep.path("libco"));
-    client_ds3231.addCSourceFile(.{ .file = sddf_dep.path("libco/libco.c") });
+    client_ds3231.root_module.addIncludePath(sddf_dep.path("libco"));
+    client_ds3231.root_module.addCSourceFile(.{ .file = sddf_dep.path("libco/libco.c") });
 
-    client_ds3231.addIncludePath(libmicrokit_include);
-    client_ds3231.addObjectFile(libmicrokit);
+    client_ds3231.root_module.addIncludePath(libmicrokit_include);
+    client_ds3231.root_module.addObjectFile(libmicrokit);
     client_ds3231.setLinkerScript(libmicrokit_linker_script);
 
     b.installArtifact(client_pn532);
@@ -183,7 +183,7 @@ pub fn build(b: *std.Build) !void {
     const dtc_cmd = b.addSystemCommand(&[_][]const u8{ "dtc", "-q", "-I", "dts", "-O", "dtb" });
     dtc_cmd.addFileInput(dts);
     dtc_cmd.addFileArg(dts);
-    const dtb = dtc_cmd.captureStdOut();
+    const dtb = dtc_cmd.captureStdOut(.{});
 
     // Run the metaprogram to get sDDF configuration binary files and the SDF file.
     const metaprogram = b.path("meta.py");

--- a/examples/i2c_bus_scan/build.zig
+++ b/examples/i2c_bus_scan/build.zig
@@ -43,7 +43,7 @@ fn findTarget(board: MicrokitBoard) std.Target.Query {
     }
 
     std.log.err("Board '{}' is not supported\n", .{board});
-    std.posix.exit(1);
+    std.process.exit(1);
 }
 
 const ConfigOptions = enum { debug, release, benchmark };
@@ -66,7 +66,7 @@ fn updateSectionObjcopy(b: *std.Build, section: []const u8, data_output: std.Bui
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
-    const default_python = if (std.posix.getenv("PYTHON")) |p| p else "python3";
+    const default_python = "python3";
     const python = b.option([]const u8, "python", "Path to Python to use") orelse default_python;
 
     const microkit_sdk = b.option(LazyPath, "sdk", "Path to Microkit SDK") orelse {
@@ -135,23 +135,23 @@ pub fn build(b: *std.Build) !void {
         }),
     });
 
-    client_scan.addCSourceFiles(.{
+    client_scan.root_module.addCSourceFiles(.{
         .files = &.{"client_scan.c"},
         .flags = &.{"-DLIBI2C_RAW"},
     });
-    client_scan.addIncludePath(sddf_dep.path("include"));
-    client_scan.addIncludePath(sddf_dep.path("include/microkit"));
-    client_scan.linkLibrary(sddf_dep.artifact("util"));
-    client_scan.linkLibrary(sddf_dep.artifact("util_putchar_serial"));
-    client_scan.linkLibrary(sddf_dep.artifact("libi2c_raw"));
+    client_scan.root_module.addIncludePath(sddf_dep.path("include"));
+    client_scan.root_module.addIncludePath(sddf_dep.path("include/microkit"));
+    client_scan.root_module.linkLibrary(sddf_dep.artifact("util"));
+    client_scan.root_module.linkLibrary(sddf_dep.artifact("util_putchar_serial"));
+    client_scan.root_module.linkLibrary(sddf_dep.artifact("libi2c_raw"));
 
     // Here we compile libco. Right now this is the only example that uses libco and so
     // we just compile it here instead of in a separate build.zig
-    client_scan.addIncludePath(sddf_dep.path("libco"));
-    client_scan.addCSourceFile(.{ .file = sddf_dep.path("libco/libco.c") });
+    client_scan.root_module.addIncludePath(sddf_dep.path("libco"));
+    client_scan.root_module.addCSourceFile(.{ .file = sddf_dep.path("libco/libco.c") });
 
-    client_scan.addIncludePath(libmicrokit_include);
-    client_scan.addObjectFile(libmicrokit);
+    client_scan.root_module.addIncludePath(libmicrokit_include);
+    client_scan.root_module.addObjectFile(libmicrokit);
     client_scan.setLinkerScript(libmicrokit_linker_script);
 
     b.installArtifact(client_scan);
@@ -163,7 +163,7 @@ pub fn build(b: *std.Build) !void {
     const dtc_cmd = b.addSystemCommand(&[_][]const u8{ "dtc", "-q", "-I", "dts", "-O", "dtb" });
     dtc_cmd.addFileInput(dts);
     dtc_cmd.addFileArg(dts);
-    const dtb = dtc_cmd.captureStdOut();
+    const dtb = dtc_cmd.captureStdOut(.{});
 
     // Run the metaprogram to get sDDF configuration binary files and the SDF file.
     const metaprogram = b.path("meta.py");

--- a/examples/serial/build.zig
+++ b/examples/serial/build.zig
@@ -206,7 +206,7 @@ fn findTarget(board: MicrokitBoard) std.Target.Query {
     }
 
     std.log.err("Board '{}' is not supported\n", .{board});
-    std.posix.exit(1);
+    std.process.exit(1);
 }
 
 const ConfigOptions = enum { debug, release, benchmark };
@@ -229,7 +229,7 @@ fn updateSectionObjcopy(b: *std.Build, section: []const u8, data_output: std.Bui
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
-    const default_python = if (std.posix.getenv("PYTHON")) |p| p else "python3";
+    const default_python = "python3";
     const python = b.option([]const u8, "python", "Path to Python to use") orelse default_python;
 
     const microkit_sdk = b.option(LazyPath, "sdk", "Path to Microkit SDK") orelse {
@@ -291,14 +291,14 @@ pub fn build(b: *std.Build) !void {
     const client1_install = b.addInstallArtifact(client, .{ .dest_sub_path = "client0.elf" });
     const client2_install = b.addInstallArtifact(client, .{ .dest_sub_path = "client1.elf" });
 
-    client.addCSourceFile(.{ .file = b.path("client.c") });
-    client.addIncludePath(sddf_dep.path("include"));
-    client.addIncludePath(sddf_dep.path("include/microkit"));
-    client.linkLibrary(sddf_dep.artifact("util"));
-    client.linkLibrary(sddf_dep.artifact("util_putchar_serial"));
+    client.root_module.addCSourceFile(.{ .file = b.path("client.c") });
+    client.root_module.addIncludePath(sddf_dep.path("include"));
+    client.root_module.addIncludePath(sddf_dep.path("include/microkit"));
+    client.root_module.linkLibrary(sddf_dep.artifact("util"));
+    client.root_module.linkLibrary(sddf_dep.artifact("util_putchar_serial"));
 
-    client.addIncludePath(libmicrokit_include);
-    client.addObjectFile(libmicrokit);
+    client.root_module.addIncludePath(libmicrokit_include);
+    client.root_module.addObjectFile(libmicrokit);
     client.setLinkerScript(libmicrokit_linker_script);
 
     b.installArtifact(client);
@@ -310,7 +310,7 @@ pub fn build(b: *std.Build) !void {
             const dtc_cmd = b.addSystemCommand(&[_][]const u8{ "dtc", "-q", "-I", "dts", "-O", "dtb" });
             dtc_cmd.addFileInput(dts);
             dtc_cmd.addFileArg(dts);
-            break :blk dtc_cmd.captureStdOut();
+            break :blk dtc_cmd.captureStdOut(.{});
         } else {
             break :blk null;
         }

--- a/examples/timer/build.zig
+++ b/examples/timer/build.zig
@@ -186,7 +186,7 @@ fn findTarget(board: MicrokitBoard) std.Target.Query {
     }
 
     std.log.err("Board '{}' is not supported\n", .{board});
-    std.posix.exit(1);
+    std.process.exit(1);
 }
 
 const ConfigOptions = enum { debug, release, benchmark };
@@ -209,7 +209,7 @@ fn updateSectionObjcopy(b: *std.Build, section: []const u8, data_output: std.Bui
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
-    const default_python = if (std.posix.getenv("PYTHON")) |p| p else "python3";
+    const default_python = "python3";
     const python = b.option([]const u8, "python", "Path to Python to use") orelse default_python;
 
     const microkit_sdk = b.option(LazyPath, "sdk", "Path to Microkit SDK") orelse {
@@ -267,14 +267,14 @@ pub fn build(b: *std.Build) !void {
         }),
     });
 
-    client.addCSourceFile(.{ .file = b.path("client.c") });
-    client.addIncludePath(sddf_dep.path("include"));
-    client.addIncludePath(sddf_dep.path("include/microkit"));
-    client.linkLibrary(sddf_dep.artifact("util"));
-    client.linkLibrary(sddf_dep.artifact("util_putchar_debug"));
+    client.root_module.addCSourceFile(.{ .file = b.path("client.c") });
+    client.root_module.addIncludePath(sddf_dep.path("include"));
+    client.root_module.addIncludePath(sddf_dep.path("include/microkit"));
+    client.root_module.linkLibrary(sddf_dep.artifact("util"));
+    client.root_module.linkLibrary(sddf_dep.artifact("util_putchar_debug"));
 
-    client.addIncludePath(libmicrokit_include);
-    client.addObjectFile(libmicrokit);
+    client.root_module.addIncludePath(libmicrokit_include);
+    client.root_module.addObjectFile(libmicrokit);
     client.setLinkerScript(libmicrokit_linker_script);
 
     b.installArtifact(client);
@@ -286,7 +286,7 @@ pub fn build(b: *std.Build) !void {
             const dtc_cmd = b.addSystemCommand(&[_][]const u8{ "dtc", "-q", "-I", "dts", "-O", "dtb" });
             dtc_cmd.addFileInput(dts);
             dtc_cmd.addFileArg(dts);
-            break :blk dtc_cmd.captureStdOut();
+            break :blk dtc_cmd.captureStdOut(.{});
         } else {
             break :blk null;
         }

--- a/flake.lock
+++ b/flake.lock
@@ -50,24 +50,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1750838302,
@@ -179,6 +161,7 @@
       }
     },
     "systems_3": {
+      "flake": false,
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -234,17 +217,17 @@
     "zig-overlay_2": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1755909141,
-        "narHash": "sha256-dogbHGpLmwfu0qkM/vntqMYazfi66DXWSQiCR1rxC4M=",
+        "lastModified": 1777251652,
+        "narHash": "sha256-AXcBaF8MdyOxbWmogXyyPwtt/hLXFjop68m1CTnSKBo=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "e010faa4eb9271b81cb6c30c828d972028465deb",
+        "rev": "22d290cf4aff3e0ffbff8339680f1a6dfd750358",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
           };
 
           llvm = pkgs.llvmPackages_18;
-          zig = zig-overlay.packages.${system}."0.15.1";
+          zig = zig-overlay.packages.${system}."0.16.0";
 
           pysdfgen = sdfgen.packages.${system}.pysdfgen.override {
             zig = zig;


### PR DESCRIPTION
If you are on macOS and have updated your Xcode SDK to 26.4, you will see this lovely error when trying to build an example with Zig:
```
error: undefined symbol: __availability_version_check
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/095b8aad870722c63fe34e0b67fc5f9e/libcompiler_rt.a(libcompiler_rt_zcu.o):___isPlatformVersionAtLeast
error: undefined symbol: _abort
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_posix.abort
error: undefined symbol: _arc4random_buf
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_crypto.tlcsprng.tlsCsprngFill
error: undefined symbol: _bzero
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_hash_map.HashMapUnmanaged(usize,*debug.SelfInfo.Module__struct_3886,hash_map.AutoContext(usize),80).initMetadatas
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_hash_map.HashMapUnmanaged([]const u8,u64,hash_map.StringContext,80).initMetadatas
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_hash_map.HashMapUnmanaged([]const u8,debug.SelfInfo.Module__struct_3886.OFileInfo,hash_map.StringContext,80).initMetadatas
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_Build.Watch.FsEvents.wait
    note: referenced 11 more times
error: undefined symbol: _clock_gettime
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_posix.clock_gettime
error: undefined symbol: _dispatch_queue_create
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_Build.Watch.FsEvents.init
error: undefined symbol: _dispatch_semaphore_create
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_Build.Watch.FsEvents.init
error: undefined symbol: _dispatch_semaphore_signal
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_Build.Watch.FsEvents.eventCallback
error: undefined symbol: _dispatch_semaphore_wait
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_Build.Watch.FsEvents.wait
error: undefined symbol: _dispatch_time
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_Build.Watch.FsEvents.wait
error: undefined symbol: _exit
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_posix.exit
error: undefined symbol: _fcopyfile
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_fs.File.Writer.sendFile
error: undefined symbol: _fork
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_posix.fork
error: undefined symbol: _free
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_heap.CAllocator.alignedFree
error: undefined symbol: _getcwd
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_posix.getcwd
error: undefined symbol: _getenv
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_posix.getenvZ
error: undefined symbol: _isatty
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_posix.isatty
error: undefined symbol: _malloc_size
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_heap.CAllocator.alignedAllocSize
error: undefined symbol: _posix_memalign
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_heap.CAllocator.alignedAlloc
error: undefined symbol: _realpath$DARWIN_EXTSN
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_posix.realpathZ
error: undefined symbol: _sigaction
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_posix.sigaction
error: undefined symbol: _sigemptyset
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_posix.sigemptyset
error: undefined symbol: _sysctlbyname
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_posix.sysctlbynameZ
error: undefined symbol: _waitpid
    note: referenced by /Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/zig-cache/o/c2214ab13b2763b270201057d634b09e/build_zcu.o:_posix.waitpid
Traceback (most recent call last):
  File "/Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/./ci/build.py", line 144, in <module>
    build(args, test_config)
    ~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/./ci/build.py", line 102, in build
    build_zig(args, test_config)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/./ci/build.py", line 63, in build_zig
    subprocess.run(
    ~~~~~~~~~~~~~~^
        [
        ^
    ...<11 lines>...
        env=zig_env,
        ^^^^^^^^^^^^
    )
    ^
  File "/opt/homebrew/Cellar/python@3.13/3.13.4/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['zig', 'build', '-Dsdk=/Users/dreamliner787-9/Downloads/microkit-sdk-2.2.0', '-Dboard=maaxboard', '-Dconfig=release', '-Doptimize=ReleaseSafe', '-p', PosixPath('/Users/dreamliner787-9/TS/libvmm_x86/dep/sddf/ci_build/examples/blk/zig/maaxboard/release'), '-j12']' returned non-zero exit status 2.
```

This is because Apple recently changed their internal SDK details as part of the Xcode 26.4 release. Which broke our entire Zig build system, as Zig 0.15.x parses these files directly and is no longer compatible with the latest Xcode SDK.

Updated to Zig 0.16.0 to pull in the upstream parsing fixes.

See https://codeberg.org/ziglang/zig/issues/31658
and https://codeberg.org/ziglang/zig/pulls/31673
for more details