### PR TITLE
ci: increase DHCP request timeout in echo_server benchmark

### DIFF
--- a/ci/benchmarks/echo_server.py
+++ b/ci/benchmarks/echo_server.py
@@ -42,7 +42,12 @@ def backend_fn(test_config: common.TestConfig, loader_img: Path) -> HardwareBack
 async def test(iq_backend: IpBenchQueueBackend, test_config: common.TestConfig):
     mq_backend = iq_backend.mq_backend
 
-    async with asyncio.timeout(20):
+    timeout = 20
+    if test_config.board.startswith("rpi4b"):
+        # See https://github.com/au-ts/sddf/issues/698 for details
+        timeout = 30
+
+    async with asyncio.timeout(timeout):
         await wait_for_output(mq_backend, b"DHCP request finished")
         dhcp_client1 = await wait_for_output(mq_backend, b"\r\n")
         await wait_for_output(mq_backend, b"DHCP request finished")


### PR DESCRIPTION
20 seconds is too short for `rpi4b_1gb` and results in [timeout](https://github.com/au-ts/sddf/actions/runs/25420819632/job/74562721287?pr=713#step:8:9196) in a recent ci run.