### PR TITLE
benchmark: define PMU events in command

### DIFF
--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -39,15 +39,15 @@ typedef struct {
  * i, see bench.h
  */
 bench_pmu_event_info_t pmu_event_table[] = {
-    {"L1 i-cache misses", SEL4BENCH_EVENT_CACHE_L1I_MISS },
-    {"L1 d-cache misses", SEL4BENCH_EVENT_CACHE_L1D_MISS },
-    {"L1 i-tlb misses", SEL4BENCH_EVENT_TLB_L1I_MISS },
-    {"L1 d-tlb misses", SEL4BENCH_EVENT_TLB_L1D_MISS },
-    {"Instructions", SEL4BENCH_EVENT_EXECUTE_INSTRUCTION },
-    {"Branch mispredictions", SEL4BENCH_EVENT_BRANCH_MISPREDICT },
-    {"CPU cycles", SEL4BENCH_EVENT_CCNT },
-    {"Data memory access", SEL4BENCH_EVENT_MEMORY_ACCESS },
-    {"Overflow counter", SEL4BENCH_EVENT_CHAIN},
+    { "L1 i-cache misses", SEL4BENCH_EVENT_CACHE_L1I_MISS },
+    { "L1 d-cache misses", SEL4BENCH_EVENT_CACHE_L1D_MISS },
+    { "L1 i-tlb misses", SEL4BENCH_EVENT_TLB_L1I_MISS },
+    { "L1 d-tlb misses", SEL4BENCH_EVENT_TLB_L1D_MISS },
+    { "Instructions", SEL4BENCH_EVENT_EXECUTE_INSTRUCTION },
+    { "Branch mispredictions", SEL4BENCH_EVENT_BRANCH_MISPREDICT },
+    { "CPU cycles", SEL4BENCH_EVENT_CCNT },
+    { "Data memory access", SEL4BENCH_EVENT_MEMORY_ACCESS },
+    { "Overflow counter", SEL4BENCH_EVENT_CHAIN },
 };
 
 static char *child_name(uint8_t child_id)
@@ -215,15 +215,14 @@ static void benchmark_stop(void)
     while (i < benchmark_config.num_pmu_events) {
         if (i + 1 < benchmark_config.num_pmu_events && benchmark_config.pmu_events[i + 1] == CHAIN) {
             sddf_printf("%s: %lu\n", pmu_event_table[benchmark_config.pmu_events[i]].event_name,
-                        counter_values[i] + (counter_values[i+1] << 32));
+                        counter_values[i] + (counter_values[i + 1] << 32));
             i += 2;
         } else {
             if (overflow_status & 1 << i) {
                 sddf_printf("%s: Overflow occurred during benchmark, event count is invalid!\n",
-                    pmu_event_table[benchmark_config.pmu_events[i]].event_name);
+                            pmu_event_table[benchmark_config.pmu_events[i]].event_name);
             } else {
-                sddf_printf("%s: %lu\n", pmu_event_table[benchmark_config.pmu_events[i]].event_name,
-                            counter_values[i]);
+                sddf_printf("%s: %lu\n", pmu_event_table[benchmark_config.pmu_events[i]].event_name, counter_values[i]);
             }
             i += 1;
         }

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -168,6 +168,9 @@ static void benchmark_start(void)
 
 #if ENABLE_PMU_EVENTS
     sel4bench_reset_counters();
+    /* Reset the overflow status flag register so we can check for overflows to
+    32-bit counters during the benchmark */
+    PMU_WRITE(PMOVSCLR, 0);
     sel4bench_start_counters(benchmark_bf);
 #endif
 
@@ -202,18 +205,26 @@ static void benchmark_stop(void)
 #if ENABLE_PMU_EVENTS
     sel4bench_get_counters(benchmark_bf, &counter_values[0]);
     sel4bench_stop_counters(benchmark_bf);
+    /* Check the overflow status flag register so we can discard any 32-bit
+    counts which have overflowed */
+    uint64_t overflow_status;
+    PMU_READ(PMOVSCLR, overflow_status);
 
     sddf_printf("{CORE %u: \n", benchmark_config.core);
     uint8_t i = 0;
     while (i < benchmark_config.num_pmu_events) {
-        /* Only even numbered counters can be chained (CHAIN counter must be odd) */
-        if (i + 1 < benchmark_config.num_pmu_events && !(i % 2) && benchmark_config.pmu_events[i + 1] == CHAIN) {
+        if (i + 1 < benchmark_config.num_pmu_events && benchmark_config.pmu_events[i + 1] == CHAIN) {
             sddf_printf("%s: %lu\n", pmu_event_table[benchmark_config.pmu_events[i]].event_name,
                         counter_values[i] + (counter_values[i+1] << 32));
             i += 2;
         } else {
-            sddf_printf("%s: %lu\n", pmu_event_table[benchmark_config.pmu_events[i]].event_name,
-                        counter_values[i]);
+            if (overflow_status & 1 << i) {
+                sddf_printf("%s: Overflow occurred during benchmark, event count is invalid!\n",
+                    pmu_event_table[benchmark_config.pmu_events[i]].event_name);
+            } else {
+                sddf_printf("%s: %lu\n", pmu_event_table[benchmark_config.pmu_events[i]].event_name,
+                            counter_values[i]);
+            }
             i += 1;
         }
     }
@@ -271,8 +282,7 @@ void init(void)
     sddf_printf("BENCH|LOG: ENABLE_PMU_EVENTS defined. Tracking PMU events:\n");
     uint8_t event = 0, i = 0;
     while (i < benchmark_config.num_pmu_events) {
-        /* Only even numbered counters can be chained (CHAIN counter must be odd) */
-        if (i + 1 < benchmark_config.num_pmu_events && !(i % 2) && benchmark_config.pmu_events[i + 1] == CHAIN) {
+        if (i + 1 < benchmark_config.num_pmu_events && benchmark_config.pmu_events[i + 1] == CHAIN) {
             sddf_printf("%u. %s (64-bit counter)\n", event, pmu_event_table[benchmark_config.pmu_events[i]].event_name);
             i += 2;
         } else {

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -26,22 +26,28 @@ counter_bitfield_t benchmark_bf;
 
 serial_queue_handle_t serial_tx_queue_handle;
 
-char *counter_names[] = {
-    "L1 i-cache misses",
-    "L1 d-cache misses",
-    "L1 i-tlb misses",
-    "L1 d-tlb misses",
-    "Instructions",
-    "Branch mispredictions",
-};
+/**
+ * PMU event information fields.
+ */
+typedef struct {
+    const char *event_name; /* Description of the PMU event for result reporting. */
+    uint64_t sel4bench_id; /* PMU event identifier - platform specific, but we limit our PMU usage to ARM */
+} bench_pmu_event_info_t;
 
-event_id_t benchmarking_events[] = {
-    SEL4BENCH_EVENT_CACHE_L1I_MISS,
-    SEL4BENCH_EVENT_CACHE_L1D_MISS,
-    SEL4BENCH_EVENT_TLB_L1I_MISS,
-    SEL4BENCH_EVENT_TLB_L1D_MISS,
-    SEL4BENCH_EVENT_EXECUTE_INSTRUCTION,
-    SEL4BENCH_EVENT_BRANCH_MISPREDICT,
+/**
+ * PMU event lookup table. Entry i corresponds to bench_pmu_events_t enum value
+ * i, see bench.h
+ */
+bench_pmu_event_info_t pmu_event_table[] = {
+    {"L1 i-cache misses", SEL4BENCH_EVENT_CACHE_L1I_MISS },
+    {"L1 d-cache misses", SEL4BENCH_EVENT_CACHE_L1D_MISS },
+    {"L1 i-tlb misses", SEL4BENCH_EVENT_TLB_L1I_MISS },
+    {"L1 d-tlb misses", SEL4BENCH_EVENT_TLB_L1D_MISS },
+    {"Instructions", SEL4BENCH_EVENT_EXECUTE_INSTRUCTION },
+    {"Branch mispredictions", SEL4BENCH_EVENT_BRANCH_MISPREDICT },
+    {"CPU cycles", SEL4BENCH_EVENT_CCNT },
+    {"Data memory access", SEL4BENCH_EVENT_MEMORY_ACCESS },
+    {"Overflow counter", SEL4BENCH_EVENT_CHAIN},
 };
 
 static char *child_name(uint8_t child_id)
@@ -134,8 +140,8 @@ static void benchmark_init(void)
 #if ENABLE_PMU_EVENTS
     sel4bench_init();
     seL4_Word n_counters = sel4bench_get_num_counters();
-    for (seL4_Word counter = 0; counter < MIN(n_counters, ARRAY_SIZE(benchmarking_events)); counter++) {
-        sel4bench_set_count_event(counter, benchmarking_events[counter]);
+    for (seL4_Word counter = 0; counter < MIN(n_counters, benchmark_config.num_pmu_events); counter++) {
+        sel4bench_set_count_event(counter, pmu_event_table[benchmark_config.pmu_events[counter]].sel4bench_id);
         benchmark_bf |= BIT(counter);
     }
 
@@ -198,8 +204,18 @@ static void benchmark_stop(void)
     sel4bench_stop_counters(benchmark_bf);
 
     sddf_printf("{CORE %u: \n", benchmark_config.core);
-    for (int i = 0; i < ARRAY_SIZE(benchmarking_events); i++) {
-        sddf_printf("%s: %lu\n", counter_names[i], counter_values[i]);
+    uint8_t i = 0;
+    while (i < benchmark_config.num_pmu_events) {
+        /* Only even numbered counters can be chained (CHAIN counter must be odd) */
+        if (i + 1 < benchmark_config.num_pmu_events && !(i % 2) && benchmark_config.pmu_events[i + 1] == CHAIN) {
+            sddf_printf("%s: %lu\n", pmu_event_table[benchmark_config.pmu_events[i]].event_name,
+                        counter_values[i] + (counter_values[i+1] << 32));
+            i += 2;
+        } else {
+            sddf_printf("%s: %lu\n", pmu_event_table[benchmark_config.pmu_events[i]].event_name,
+                        counter_values[i]);
+            i += 1;
+        }
     }
     sddf_printf("}\n");
 #endif
@@ -252,7 +268,19 @@ void init(void)
     sddf_printf("BENCH|LOG: ENABLE_BENCHMARKING defined\n");
 #endif
 #if ENABLE_PMU_EVENTS
-    sddf_printf("BENCH|LOG: ENABLE_PMU_EVENTS defined\n");
+    sddf_printf("BENCH|LOG: ENABLE_PMU_EVENTS defined. Tracking PMU events:\n");
+    uint8_t event = 0, i = 0;
+    while (i < benchmark_config.num_pmu_events) {
+        /* Only even numbered counters can be chained (CHAIN counter must be odd) */
+        if (i + 1 < benchmark_config.num_pmu_events && !(i % 2) && benchmark_config.pmu_events[i + 1] == CHAIN) {
+            sddf_printf("%u. %s (64-bit counter)\n", event, pmu_event_table[benchmark_config.pmu_events[i]].event_name);
+            i += 2;
+        } else {
+            sddf_printf("%u. %s (32-bit counter)\n", event, pmu_event_table[benchmark_config.pmu_events[i]].event_name);
+            i += 1;
+        }
+        event++;
+    }
 #endif
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
     sddf_printf("BENCH|LOG: CONFIG_BENCHMARK_TRACK_UTILISATION defined\n");

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -170,7 +170,7 @@ static void benchmark_start(void)
     sel4bench_reset_counters();
     /* Reset the overflow status flag register so we can check for overflows to
     32-bit counters during the benchmark */
-    PMU_WRITE(PMOVSCLR, 0);
+    PMU_WRITE(PMOVSCLR, 0b111111);
     sel4bench_start_counters(benchmark_bf);
 #endif
 

--- a/examples/echo_server/README.md
+++ b/examples/echo_server/README.md
@@ -232,20 +232,11 @@ three mechanisms for measuring its performance which can be used simultaneously:
    PD. A choice between utilisation or kernel entries must be made as each
    requires a different benchmarking mode of the kernel.
 2. Per-core system utilisation based on cycle counts measured by an idle thread.
-3. PMU data, see below from the [benchmark PD](/benchmark/benchmark.c):
+3. On AArch64 boards, PMU event counters can also be utilised. Details on how to
+   select which PMU events are tracked can be found in the [PMU benchmarking
+   data](#pmu-benchmarking-data) section.
 
-```c
-char *counter_names[] = {
-    "L1 i-cache misses",
-    "L1 d-cache misses",
-    "L1 i-tlb misses",
-    "L1 d-tlb misses",
-    "Instructions",
-    "Branch mispredictions",
-};
-```
-
-PMU and kernel tracked statistics are managed by the [benchmark
+PMU and kernel tracked statistics are managed and reported by the [benchmark
 PD](/benchmark/benchmark.c), while total and idle cycle counts are maintained by
 the [idle thread](/benchmark/idle.c). The idle thread has only one function
 which is to maintain a count of total and idle core cycles which resides in
@@ -258,8 +249,100 @@ idle thread enters an infinite loop of the following:
    those cycles are categorised as *idle* and added to the idle count.
  * Update the total cycle count.
 
-Thus the idle thread maintains a page of shared memory that is used to calculate
-system utilisation.
+The idle thread maintains a page of memory with these counts which the
+benchmarking client uses to calculate system utilisation.
+
+#### PMU benchmarking data
+
+On AArch64 boards, the [benchmark PD](/benchmark/benchmark.c) has access to 6
+32-bit PMU event counters which can be configured to track custom PMU events.
+The events can be set at build time using the `BENCH_PMU_EVENTS` make flag:
+
+```sh
+make BENCH_PMU_EVENTS=EXECUTE_INSTRUCTION,MEM_ACCESS,CACHE_L1D_MISS
+```
+
+Alternatively the events can be set by modifying the `pmu_events` variable in
+[metaprogram](/examples/echo_server/meta.py):
+
+```py
+pmu_events = [
+    "EXECUTE_INSTRUCTION",
+    "MEM_ACCESS",
+    "CACHE_L1D_MISS",
+]
+```
+
+Since each counter is only 32-bits, it is possible for them overflow depending
+on the event they are tracking. We have implemented two solutions to this:
+
+1. Using the `CHAIN` PMU event: The chain event can be used to track the number
+   of times the preceding counter has overflowed, essentially allowing us to
+   repurpose two 32-bit counters into a 64-bit counter. For example, if we set
+   the PMU event flag as follows:
+
+```sh
+BENCH_PMU_EVENTS=EXECUTE_INSTRUCTION,CHAIN
+```
+
+ Then the total count of instructions executed will be given by:
+
+ ```c
+ counter[0] + counter[1] << 32
+ ```
+
+> [!NOTE]
+> Only *odd* counters can be used for chaining. The metaprogram will not allow
+> an even counter to be set to `CHAIN`.
+
+2. Checking for overflows using the overflow status flag register:
+
+  For any counters *not* utilising chaining, we also check the overflow status
+  flag register `PMOVSCLR` after each benchmark to check whether an overflow
+  occurred. Since this register only encodes whether *one or more* overflows
+  occurred, we cannot infer the correct count. Thus, if an overflow occurs the
+  benchmark PD will not report the 32-bit count, and instead will output:
+
+```sh
+Instructions: Overflow occurred during benchmark, event count is invalid!
+```
+
+If the `BENCH_PMU_EVENTS` flag is not set, the echo server will default to
+tracking the following events:
+
+```py
+pmu_events = [
+    "EXECUTE_INSTRUCTION",
+    "CHAIN",
+    "MEM_ACCESS",
+    "CHAIN",
+    "CACHE_L1D_MISS",
+    "CHAIN",
+]
+```
+
+#### Available PMU events
+
+For a list of the PMU events that are currently available to select, check the
+`bench_pmu_events_t` enum in [bench.h](/include/sddf/benchmark/bench.h), or
+alternatively the `bench_pmu_events` dictionary in the
+[metaprogram](/examples/echo_server/meta.py). It is important that these two
+data structures *always match*, as this is how the build system transfers the
+user selected events to the benchmark PD.
+
+Adding support for an unlisted PMU event is simple:
+1. Create a new `bench_pmu_events_t` enum member for the event in
+   [bench.h](/include/sddf/benchmark/bench.h). The value of this enum is now the
+   event's identifier.
+2. Add an entry to the `bench_pmu_events` dictionary in the
+   [metaprogram](/examples/echo_server/meta.py) recording the event's
+   identifier.
+3. [Optional] List any boards that don't support tracking of the event in the
+   dictionary entry. This enables build-time failure in the error case.
+4. Add an entry to the `pmu_event_table` in
+   [benchmark.c](/benchmark/benchmark.c) at the index of the event's identifier.
+   This table is used for results reporting, so requires a brief description of
+   the event, as well as the event's seL4bench identifier.
 
 #### Benchmarking timeline
 

--- a/examples/echo_server/echo.mk
+++ b/examples/echo_server/echo.mk
@@ -91,11 +91,13 @@ $(SYSTEM_FILE): $(METAPROGRAM) $(IMAGES) $(DTB)
 ifneq ($(strip $(DTS)),)
 	$(PYTHON)\
 	    $(METAPROGRAM) --sddf $(SDDF) --board $(MICROKIT_BOARD) \
-	    --dtb $(DTB) --output . --sdf $(SYSTEM_FILE) --objcopy $(OBJCOPY) --smp $(SMP_CONFIG)
+	    --dtb $(DTB) --output . --sdf $(SYSTEM_FILE) --objcopy $(OBJCOPY) --smp $(SMP_CONFIG) \
+		$(if $(BENCH_PMU_EVENTS), --bench_pmu_events $(BENCH_PMU_EVENTS))
 else
 	$(PYTHON)\
 	    $(METAPROGRAM) --sddf $(SDDF) --board $(MICROKIT_BOARD) \
-	    --output . --sdf $(SYSTEM_FILE) --objcopy $(OBJCOPY) --smp $(SMP_CONFIG)
+	    --output . --sdf $(SYSTEM_FILE) --objcopy $(OBJCOPY) --smp $(SMP_CONFIG) \
+		$(if $(BENCH_PMU_EVENTS), --bench_pmu_events $(BENCH_PMU_EVENTS))
 endif
 	$(OBJCOPY) --update-section .device_resources=serial_driver_device_resources.data serial_driver.elf
 	$(OBJCOPY) --update-section .serial_driver_config=serial_driver_config.data serial_driver.elf

--- a/examples/echo_server/meta.py
+++ b/examples/echo_server/meta.py
@@ -524,11 +524,20 @@ def generate(
         f.write(sdf.render())
 
 # ARM PMU event identifier dictionary:
-# The value of each PMU event string is a pair whose first entry is the PMU
-# event's enum value (defined in bench.h), and second entry is a list of boards
-# that DO NOT support tracking of the event.
-# PMU events can be configured by setting the make flag `BENCH_PMU_EVENTS` to a
-# comma separated list of events
+#
+# The bench_pmu_events_t enum type (defined in bench.h) lists the set of PMU
+# events the system can be configured to track during a benchmark run. The
+# python dictionary bench_pmu_events encodes this enum. For each enum event x:
+#
+# bench_pmu_events[x][0] = the enum value of x
+# bench_pmu_events[x][1] = any ARM boards listed in BOARDS that DO NOT support
+# benchmark tracking of event x
+#
+# Which PMU events are tracked can be configured by setting the make flag
+# BENCH_PMU_EVENTS to a comma separated list of events.
+#
+# See the echo server README.md for more information, in particular if you wish
+# to track a PMU event which is not currently listed.
 bench_pmu_events = {
     "CACHE_L1I_MISS": (0, []),
     "CACHE_L1D_MISS": (1, []),

--- a/examples/echo_server/meta.py
+++ b/examples/echo_server/meta.py
@@ -85,6 +85,7 @@ class BenchmarkConfig:
         core: int,
         last_core: bool,
         children: List[Tuple[int, str]],
+        pmu_events: List[int],
     ):
         self.ch_rx_start = ch_rx_start
         self.ch_tx_start = ch_tx_start
@@ -94,6 +95,7 @@ class BenchmarkConfig:
         self.core = core
         self.last_core = last_core
         self.children = children
+        self.pmu_events = pmu_events
 
     """
         Matches struct definition:
@@ -110,12 +112,14 @@ class BenchmarkConfig:
                 char [64];
                 uint8_t;
             } [64];
+            uint8_t [6];
+            uint8_t;
         }
     """
 
     def serialise(self) -> bytes:
         child_config_format = "c" * 65
-        pack_str = "<BBBBBB?B" + child_config_format * 64
+        pack_str = "<BBBBBB?B" + child_config_format * 64 + "BBBBBBB"
         child_bytes = bytearray()
         for child in self.children:
             c_name = child[1].encode("utf-8")
@@ -128,6 +132,10 @@ class BenchmarkConfig:
 
         child_bytes_list = [x.to_bytes(1, "little") for x in child_bytes]
 
+        num_pmu_events = len(self.pmu_events)
+        assert num_pmu_events <= 6
+        self.pmu_events.extend(0 for i in range(6 - num_pmu_events))
+
         return struct.pack(
             pack_str,
             self.ch_rx_start,
@@ -139,6 +147,8 @@ class BenchmarkConfig:
             self.last_core,
             len(self.children),
             *child_bytes_list,
+            *self.pmu_events,
+            num_pmu_events
         )
 
 
@@ -179,6 +189,7 @@ def generate(
     output_dir: str,
     dtb: Optional[DeviceTree],
     get_core: Callable[[str], int],
+    pmu_event_ids: List[int],
 ):
     uart_node = None
     ethernet_node = None
@@ -450,6 +461,7 @@ def generate(
                 core_objs[i - 1]["core"],
                 False,
                 core_objs[i - 1]["children"],
+                pmu_event_ids,
             )
 
     # Finally create the last benchmark PD config
@@ -462,6 +474,7 @@ def generate(
         core_objs[num_cores - 1]["core"],
         True,
         core_objs[num_cores - 1]["children"],
+        pmu_event_ids,
     )
 
     assert serial_system.connect()
@@ -510,6 +523,23 @@ def generate(
     with open(f"{output_dir}/{sdf_file}", "w+") as f:
         f.write(sdf.render())
 
+# ARM PMU event identifier dictionary:
+# The value of each PMU event string is a pair whose first entry is the PMU
+# event's enum value (defined in bench.h), and second entry is a list of boards
+# that DO NOT support tracking of the event.
+# PMU events can be configured by setting the make flag `BENCH_PMU_EVENTS` to a
+# comma separated list of events
+bench_pmu_events = {
+    "CACHE_L1I_MISS": (0, []),
+    "CACHE_L1D_MISS": (1, []),
+    "TLB_L1I_MISS": (2, []),
+    "TLB_L1D_MISS": (3, []),
+    "EXECUTE_INSTRUCTION": (4, []),
+    "BRANCH_MISPREDICT": (5, []),
+    "CPU_CYCLES": (6, []),
+    "MEM_ACCESS": (7, []),
+    "CHAIN": (8, []),
+}
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -520,6 +550,7 @@ if __name__ == "__main__":
     parser.add_argument("--sdf", required=True)
     parser.add_argument("--objcopy", required=True)
     parser.add_argument("--smp", required=True)
+    parser.add_argument("--bench_pmu_events", required=False)
 
     args = parser.parse_args()
 
@@ -540,4 +571,22 @@ if __name__ == "__main__":
         with open(args.dtb, "rb") as f:
             dtb = DeviceTree(f.read())
 
-    generate(args.sdf, args.output, dtb, get_core)
+    if args.bench_pmu_events:
+        pmu_events = args.bench_pmu_events.split(",")
+    else:
+        # If benchmarking PMU events are not provided, we use these default events
+        pmu_events = ["EXECUTE_INSTRUCTION", "CHAIN", "MEM_ACCESS", "CHAIN", "CACHE_L1D_MISS", "CHAIN"]
+
+    assert len(pmu_events) <= 6, "Supplied more than 6 benchmarking PMU events to track!"
+    pmu_event_ids = []
+    for i in range(len(pmu_events)):
+        if not i % 2:
+            assert pmu_events[i] != "CHAIN", f"Chaining (overflow counting) can only be used by odd counters (selected counter {i})!"
+
+        assert pmu_events[i] in bench_pmu_events, f"Selected PMU event {i} ({pmu_events[i]}) is not supported!"
+
+        assert args.board not in bench_pmu_events[pmu_events[i]][1], f"Selected PMU event {i} ({pmu_events[i]}) is not supported by board {args.board}!"
+
+        pmu_event_ids.append(bench_pmu_events[pmu_events[i]][0])
+
+    generate(args.sdf, args.output, dtb, get_core, pmu_event_ids)

--- a/examples/echo_server/meta.py
+++ b/examples/echo_server/meta.py
@@ -148,7 +148,7 @@ class BenchmarkConfig:
             len(self.children),
             *child_bytes_list,
             *self.pmu_events,
-            num_pmu_events
+            num_pmu_events,
         )
 
 
@@ -523,6 +523,7 @@ def generate(
     with open(f"{output_dir}/{sdf_file}", "w+") as f:
         f.write(sdf.render())
 
+
 # ARM PMU event identifier dictionary:
 #
 # The bench_pmu_events_t enum type (defined in bench.h) lists the set of PMU
@@ -584,17 +585,32 @@ if __name__ == "__main__":
         pmu_events = args.bench_pmu_events.split(",")
     else:
         # If benchmarking PMU events are not provided, we use these default events
-        pmu_events = ["EXECUTE_INSTRUCTION", "CHAIN", "MEM_ACCESS", "CHAIN", "CACHE_L1D_MISS", "CHAIN"]
+        pmu_events = [
+            "EXECUTE_INSTRUCTION",
+            "CHAIN",
+            "MEM_ACCESS",
+            "CHAIN",
+            "CACHE_L1D_MISS",
+            "CHAIN",
+        ]
 
-    assert len(pmu_events) <= 6, "Supplied more than 6 benchmarking PMU events to track!"
+    assert (
+        len(pmu_events) <= 6
+    ), "Supplied more than 6 benchmarking PMU events to track!"
     pmu_event_ids = []
     for i in range(len(pmu_events)):
         if not i % 2:
-            assert pmu_events[i] != "CHAIN", f"Chaining (overflow counting) can only be used by odd counters (selected counter {i})!"
+            assert (
+                pmu_events[i] != "CHAIN"
+            ), f"Chaining (overflow counting) can only be used by odd counters (selected counter {i})!"
 
-        assert pmu_events[i] in bench_pmu_events, f"Selected PMU event {i} ({pmu_events[i]}) is not supported!"
+        assert (
+            pmu_events[i] in bench_pmu_events
+        ), f"Selected PMU event {i} ({pmu_events[i]}) is not supported!"
 
-        assert args.board not in bench_pmu_events[pmu_events[i]][1], f"Selected PMU event {i} ({pmu_events[i]}) is not supported by board {args.board}!"
+        assert (
+            args.board not in bench_pmu_events[pmu_events[i]][1]
+        ), f"Selected PMU event {i} ({pmu_events[i]}) is not supported by board {args.board}!"
 
         pmu_event_ids.append(bench_pmu_events[pmu_events[i]][0])
 

--- a/examples/echo_server/scripts/process_output.py
+++ b/examples/echo_server/scripts/process_output.py
@@ -218,7 +218,10 @@ with open(file, "r") as f:
 
             # Capture PMU details
             match = re.match(r"([\d\w -]+): ([0-9]+).*", line)
-            match_overflow = re.match(r"([\d\w -]+): Overflow occurred during benchmark, event count is invalid!", line)
+            match_overflow = re.match(
+                r"([\d\w -]+): Overflow occurred during benchmark, event count is invalid!",
+                line,
+            )
             if match:
                 pmu_key = match.group(1)
                 pmu_value = int(match.group(2))
@@ -239,7 +242,10 @@ with open(file, "r") as f:
                     pmu_data[pmu_key] = [pmu_value]
                 elif len(pmu_data[pmu_key]) == (test["test"] - 1):
                     pmu_data[pmu_key].append(pmu_value)
-                elif pmu_data[pmu_key][test["test"] - 1] == "overflow" or pmu_value == "overflow":
+                elif (
+                    pmu_data[pmu_key][test["test"] - 1] == "overflow"
+                    or pmu_value == "overflow"
+                ):
                     # An overflow occurred, count is invalid
                     pmu_data[pmu_key][test["test"] - 1] = "overflow"
                 else:

--- a/examples/echo_server/scripts/process_output.py
+++ b/examples/echo_server/scripts/process_output.py
@@ -217,12 +217,17 @@ with open(file, "r") as f:
                 continue
 
             # Capture PMU details
-            match = re.match(r"([\d\w -]+): ([0-9A-F]+).*", line)
-            if not match:
+            match = re.match(r"([\d\w -]+): ([0-9]+).*", line)
+            match_overflow = re.match(r"([\d\w -]+): Overflow occurred during benchmark, event count is invalid!", line)
+            if match:
+                pmu_key = match.group(1)
+                pmu_value = int(match.group(2))
+            elif match_overflow:
+                pmu_key = match_overflow.group(1)
+                pmu_value = "overflow"
+            else:
                 continue
 
-            pmu_key = match.group(1)
-            pmu_value = match.group(2)
             if (
                 "psci" not in pmu_key
                 and "Model" not in pmu_key
@@ -231,11 +236,14 @@ with open(file, "r") as f:
 
                 # Create PMU entry per test
                 if pmu_key not in pmu_data:
-                    pmu_data[pmu_key] = [int(pmu_value)]
+                    pmu_data[pmu_key] = [pmu_value]
                 elif len(pmu_data[pmu_key]) == (test["test"] - 1):
-                    pmu_data[pmu_key].append(int(pmu_value))
+                    pmu_data[pmu_key].append(pmu_value)
+                elif pmu_data[pmu_key][test["test"] - 1] == "overflow" or pmu_value == "overflow":
+                    # An overflow occurred, count is invalid
+                    pmu_data[pmu_key][test["test"] - 1] = "overflow"
                 else:
-                    pmu_data[pmu_key][test["test"] - 1] += int(pmu_value)
+                    pmu_data[pmu_key][test["test"] - 1] += pmu_value
 
 # Output results from final test
 if test["test"]:

--- a/include/sddf/benchmark/bench.h
+++ b/include/sddf/benchmark/bench.h
@@ -32,3 +32,28 @@ struct bench {
     /* Cycles attributed to the idle thread */
     uint64_t idle_ccount;
 };
+
+/**
+ * On the ARM CPUs we use, there are 6 32-bit counters available for tracking
+ * PMU events. PMU events can be selected using the BENCH_PMU_EVENTS make flag
+ * or in the metaprogram. The selected events are serialised and copied into the
+ * benchmark PD's ELF file.
+ */
+#define BENCHMARK_MAX_PMU_EVENTS 6
+
+/**
+ * PMU event identifiers - used by the metaprogram to select events. Event i is
+ * described by the pmu_event_table[i] entry in benchmark.c.
+ */
+typedef enum {
+    CACHE_L1I_MISS = 0,
+    CACHE_L1D_MISS,
+    TLB_L1I_MISS,
+    TLB_L1D_MISS,
+    EXECUTE_INSTRUCTION,
+    BRANCH_MISPREDICT,
+    CPU_CYCLES,
+    MEM_ACCESS,
+    CHAIN,
+    PMU_EVENT_COUNT,
+} bench_pmu_events_t;

--- a/include/sddf/benchmark/config.h
+++ b/include/sddf/benchmark/config.h
@@ -8,6 +8,7 @@
 #include <os/sddf.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include "bench.h"
 
 /* At the moment we run systems that contain this benchmarking code on architectures
  * where we cannot properly do benchmarking. We also include the benchmarking PD
@@ -58,6 +59,10 @@ typedef struct benchmark_config {
     uint8_t num_children;
     /* PDs requiring cycle counts sharing a core with this benchmark PD. */
     benchmark_child_config_t children[BENCHMARK_MAX_CHILDREN];
+    /* PMU events to track */
+    bench_pmu_events_t pmu_events[BENCHMARK_MAX_PMU_EVENTS];
+    /* Number of PMU events to track */
+    uint8_t num_pmu_events;
 } benchmark_config_t;
 
 typedef struct benchmark_idle_config {

--- a/include/sddf/benchmark/config.h
+++ b/include/sddf/benchmark/config.h
@@ -60,7 +60,7 @@ typedef struct benchmark_config {
     /* PDs requiring cycle counts sharing a core with this benchmark PD. */
     benchmark_child_config_t children[BENCHMARK_MAX_CHILDREN];
     /* PMU events to track */
-    bench_pmu_events_t pmu_events[BENCHMARK_MAX_PMU_EVENTS];
+    uint8_t pmu_events[BENCHMARK_MAX_PMU_EVENTS];
     /* Number of PMU events to track */
     uint8_t num_pmu_events;
 } benchmark_config_t;

--- a/include/sddf/benchmark/sel4bench.h
+++ b/include/sddf/benchmark/sel4bench.h
@@ -61,6 +61,7 @@ typedef uint64_t ccnt_t;
 #define PMSELR      "PMSELR_EL0"
 #define PMXEVTYPER  "PMXEVTYPER_EL0"
 #define PMCCNTR     "PMCCNTR_EL0"
+#define PMOVSCLR    "PMOVSCLR_EL0"
 
 #define PMU_WRITE(reg, v)                      \
     do {                                       \

--- a/include/sddf/benchmark/sel4bench.h
+++ b/include/sddf/benchmark/sel4bench.h
@@ -22,6 +22,9 @@ The definitions are specific to ARMv8 - different definitions will need to used 
 #define SEL4BENCH_EVENT_TLB_L1D_MISS                0x05
 #define SEL4BENCH_EVENT_EXECUTE_INSTRUCTION         0x08
 #define SEL4BENCH_EVENT_BRANCH_MISPREDICT           0x10
+#define SEL4BENCH_EVENT_CCNT                        0x11
+#define SEL4BENCH_EVENT_MEMORY_ACCESS               0x13
+#define SEL4BENCH_EVENT_CHAIN                       0x1E
 
 /* Armv8 constants. */
 #define SEL4BENCH_ARMV8A_COUNTER_CCNT 31

--- a/tools/make/board/common.mk
+++ b/tools/make/board/common.mk
@@ -56,7 +56,7 @@ eth_driver.elf: ${ETH_DRIV}
 
 # Magic to ensure stuff gets recompiled if we change
 # board name, or use a different Microkit etc.
-CHECK_FLAGS_BOARD_HASH := .board_cflags-$(shell echo -- ${CFLAGS} ${MICROKIT_SDK} ${MICROKIT_BOARD} ${MICROKIT_CONFIG} ${SMP_CONFIG} | shasum | sed 's/ *-//g')
+CHECK_FLAGS_BOARD_HASH := .board_cflags-$(shell echo -- ${CFLAGS} ${MICROKIT_SDK} ${MICROKIT_BOARD} ${MICROKIT_CONFIG} ${SMP_CONFIG} ${BENCH_PMU_EVENTS} | shasum | sed 's/ *-//g')
 
 ${CHECK_FLAGS_BOARD_HASH}:
 	-rm -f .board_cflags-*


### PR DESCRIPTION
This is a temporary solution for issue #525

Allow to define PMU events with the flag BENCH_PMU_EVENTS instead of modifying benchmark.c every time.

Usage example: BENCH_PMU_EVENTS=CACHE_L1I_MISS,EXECUTE_INSTRUCTION,CHAIN

Add CHAIN event, which collects overflows of previous event counter.