### PR TITLE
FS malloc and Bit Array fixes

### DIFF
--- a/include/sddf/util/bitarray.h
+++ b/include/sddf/util/bitarray.h
@@ -34,7 +34,7 @@ typedef struct bitarray {
  * @param words pointer to the word array.
  * @param num_of_bits number of bits in the word array.
  */
-void bitarray_init(bitarray_t *bitarr, uint64_t *words, uint64_t num_of_bits);
+void bitarray_init(bitarray_t *bitarr, uint64_t *words, uint64_t num_bits);
 
 /**
  * Get the value of a specific bit in the bit array.

--- a/include/sddf/util/bitarray.h
+++ b/include/sddf/util/bitarray.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 /**
  * This file provides functions and macros to manipulate bit arrays efficiently.

--- a/include/sddf/util/bitarray.h
+++ b/include/sddf/util/bitarray.h
@@ -14,39 +14,17 @@
  * (e.g., 32 bits or 64 bits). This implementation uses 64 bits.
  */
 
-typedef uint64_t word_t; /* type of word in the bitarray. */
-typedef uint64_t word_index_t; /* type for index of a word in the bitarray. */
-typedef uint64_t bit_index_t; /* type for index of a bit in the bitarray. */
-typedef uint8_t word_offset_t; /* type for offset of a bit within a word in the bitarray. */
-
-/**
- * Rounds up the number of bits to the nearest number of bytes.
- *
- * @param bits The number of bits.
- * @return The number of bytes.
- */
-#define roundup_bits2bytes(bits)   (((bits)+7)/8)
-
-/**
- * Rounds up the number of bits to the nearest number of 32-bit words.
- *
- * @param bits The number of bits.
- * @return The number of 32-bit words.
- */
-#define roundup_bits2words32(bits) (((bits)+31)/32)
-
 /**
  * Rounds up the number of bits to the nearest number of 64-bit words.
  *
  * @param bits The number of bits.
  * @return The number of 64-bit words.
  */
-#define roundup_bits2words64(bits) (((bits)+63)/64)
+#define BITS_2_WORDS64(bits) (((bits)+63)/64)
 
 typedef struct bitarray {
-    word_t *words; /* Word array */
-    bit_index_t num_of_bits; /* Number of bits, calculated by number of words * size of word */
-    word_index_t num_of_words; /* Number of words */
+    uint64_t num_bits; /* Total number of bits */
+    uint64_t *words; /* Word array */
 } bitarray_t;
 
 /**
@@ -54,27 +32,29 @@ typedef struct bitarray {
  *
  * @param bitarr pointer to the bitarray struct.
  * @param words pointer to the word array.
- * @param num_of_words number of words in the word array.
+ * @param num_of_bits number of bits in the word array.
  */
-void bitarray_init(bitarray_t *bitarr, word_t *words, word_index_t num_of_words);
+void bitarray_init(bitarray_t *bitarr, uint64_t *words, uint64_t num_of_bits);
 
 /**
  * Get the value of a specific bit in the bit array.
  *
  * @param bitarr pointer to the bitarray struct.
  * @param index index of the bit to get.
+ *
  * @return the value of the bit (0 or 1).
  */
-char bitarray_get_bit(bitarray_t *bitarr, bit_index_t index);
+char bitarray_get_bit(bitarray_t *bitarr, uint64_t index);
 
 /**
- * Set all the bits in a specific region of the bit array.
+ * Set all the bits to 0 or 1 in a specific region of the bit array.
  *
  * @param bitarr pointer to the bitarray struct.
  * @param start starting index of the region.
  * @param len length of the region.
+ * @param value value to set the bits.
  */
-void bitarray_set_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len);
+void bitarray_set_region(bitarray_t *bitarr, uint64_t start, uint64_t len, uint8_t value);
 
 /**
  * Toggle all the bits in a specific region of the bit array.
@@ -83,26 +63,15 @@ void bitarray_set_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len)
  * @param start starting index of the region.
  * @param len length of the region.
  */
-void bitarray_toggle_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len);
+void bitarray_toggle_region(bitarray_t *bitarr, uint64_t start, uint64_t len);
 
 /**
- * Clear all the bits in a specific region of the bit array.
+ * Count the number of contiguous bits set to 0 or 1 starting from the start bit.
  *
  * @param bitarr pointer to the bitarray struct.
- * @param start starting index of the region.
- * @param len length of the region.
- */
-void bitarray_clear_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len);
-
-/**
- * Compare two regions of bit arrays.
+ * @param start bit to start counting from.
+ * @param value value of bits to count.
  *
- * @param bitarr1 pointer to the first bitarray struct.
- * @param start1 starting index of the first region.
- * @param bitarr2 pointer to the second bitarray struct.
- * @param start2 starting index of the second region.
- * @param len length of the regions to compare.
- * @return true if the two regions are equal, false otherwise.
+ * @return number of contiguous bits starting from start having the value provided.
  */
-bool bitarray_cmp_region(bitarray_t *bitarr1, bit_index_t start1, bitarray_t *bitarr2, bit_index_t start2,
-                         bit_index_t len);
+uint64_t bitarray_count_bits(bitarray_t *bitarr, uint64_t start, uint8_t value);

--- a/include/sddf/util/bitarray.h
+++ b/include/sddf/util/bitarray.h
@@ -23,7 +23,7 @@
 #define BITS_2_WORDS64(bits) (((bits)+63)/64)
 
 typedef struct bitarray {
-    uint64_t num_bits; /* Total number of bits */
+    size_t num_bits; /* Total number of bits */
     uint64_t *words; /* Word array */
 } bitarray_t;
 
@@ -34,7 +34,7 @@ typedef struct bitarray {
  * @param words pointer to the word array.
  * @param num_of_bits number of bits in the word array.
  */
-void bitarray_init(bitarray_t *bitarr, uint64_t *words, uint64_t num_bits);
+void bitarray_init(bitarray_t *bitarr, uint64_t *words, size_t num_bits);
 
 /**
  * Get the value of a specific bit in the bit array.
@@ -44,7 +44,7 @@ void bitarray_init(bitarray_t *bitarr, uint64_t *words, uint64_t num_bits);
  *
  * @return the value of the bit (0 or 1).
  */
-char bitarray_get_bit(bitarray_t *bitarr, uint64_t index);
+char bitarray_get_bit(bitarray_t *bitarr, size_t index);
 
 /**
  * Set all the bits to 0 or 1 in a specific region of the bit array.
@@ -54,7 +54,7 @@ char bitarray_get_bit(bitarray_t *bitarr, uint64_t index);
  * @param len length of the region.
  * @param value true sets the bits to 1, false sets the bits to 0.
  */
-void bitarray_set_region(bitarray_t *bitarr, uint64_t start, uint64_t len, bool value);
+void bitarray_set_region(bitarray_t *bitarr, size_t start, size_t len, bool value);
 
 /**
  * Toggle all the bits in a specific region of the bit array.
@@ -63,7 +63,7 @@ void bitarray_set_region(bitarray_t *bitarr, uint64_t start, uint64_t len, bool 
  * @param start starting index of the region.
  * @param len length of the region.
  */
-void bitarray_toggle_region(bitarray_t *bitarr, uint64_t start, uint64_t len);
+void bitarray_toggle_region(bitarray_t *bitarr, size_t start, size_t len);
 
 /**
  * Count the number of contiguous bits set to 0 or 1 starting from the start bit.
@@ -74,4 +74,4 @@ void bitarray_toggle_region(bitarray_t *bitarr, uint64_t start, uint64_t len);
  *
  * @return number of contiguous bits starting from start having the value provided.
  */
-uint64_t bitarray_count_bits(bitarray_t *bitarr, uint64_t start, bool is_set);
+size_t bitarray_count_bits(bitarray_t *bitarr, size_t start, bool is_set);

--- a/include/sddf/util/bitarray.h
+++ b/include/sddf/util/bitarray.h
@@ -52,9 +52,9 @@ char bitarray_get_bit(bitarray_t *bitarr, uint64_t index);
  * @param bitarr pointer to the bitarray struct.
  * @param start starting index of the region.
  * @param len length of the region.
- * @param value value to set the bits.
+ * @param value true sets the bits to 1, false sets the bits to 0.
  */
-void bitarray_set_region(bitarray_t *bitarr, uint64_t start, uint64_t len, uint8_t value);
+void bitarray_set_region(bitarray_t *bitarr, uint64_t start, uint64_t len, bool value);
 
 /**
  * Toggle all the bits in a specific region of the bit array.
@@ -70,8 +70,8 @@ void bitarray_toggle_region(bitarray_t *bitarr, uint64_t start, uint64_t len);
  *
  * @param bitarr pointer to the bitarray struct.
  * @param start bit to start counting from.
- * @param value value of bits to count.
+ * @param is_set true counts the bits set to 1, false counts the bits set to 0.
  *
  * @return number of contiguous bits starting from start having the value provided.
  */
-uint64_t bitarray_count_bits(bitarray_t *bitarr, uint64_t start, uint8_t value);
+uint64_t bitarray_count_bits(bitarray_t *bitarr, uint64_t start, bool is_set);

--- a/include/sddf/util/fsmalloc.h
+++ b/include/sddf/util/fsmalloc.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <sddf/util/bitarray.h>
 
 /**

--- a/include/sddf/util/fsmalloc.h
+++ b/include/sddf/util/fsmalloc.h
@@ -26,16 +26,6 @@ typedef struct fsmalloc {
 } fsmalloc_t;
 
 /**
- * Check if the memory region can fit count more free cells.
- *
- * @param fsmalloc pointer to the fsmalloc struct.
- * @param count number of cells to check.
- *
- * @return true indicates the data region is full, false otherwise.
- */
-bool fsmalloc_full(fsmalloc_t *fsmalloc, uint64_t count);
-
-/**
  * Get count many free cells in the data region.
  *
  * @param fsmalloc pointer to the fsmalloc struct.
@@ -64,7 +54,7 @@ void fsmalloc_free(fsmalloc_t *fsmalloc, uintptr_t addr, uint64_t count);
  * @param num_cells number of cells in the data region.
  * @param bitarr pointer to the bitarray struct representing available data cells.
  * @param words pointer to the array of words in bitarray struct.
- * @param num_words number of words in the array of bitarray struct. This needs to be > num_cells/64. Can be calculated using roundup_bits2words64(num_cells).
+ * @param num_words number of words in the array of bitarray struct. This needs to be >= num_cells/64. Can be calculated using BITS_2_WORDS64(num_cells).
  */
 void fsmalloc_init(fsmalloc_t *fsmalloc, uintptr_t base_addr, uint64_t cell_size, uint64_t num_cells,
-                   bitarray_t *bitarr, word_t *words, word_index_t num_words);
+                   bitarray_t *bitarr, uint64_t *words, uint64_t num_words);

--- a/include/sddf/util/fsmalloc.h
+++ b/include/sddf/util/fsmalloc.h
@@ -57,4 +57,4 @@ void fsmalloc_free(fsmalloc_t *fsmalloc, uintptr_t addr, uint64_t count);
  * @param num_words number of words in the array of bitarray struct. This needs to be >= num_cells/64. Can be calculated using BITS_2_WORDS64(num_cells).
  */
 void fsmalloc_init(fsmalloc_t *fsmalloc, uintptr_t base_addr, uint64_t cell_size, uint64_t num_cells,
-                   bitarray_t *bitarr, uint64_t *words, uint64_t num_words);
+                   bitarray_t *bitarr, uint64_t *words, size_t num_words);

--- a/util/bitarray.c
+++ b/util/bitarray.c
@@ -4,6 +4,7 @@
  */
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <sddf/util/bitarray.h>
 #include <sddf/util/util.h>
 
@@ -67,17 +68,12 @@ static void set_region(bitarray_t *bitarr, uint64_t start, uint64_t length, bita
     }
 }
 
-void bitarray_set_region(bitarray_t *bitarr, uint64_t start, uint64_t len, uint8_t value)
+void bitarray_set_region(bitarray_t *bitarr, uint64_t start, uint64_t len, bool value)
 {
-    assert(value == 0 || value == 1);
-
-    switch (value) {
-    case 0:
-        set_region(bitarr, start, len, ZERO_REGION);
-        break;
-    case 1:
+    if (value) {
         set_region(bitarr, start, len, FILL_REGION);
-        break;
+    } else {
+        set_region(bitarr, start, len, ZERO_REGION);
     }
 }
 
@@ -86,7 +82,7 @@ void bitarray_toggle_region(bitarray_t *bitarr, uint64_t start, uint64_t len)
     set_region(bitarr, start, len, SWAP_REGION);
 }
 
-uint64_t bitarray_count_bits(bitarray_t *bitarr, uint64_t start, uint8_t value)
+uint64_t bitarray_count_bits(bitarray_t *bitarr, uint64_t start, bool is_set)
 {
     assert(start < bitarr->num_bits);
 
@@ -105,7 +101,7 @@ uint64_t bitarray_count_bits(bitarray_t *bitarr, uint64_t start, uint8_t value)
         }
 
         while (bit_idx <= last_bit_idx) {
-            if (((word >> bit_idx) & 1) != value) {
+            if (((word >> bit_idx) & 1) != is_set) {
                 return count;
             }
             count++;

--- a/util/bitarray.c
+++ b/util/bitarray.c
@@ -29,7 +29,7 @@ char bitarray_get_bit(bitarray_t *bitarr, uint64_t index)
     return (bitarr->words[WORD_IDX(index)] >> BIT_IDX(index)) & 1;
 }
 
-typedef enum {ZERO_REGION, FILL_REGION, SWAP_REGION} bitarray_action_t;
+typedef enum { ZERO_REGION, FILL_REGION, SWAP_REGION } bitarray_action_t;
 
 static void set_region(bitarray_t *bitarr, uint64_t start, uint64_t length, bitarray_action_t action)
 {

--- a/util/bitarray.c
+++ b/util/bitarray.c
@@ -3,203 +3,118 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <stdint.h>
 #include <sddf/util/bitarray.h>
 #include <sddf/util/util.h>
 
-#define WORD_MAX  (~(word_t)0)
+/* Create a bit mask of nbits contiguous bits starting from the least
+significant bit*/
+#define BITMASK(nbits) ((nbits) ? ~(uint64_t)0 >> (64 - nbits): (uint64_t)0)
 
-#define bitmask(nbits,type) ((nbits) ? ~(type)0 >> (sizeof(type)*8-(nbits)): (type)0)
-#define bitmask32(nbits) bitmask(nbits,uint32_t)
-#define bitmask64(nbits) bitmask(nbits,uint64_t)
+/* Find the index of the word containing the bit_pos bit */
+#define WORD_IDX(bit_pos) ((bit_pos) >> 6)
 
-#define bitset64_wrd(bit_pos) ((bit_pos) >> 6)
-#define bitset64_idx(bit_pos) ((bit_pos) & 63)
+/* Find the index of the bit_pos bit within it's word */
+#define BIT_IDX(bit_pos) ((bit_pos) & 63)
 
-/**
- * Set a region of bits in a bit array to a specified value.
- *
- * @param arr The bit array.
- * @param start The starting position of the region.
- * @param len The length of the region.
- */
-#define SET_REGION(arr,start,len) _set_region((arr),(start),(len),FILL_REGION)
-
-/**
- * Clear a region of bits in a bit array, setting them to 0.
- *
- * @param arr The bit array.
- * @param start The starting position of the region.
- * @param len The length of the region.
- */
-#define CLEAR_REGION(arr,start,len) _set_region((arr),(start),(len),ZERO_REGION)
-
-/**
- * Toggle a region of bits in a bit array, flipping their values.
- *
- * @param arr The bit array.
- * @param start The starting position of the region.
- * @param len The length of the region.
- */
-#define TOGGLE_REGION(arr,start,len) _set_region((arr),(start),(len),SWAP_REGION)
-
-void bitarray_init(bitarray_t *bitarr, word_t *words, word_index_t num_of_words)
+void bitarray_init(bitarray_t *bitarr, uint64_t *words, uint64_t num_bits)
 {
+    bitarr->num_bits = num_bits;
     bitarr->words = words;
-    bitarr->num_of_words = num_of_words;
-    bitarr->num_of_bits = num_of_words * 64;
 }
 
-char bitarray_get_bit(bitarray_t *bitarr, bit_index_t index)
+char bitarray_get_bit(bitarray_t *bitarr, uint64_t index)
 {
-    word_index_t word = bitset64_wrd(index);
-    word_offset_t offset = bitset64_idx(index);
-    return (bitarr->words[word] >> offset) & 1;
+    assert(index < bitarr->num_bits);
+    return (bitarr->words[WORD_IDX(index)] >> BIT_IDX(index)) & 1;
 }
 
-// FillAction is fill with 0 or 1 or toggle
-typedef enum {ZERO_REGION, FILL_REGION, SWAP_REGION} FillAction;
+typedef enum {ZERO_REGION, FILL_REGION, SWAP_REGION} bitarray_action_t;
 
-static inline void _set_region(bitarray_t *bitarr, bit_index_t start,
-                               bit_index_t length, FillAction action)
+static void set_region(bitarray_t *bitarr, uint64_t start, uint64_t length, bitarray_action_t action)
 {
+    assert(start < bitarr->num_bits && start + length <= bitarr->num_bits);
+
     if (length == 0) {
         return;
     }
 
-    word_index_t first_word = bitset64_wrd(start);
-    word_index_t last_word = bitset64_wrd(start + length - 1);
-    word_offset_t foffset = bitset64_idx(start);
-    word_offset_t loffset = bitset64_idx(start + length - 1);
+    uint64_t word_idx = WORD_IDX(start);
+    uint64_t last_word_idx = WORD_IDX(start + length - 1);
+    uint64_t bit_idx = BIT_IDX(start);
+    uint64_t last_bit_idx = 63;
 
-    if (first_word == last_word) {
-        word_t mask = bitmask64(length) << foffset;
+    while (word_idx <= last_word_idx) {
+        if (word_idx == last_word_idx) {
+            last_bit_idx = BIT_IDX(start + length - 1);
+        }
+        uint64_t mask = BITMASK(last_bit_idx - bit_idx + 1) << bit_idx;
 
         switch (action) {
         case ZERO_REGION:
-            bitarr->words[first_word] &= ~mask;
+            bitarr->words[word_idx] &= ~mask;
             break;
         case FILL_REGION:
-            bitarr->words[first_word] |=  mask;
+            bitarr->words[word_idx] |= mask;
             break;
         case SWAP_REGION:
-            bitarr->words[first_word] ^=  mask;
-            break;
-        }
-    } else {
-        // Set first word
-        switch (action) {
-        case ZERO_REGION:
-            bitarr->words[first_word] &=  bitmask64(foffset);
-            break;
-        case FILL_REGION:
-            bitarr->words[first_word] |= ~bitmask64(foffset);
-            break;
-        case SWAP_REGION:
-            bitarr->words[first_word] ^= ~bitmask64(foffset);
+            bitarr->words[word_idx] ^= mask;
             break;
         }
 
-        word_index_t i;
-
-        // Set whole words
-        switch (action) {
-        case ZERO_REGION:
-            for (i = first_word + 1; i < last_word; i++) {
-                bitarr->words[i] = (word_t)0;
-            }
-            break;
-        case FILL_REGION:
-            for (i = first_word + 1; i < last_word; i++) {
-                bitarr->words[i] = WORD_MAX;
-            }
-            break;
-        case SWAP_REGION:
-            for (i = first_word + 1; i < last_word; i++) {
-                bitarr->words[i] ^= WORD_MAX;
-            }
-            break;
-        }
-
-        // Set last word
-        switch (action) {
-        case ZERO_REGION:
-            bitarr->words[last_word] &= ~bitmask64(loffset + 1);
-            break;
-        case FILL_REGION:
-            bitarr->words[last_word] |=  bitmask64(loffset + 1);
-            break;
-        case SWAP_REGION:
-            bitarr->words[last_word] ^=  bitmask64(loffset + 1);
-            break;
-        }
+        word_idx++;
+        bit_idx = 0;
     }
 }
 
-void bitarray_set_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len)
+void bitarray_set_region(bitarray_t *bitarr, uint64_t start, uint64_t len, uint8_t value)
 {
-    assert(start + len <= bitarr->num_of_bits);
-    SET_REGION(bitarr, start, len);
+    assert(value == 0 || value == 1);
+
+    switch (value) {
+    case 0:
+        set_region(bitarr, start, len, ZERO_REGION);
+        break;
+    case 1:
+        set_region(bitarr, start, len, FILL_REGION);
+        break;
+    }
 }
 
-void bitarray_clear_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len)
+void bitarray_toggle_region(bitarray_t *bitarr, uint64_t start, uint64_t len)
 {
-    assert(start + len <= bitarr->num_of_bits);
-    CLEAR_REGION(bitarr, start, len);
+    set_region(bitarr, start, len, SWAP_REGION);
 }
 
-void bitarray_toggle_region(bitarray_t *bitarr, bit_index_t start, bit_index_t len)
+uint64_t bitarray_count_bits(bitarray_t *bitarr, uint64_t start, uint8_t value)
 {
-    assert(start + len <= bitarr->num_of_bits);
-    TOGGLE_REGION(bitarr, start, len);
-}
+    assert(start < bitarr->num_bits);
 
-bool bitarray_cmp_region(bitarray_t *bitarr1, bit_index_t start1,
-                         bitarray_t *bitarr2, bit_index_t start2, bit_index_t len)
-{
-    assert(start1 + len <= bitarr1->num_of_bits);
-    assert(start2 + len <= bitarr2->num_of_bits);
+    uint64_t count = 0;
+    uint64_t word_idx = WORD_IDX(start);
+    uint64_t last_word_idx = WORD_IDX(bitarr->num_bits - 1);
+    uint64_t bit_idx = BIT_IDX(start);
+    uint64_t last_bit_idx = 63;
 
-    if (len == 0) {
-        return true;
+    while (word_idx <= last_word_idx) {
+
+        uint64_t word = bitarr->words[word_idx];
+
+        if (word_idx == last_word_idx) {
+            last_bit_idx = BIT_IDX(bitarr->num_bits - 1);
+        }
+
+        while (bit_idx <= last_bit_idx) {
+            if ((word & (1 >> bit_idx)) != value) {
+                return count;
+            }
+            count++;
+            bit_idx++;
+        }
+
+        word_idx++;
+        bit_idx = 0;
     }
 
-    while (len > 0) {
-        // calculate the word index and bit offset for both arrays
-        word_index_t word_idx1 = bitset64_wrd(start1);
-        word_offset_t bit_offset1 = bitset64_idx(start1);
-        word_index_t word_idx2 = bitset64_wrd(start2);
-        word_offset_t bit_offset2 = bitset64_idx(start2);
-
-        // calculate the number of bits to compare in this iteration
-        bit_index_t bits_in_current_word1 = 64 - bit_offset1;
-        bit_index_t bits_in_current_word2 = 64 - bit_offset2;
-        bit_index_t bits_to_compare = len;
-        if (bits_to_compare > bits_in_current_word1) {
-            bits_to_compare = bits_in_current_word1;
-        }
-        if (bits_to_compare > bits_in_current_word2) {
-            bits_to_compare = bits_in_current_word2;
-        }
-
-        // create masks for the bits to compare
-        word_t mask1 = bitmask64(bits_to_compare) << bit_offset1;
-        word_t mask2 = bitmask64(bits_to_compare) << bit_offset2;
-
-        // extract the relevant bits from each array
-        word_t bits1 = (bitarr1->words[word_idx1] & mask1) >> bit_offset1;
-        word_t bits2 = (bitarr2->words[word_idx2] & mask2) >> bit_offset2;
-
-        // compare the bits
-        if (bits1 != bits2) {
-            return false;
-        }
-
-        // update for the next iteration
-        len -= bits_to_compare;
-        start1 += bits_to_compare;
-        start2 += bits_to_compare;
-    }
-
-    return true;
+    return count;
 }
-

--- a/util/bitarray.c
+++ b/util/bitarray.c
@@ -10,7 +10,7 @@
 
 /* Create a bit mask of nbits contiguous bits starting from the least
 significant bit*/
-#define BITMASK(nbits) ((nbits) ? ~(uint64_t)0 >> (64 - (nbits)): (uint64_t)0)
+#define BITMASK(nbits) ((nbits) ? ~0ull >> (64 - (nbits)): 0ull)
 
 /* Find the index of the word containing the bit_pos bit */
 #define WORD_IDX(bit_pos) ((bit_pos) >> 6)

--- a/util/bitarray.c
+++ b/util/bitarray.c
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <sddf/util/bitarray.h>
 #include <sddf/util/util.h>
 

--- a/util/bitarray.c
+++ b/util/bitarray.c
@@ -9,7 +9,7 @@
 
 /* Create a bit mask of nbits contiguous bits starting from the least
 significant bit*/
-#define BITMASK(nbits) ((nbits) ? ~(uint64_t)0 >> (64 - nbits): (uint64_t)0)
+#define BITMASK(nbits) ((nbits) ? ~(uint64_t)0 >> (64 - (nbits)): (uint64_t)0)
 
 /* Find the index of the word containing the bit_pos bit */
 #define WORD_IDX(bit_pos) ((bit_pos) >> 6)
@@ -105,7 +105,7 @@ uint64_t bitarray_count_bits(bitarray_t *bitarr, uint64_t start, uint8_t value)
         }
 
         while (bit_idx <= last_bit_idx) {
-            if ((word & (1 >> bit_idx)) != value) {
+            if (((word >> bit_idx) & 1) != value) {
                 return count;
             }
             count++;

--- a/util/bitarray.c
+++ b/util/bitarray.c
@@ -15,16 +15,16 @@ significant bit*/
 /* Find the index of the word containing the bit_pos bit */
 #define WORD_IDX(bit_pos) ((bit_pos) >> 6)
 
-/* Find the index of the bit_pos bit within it's word */
+/* Find the index of the bit_pos bit within its word */
 #define BIT_IDX(bit_pos) ((bit_pos) % 64)
 
-void bitarray_init(bitarray_t *bitarr, uint64_t *words, uint64_t num_bits)
+void bitarray_init(bitarray_t *bitarr, uint64_t *words, size_t num_bits)
 {
     bitarr->num_bits = num_bits;
     bitarr->words = words;
 }
 
-char bitarray_get_bit(bitarray_t *bitarr, uint64_t index)
+char bitarray_get_bit(bitarray_t *bitarr, size_t index)
 {
     assert(index < bitarr->num_bits);
     return (bitarr->words[WORD_IDX(index)] >> BIT_IDX(index)) & 1;
@@ -32,7 +32,7 @@ char bitarray_get_bit(bitarray_t *bitarr, uint64_t index)
 
 typedef enum { ZERO_REGION, FILL_REGION, SWAP_REGION } bitarray_action_t;
 
-static void set_region(bitarray_t *bitarr, uint64_t start, uint64_t length, bitarray_action_t action)
+static void set_region(bitarray_t *bitarr, size_t start, size_t length, bitarray_action_t action)
 {
     assert(start < bitarr->num_bits && start + length <= bitarr->num_bits);
 
@@ -40,10 +40,10 @@ static void set_region(bitarray_t *bitarr, uint64_t start, uint64_t length, bita
         return;
     }
 
-    uint64_t word_idx = WORD_IDX(start);
-    uint64_t last_word_idx = WORD_IDX(start + length - 1);
-    uint64_t bit_idx = BIT_IDX(start);
-    uint64_t last_bit_idx = 63;
+    size_t word_idx = WORD_IDX(start);
+    size_t last_word_idx = WORD_IDX(start + length - 1);
+    size_t bit_idx = BIT_IDX(start);
+    size_t last_bit_idx = 63;
 
     while (word_idx <= last_word_idx) {
         if (word_idx == last_word_idx) {
@@ -68,7 +68,7 @@ static void set_region(bitarray_t *bitarr, uint64_t start, uint64_t length, bita
     }
 }
 
-void bitarray_set_region(bitarray_t *bitarr, uint64_t start, uint64_t len, bool value)
+void bitarray_set_region(bitarray_t *bitarr, size_t start, size_t len, bool value)
 {
     if (value) {
         set_region(bitarr, start, len, FILL_REGION);
@@ -77,20 +77,20 @@ void bitarray_set_region(bitarray_t *bitarr, uint64_t start, uint64_t len, bool 
     }
 }
 
-void bitarray_toggle_region(bitarray_t *bitarr, uint64_t start, uint64_t len)
+void bitarray_toggle_region(bitarray_t *bitarr, size_t start, size_t len)
 {
     set_region(bitarr, start, len, SWAP_REGION);
 }
 
-uint64_t bitarray_count_bits(bitarray_t *bitarr, uint64_t start, bool is_set)
+size_t bitarray_count_bits(bitarray_t *bitarr, size_t start, bool is_set)
 {
     assert(start < bitarr->num_bits);
 
-    uint64_t count = 0;
-    uint64_t word_idx = WORD_IDX(start);
-    uint64_t last_word_idx = WORD_IDX(bitarr->num_bits - 1);
-    uint64_t bit_idx = BIT_IDX(start);
-    uint64_t last_bit_idx = 63;
+    size_t count = 0;
+    size_t word_idx = WORD_IDX(start);
+    size_t last_word_idx = WORD_IDX(bitarr->num_bits - 1);
+    size_t bit_idx = BIT_IDX(start);
+    size_t last_bit_idx = 63;
 
     while (word_idx <= last_word_idx) {
 

--- a/util/bitarray.c
+++ b/util/bitarray.c
@@ -16,7 +16,7 @@ significant bit*/
 #define WORD_IDX(bit_pos) ((bit_pos) >> 6)
 
 /* Find the index of the bit_pos bit within it's word */
-#define BIT_IDX(bit_pos) ((bit_pos) & 63)
+#define BIT_IDX(bit_pos) ((bit_pos) % 64)
 
 void bitarray_init(bitarray_t *bitarr, uint64_t *words, uint64_t num_bits)
 {

--- a/util/fsmalloc.c
+++ b/util/fsmalloc.c
@@ -4,6 +4,7 @@
  */
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <sddf/util/bitarray.h>
 #include <sddf/util/fsmalloc.h>
 #include <sddf/util/util.h>
@@ -11,7 +12,9 @@
 /**
  * Convert a bit position to the address of the corresponding data cell.
  *
+ * @param fsmalloc pointer to the fsmalloc struct.
  * @param bitpos bit position of the data cell
+ *
  * @return address of the data cell
  */
 static inline uintptr_t bitpos_to_addr(fsmalloc_t *fsmalloc, uint64_t bitpos)
@@ -22,7 +25,9 @@ static inline uintptr_t bitpos_to_addr(fsmalloc_t *fsmalloc, uint64_t bitpos)
 /**
  * Convert an address to the bit position of the corresponding data cell.
  *
+ * @param fsmalloc pointer to the fsmalloc struct.
  * @param addr address of the data cell
+ *
  * @return bit position of the data cell
  */
 static inline uint64_t addr_to_bitpos(fsmalloc_t *fsmalloc, uintptr_t addr)
@@ -30,85 +35,63 @@ static inline uint64_t addr_to_bitpos(fsmalloc_t *fsmalloc, uintptr_t addr)
     return (uint64_t)(addr - fsmalloc->base_addr) / fsmalloc->cell_size;
 }
 
-/**
- * Check if count number of cells will overflow the end of the data region.
- *
- * @param count number of cells to check
- * @return true if count number of cells will overflow the end of the data region, false otherwise
- */
-static inline bool fsmalloc_overflow(fsmalloc_t *fsmalloc, uint64_t count)
-{
-    return (fsmalloc->avail_bitpos + count > fsmalloc->num_cells);
-}
-
-bool fsmalloc_full(fsmalloc_t *fsmalloc, uint64_t count)
-{
-    if (count > fsmalloc->num_cells) {
-        return true;
-    }
-
-    if (count == 0) {
-        return false;
-    }
-
-    unsigned int start_bitpos = fsmalloc->avail_bitpos;
-    if (fsmalloc_overflow(fsmalloc, count)) {
-        start_bitpos = 0;
-    }
-
-    // Create a bit mask with count many 1's
-    bitarray_t bitarr_mask;
-    word_t words[roundup_bits2words64(count)];
-    bitarray_init(&bitarr_mask, words, roundup_bits2words64(count));
-    bitarray_set_region(&bitarr_mask, 0, count);
-
-    if (bitarray_cmp_region(fsmalloc->avail_bitarr, start_bitpos, &bitarr_mask, 0, count)) {
-        return false;
-    }
-
-    return true;
-}
-
 void fsmalloc_free(fsmalloc_t *fsmalloc, uintptr_t addr, uint64_t count)
 {
     unsigned int start_bitpos = addr_to_bitpos(fsmalloc, addr);
 
-    // Assert here in case we try to free cells that overflow the data region
-    assert(start_bitpos + count <= fsmalloc->num_cells);
+    // Assert that these bits were allocated
+    assert(bitarray_count_bits(fsmalloc->avail_bitarr, start_bitpos, 0) >= count);
 
     // Set the next count many bits as available
-    bitarray_set_region(fsmalloc->avail_bitarr, start_bitpos, count);
+    bitarray_set_region(fsmalloc->avail_bitarr, start_bitpos, count, 1);
 }
 
 int fsmalloc_alloc(fsmalloc_t *fsmalloc, uintptr_t *addr, uint64_t count)
 {
-    if (fsmalloc_full(fsmalloc, count)) {
+    if (count == 0 || count > fsmalloc->num_cells) {
         return -1;
     }
 
-    if (fsmalloc_overflow(fsmalloc, count)) {
-        fsmalloc->avail_bitpos = 0;
+    uint64_t curr_bitpos = fsmalloc->avail_bitpos;
+    uint64_t searched = 0;
+    while (searched < fsmalloc->num_cells) {
+
+        // No space at the end, wrap around
+        if (curr_bitpos + count > fsmalloc->num_cells) {
+            curr_bitpos = 0;
+            searched += fsmalloc->num_cells - curr_bitpos;
+        }
+
+        uint64_t free_blocks = bitarray_count_bits(fsmalloc->avail_bitarr, curr_bitpos, 1);
+        // Allocate blocks, update head
+        if (free_blocks >= count) {
+            *addr = bitpos_to_addr(fsmalloc, curr_bitpos);
+
+            // Set the next count many bits as unavailable
+            bitarray_set_region(fsmalloc->avail_bitarr, curr_bitpos, count, 0);
+
+            // Update the bitpos
+            fsmalloc->avail_bitpos = (curr_bitpos + count) % fsmalloc->num_cells;
+            return 0;
+        }
+
+        // Skip past the allocated blocks
+        curr_bitpos += free_blocks;
+        uint64_t alloced_blocks = bitarray_count_bits(fsmalloc->avail_bitarr, curr_bitpos, 0);
+
+        curr_bitpos = (curr_bitpos + alloced_blocks) % fsmalloc->num_cells;
+        searched += free_blocks + alloced_blocks;
     }
 
-    *addr = bitpos_to_addr(fsmalloc, fsmalloc->avail_bitpos);
-
-    // Set the next count many bits as unavailable
-    bitarray_clear_region(fsmalloc->avail_bitarr, fsmalloc->avail_bitpos, count);
-
-    // Update the bitpos
-    uint64_t new_bitpos = fsmalloc->avail_bitpos + count;
-    if (new_bitpos == fsmalloc->num_cells) {
-        new_bitpos = 0;
-    }
-    fsmalloc->avail_bitpos = new_bitpos;
-
-    return 0;
+    return -1;
 }
 
 void fsmalloc_init(fsmalloc_t *fsmalloc, uintptr_t base_addr, uint64_t cell_size, uint64_t num_cells,
-                   bitarray_t *bitarr, word_t *words, word_index_t num_words)
+                   bitarray_t *bitarr, uint64_t *words, uint64_t num_words)
 {
-    bitarray_init(bitarr, words, num_words);
+    assert(num_words >= BITS_2_WORDS64(num_cells));
+
+    bitarray_init(bitarr, words, num_cells);
 
     fsmalloc->avail_bitpos = 0;
     fsmalloc->avail_bitarr = bitarr;
@@ -117,5 +100,5 @@ void fsmalloc_init(fsmalloc_t *fsmalloc, uintptr_t base_addr, uint64_t cell_size
     fsmalloc->num_cells = num_cells;
 
     /* Set all available bits to 1 to indicate all cells are available */
-    bitarray_set_region(bitarr, 0, num_cells);
+    bitarray_set_region(bitarr, 0, num_cells, 1);
 }

--- a/util/fsmalloc.c
+++ b/util/fsmalloc.c
@@ -87,7 +87,7 @@ int fsmalloc_alloc(fsmalloc_t *fsmalloc, uintptr_t *addr, uint64_t count)
 }
 
 void fsmalloc_init(fsmalloc_t *fsmalloc, uintptr_t base_addr, uint64_t cell_size, uint64_t num_cells,
-                   bitarray_t *bitarr, uint64_t *words, uint64_t num_words)
+                   bitarray_t *bitarr, uint64_t *words, size_t num_words)
 {
     assert(num_words >= BITS_2_WORDS64(num_cells));
 

--- a/util/fsmalloc.c
+++ b/util/fsmalloc.c
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <sddf/util/bitarray.h>
 #include <sddf/util/fsmalloc.h>
 #include <sddf/util/util.h>

--- a/util/fsmalloc.c
+++ b/util/fsmalloc.c
@@ -40,10 +40,10 @@ void fsmalloc_free(fsmalloc_t *fsmalloc, uintptr_t addr, uint64_t count)
     unsigned int start_bitpos = addr_to_bitpos(fsmalloc, addr);
 
     // Assert that these bits were allocated
-    assert(bitarray_count_bits(fsmalloc->avail_bitarr, start_bitpos, 0) >= count);
+    assert(bitarray_count_bits(fsmalloc->avail_bitarr, start_bitpos, false) >= count);
 
     // Set the next count many bits as available
-    bitarray_set_region(fsmalloc->avail_bitarr, start_bitpos, count, 1);
+    bitarray_set_region(fsmalloc->avail_bitarr, start_bitpos, count, true);
 }
 
 int fsmalloc_alloc(fsmalloc_t *fsmalloc, uintptr_t *addr, uint64_t count)
@@ -62,13 +62,13 @@ int fsmalloc_alloc(fsmalloc_t *fsmalloc, uintptr_t *addr, uint64_t count)
             searched += fsmalloc->num_cells - curr_bitpos;
         }
 
-        uint64_t free_blocks = bitarray_count_bits(fsmalloc->avail_bitarr, curr_bitpos, 1);
+        uint64_t free_blocks = bitarray_count_bits(fsmalloc->avail_bitarr, curr_bitpos, true);
         // Allocate blocks, update head
         if (free_blocks >= count) {
             *addr = bitpos_to_addr(fsmalloc, curr_bitpos);
 
             // Set the next count many bits as unavailable
-            bitarray_set_region(fsmalloc->avail_bitarr, curr_bitpos, count, 0);
+            bitarray_set_region(fsmalloc->avail_bitarr, curr_bitpos, count, false);
 
             // Update the bitpos
             fsmalloc->avail_bitpos = (curr_bitpos + count) % fsmalloc->num_cells;
@@ -77,7 +77,7 @@ int fsmalloc_alloc(fsmalloc_t *fsmalloc, uintptr_t *addr, uint64_t count)
 
         // Skip past the allocated blocks
         curr_bitpos += free_blocks;
-        uint64_t alloced_blocks = bitarray_count_bits(fsmalloc->avail_bitarr, curr_bitpos, 0);
+        uint64_t alloced_blocks = bitarray_count_bits(fsmalloc->avail_bitarr, curr_bitpos, false);
 
         curr_bitpos = (curr_bitpos + alloced_blocks) % fsmalloc->num_cells;
         searched += free_blocks + alloced_blocks;
@@ -100,5 +100,5 @@ void fsmalloc_init(fsmalloc_t *fsmalloc, uintptr_t base_addr, uint64_t cell_size
     fsmalloc->num_cells = num_cells;
 
     /* Set all available bits to 1 to indicate all cells are available */
-    bitarray_set_region(bitarr, 0, num_cells, 1);
+    bitarray_set_region(bitarr, 0, num_cells, true);
 }


### PR DESCRIPTION
This PR simplifies the bit array and and FS malloc libraries, with the goal of fixing some issues that have been occurring (allocator is reporting full when it is not). Changes include:

- Removing `fsmalloc_full`, in favour of allowing the allocation to fail
- Only supporting 64 bit words in the bit array library (we had a small amount of support for other sized words)
- Rewriting the bit transformation code to have only a single loop
- Removing the the bit array comparison code in favour of the function `bitarray_count_bits`, which returns the number of contiguous bits set to 0 or 1 from a starting index (this allows us to speed up the search for an amount of free space)