### PR TITLE
use /usr/bin/env instead of hardcoded shell paths

### DIFF
--- a/ci/genmc/genmc.sh
+++ b/ci/genmc/genmc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2025, UNSW
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/docs/design/tools/bibexport.sh
+++ b/docs/design/tools/bibexport.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##
 ## This is file `bibexport.sh',
 ## generated with the docstrip utility.

--- a/docs/design/tools/countwords.sh
+++ b/docs/design/tools/countwords.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 echo "word count: `cat sections/*.tex | python removecomments.py | detex | tr -d '&' | wc -w`"
 for f in sections/*.tex; do

--- a/docs/design/tools/pages.sh
+++ b/docs/design/tools/pages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Return how many pages a PDF has. For fun times, construct a commit hook from
 # this that updates a 'underlimit' tag to point at the latest changeset under

--- a/network/ipstacks/lwip/doc/doxygen/generate.sh
+++ b/network/ipstacks/lwip/doc/doxygen/generate.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 doxygen lwip.Doxyfile

--- a/network/ipstacks/lwip/test/fuzz/output_to_pcap.sh
+++ b/network/ipstacks/lwip/test/fuzz/output_to_pcap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$1" ]
 then

--- a/tools/mkvirtdisk
+++ b/tools/mkvirtdisk
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2024, UNSW
 #


### PR DESCRIPTION
For making the shell scripts portable to other systems (that may not have the hardcoded paths for shells such as NixOS)