### PR TITLE
Remove Zig from GitHub actions scripts

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -23,7 +23,6 @@ env:
   MICROKIT_VERSION: 2.2.0
   MICROKIT_URL: https://github.com/seL4/microkit/releases/download/2.2.0/
   SDFGEN_VERSION: 0.33.0
-  ZIG_VERSION: 0.15.1
 
 jobs:
   build_linux_x86_64:
@@ -38,10 +37,6 @@ jobs:
           tar xf microkit-sdk-${{ env.MICROKIT_VERSION }}-linux-x86-64.tar.gz
       - name: Install dependencies (via apt)
         run: sudo apt update && sudo apt install -y make llvm lld imagemagick device-tree-compiler
-      - name: Install Zig
-        uses: mlugg/setup-zig@v2.2.1
-        with:
-          version: ${{ env.ZIG_VERSION }}
       - name: Setup pyenv
         run: |
           python3 -m venv venv
@@ -110,10 +105,6 @@ jobs:
         run: |
           brew install llvm lld make imagemagick dtc
           echo "/opt/homebrew/opt/llvm/bin:$PATH" >> $GITHUB_PATH
-      - name: Install Zig
-        uses: mlugg/setup-zig@v2.2.1
-        with:
-          version: ${{ env.ZIG_VERSION }}
       - name: Setup pyenv
         run: |
           python3.13 -m venv venv

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,22 +39,6 @@ jobs:
         run: |
           git clang-format-18 --diff ${GITHUB_BASE_REF} test-revision --verbose
 
-  style_zig:
-    name: Style (Zig)
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Install Zig
-        uses: mlugg/setup-zig@v2.2.1
-        with:
-          version: ${{ env.ZIG_VERSION }}
-
-      - name: Ensure zig version
-        run: zig version
-      - name: Check formatting
-        run: zig fmt . --check
-
   style_python:
     name: Style (Python)
     runs-on: ubuntu-24.04


### PR DESCRIPTION
As it says in the title: removing Zig from our CI actions.