### PR TITLE
drivers/tsc_hpet: serialise rdtsc

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -40,6 +40,7 @@ Device Tree compatible strings/platforms it is known to work with.
     * `amlogic,meson-g12a-dwmac`
 * virtIO network
     * `virtio,mmio`
+    * PCI is also supported for x86-64 platforms.
 
 ## GPU
 
@@ -84,3 +85,5 @@ Device Tree compatible strings/platforms it is known to work with.
     * `cdns,ttc`
 * BCM2835
     * `brcm,bcm2835-system-timer`
+* x86-64 TSC & HPET:
+    * `tsc_hpet`

--- a/drivers/timer/tsc_hpet/timer.c
+++ b/drivers/timer/tsc_hpet/timer.c
@@ -131,8 +131,9 @@ uint64_t next_timeout = UINT64_MAX;
 
 static inline uint64_t rdtsc(void)
 {
-    uint32_t lo, hi;
-    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+    uint32_t lo, hi, unused;
+    __asm__ __volatile__("rdtscp" : "=a"(lo), "=d"(hi), "=c"(unused));
+    __asm__ __volatile__("lfence" ::: "memory");
     return ((uint64_t)hi << 32) | lo;
 }
 


### PR DESCRIPTION
`rdtsc` isn't a serialising instruction, so force the CPU to not execute it out of order.