### PR TITLE
serial/virtio: update to use new virtio-transport layer.

### DIFF
--- a/drivers/serial/virtio/console.c
+++ b/drivers/serial/virtio/console.c
@@ -18,11 +18,14 @@
 
 #include <os/sddf.h>
 #include <sddf/util/ialloc.h>
-#include <sddf/virtio/virtio.h>
-#include <sddf/virtio/virtio_queue.h>
+#include <sddf/virtio/transport/common.h>
+#include <sddf/virtio/queue.h>
+#include <sddf/virtio/feature.h>
 #include <sddf/resources/device.h>
 #include <sddf/serial/config.h>
 #include "console.h"
+
+virtio_device_handle_t dev;
 
 __attribute__((__section__(".device_resources"))) device_resources_t device_resources;
 __attribute__((__section__(".serial_driver_config"))) serial_driver_config_t config;
@@ -91,8 +94,6 @@ static inline bool virtio_avail_full_tx(struct virtq *virtq)
     return tx_last_desc_idx >= tx_virtq.num;
 }
 
-volatile virtio_mmio_regs_t *uart_regs;
-
 static void tx_provide(void)
 {
     bool transferred = false;
@@ -132,7 +133,8 @@ static void tx_provide(void)
     if (transferred) {
         /* Finally, need to notify the queue if we have transferred data */
         /* This assumes VIRTIO_F_NOTIFICATION_DATA has not been negotiated */
-        uart_regs->QueueNotify = VIRTIO_SERIAL_TX_QUEUE;
+        virtio_transport_queue_notify(&dev, VIRTIO_SERIAL_TX_QUEUE);
+        // uart_regs->QueueNotify = VIRTIO_SERIAL_TX_QUEUE;
         if (serial_require_consumer_signal(&tx_queue_handle)) {
             serial_cancel_consumer_signal(&tx_queue_handle);
             sddf_notify(config.tx.id);
@@ -204,7 +206,8 @@ static void rx_provide(void)
 
     if (transferred) {
         /* We have added more avail buffers, so notify the device */
-        uart_regs->QueueNotify = VIRTIO_SERIAL_RX_QUEUE;
+        virtio_transport_queue_notify(&dev, VIRTIO_SERIAL_RX_QUEUE);
+        // uart_regs->QueueNotify = VIRTIO_SERIAL_RX_QUEUE;
     }
 }
 
@@ -262,44 +265,30 @@ static void rx_return(void)
 
 void console_setup()
 {
-    if (!virtio_mmio_check_magic(uart_regs)) {
-        LOG_DRIVER_ERR("invalid virtIO magic value!\n");
-        return;
-    }
-
-    if (!virtio_mmio_check_device_id(uart_regs, VIRTIO_DEVICE_ID_CONSOLE)) {
-        LOG_DRIVER_ERR("Not a virtIO console device!\n");
-        return;
-    }
-
-    if (virtio_mmio_version(uart_regs) != VIRTIO_VERSION) {
-        LOG_DRIVER_ERR("not correct virtIO version!\n");
-        return;
-    }
+    assert(virtio_transport_probe(&device_resources, &dev, VIRTIO_DEVICE_ID_CONSOLE));
 
     LOG_DRIVER("version: 0x%x\n", virtio_mmio_version(uart_regs));
 
     // Do normal device initialisation (section 3.2)
     // First reset the device
-    uart_regs->Status = 0;
+    virtio_transport_set_status(&dev, 0);
 
     // Set the ACKNOWLEDGE bit to say we have noticed the device
-    uart_regs->Status = VIRTIO_DEVICE_STATUS_ACKNOWLEDGE;
+    virtio_transport_set_status(&dev, VIRTIO_DEVICE_STATUS_ACKNOWLEDGE);
 
         // Set the DRIVER bit to say we know how to drive the device
-    uart_regs->Status = VIRTIO_DEVICE_STATUS_DRIVER;
+    virtio_transport_set_status(&dev, VIRTIO_DEVICE_STATUS_DRIVER);
 
 #ifdef DEBUG_DRIVER
-    uint32_t features_low = uart_regs->DeviceFeatures;
-    uart_regs->DeviceFeaturesSel = 1;
-    uint32_t features_high = uart_regs->DeviceFeatures;
+    uint32_t features_low = virtio_transport_get_device_features(&dev, 0);
+    uint32_t features_high = virtio_transport_get_device_features(&dev, 1);
     uint64_t features = features_low | ((uint64_t)features_high << 32);
     virtio_console_print_features(features);
 #endif /* DEBUG_DRIVER */
 
-    uart_regs->Status = VIRTIO_DEVICE_STATUS_FEATURES_OK;
+    virtio_transport_set_status(&dev, VIRTIO_DEVICE_STATUS_FEATURES_OK);
 
-    if (!(uart_regs->Status & VIRTIO_DEVICE_STATUS_FEATURES_OK)) {
+    if (!(virtio_transport_get_status(&dev) & VIRTIO_DEVICE_STATUS_FEATURES_OK)) {
         LOG_DRIVER_ERR("device status features is not OK!\n");
         return;
     }
@@ -336,40 +325,25 @@ void console_setup()
     }
 
     // Setup RX queue first
-    assert(uart_regs->QueueNumMax >= RX_COUNT);
-    uart_regs->QueueSel = VIRTIO_SERIAL_RX_QUEUE;
-    uart_regs->QueueNum = RX_COUNT;
-    uart_regs->QueueDescLow = (hw_ring_buffer_paddr + rx_desc_off) & 0xFFFFFFFF;
-    uart_regs->QueueDescHigh = (hw_ring_buffer_paddr + rx_desc_off) >> 32;
-    uart_regs->QueueDriverLow = (hw_ring_buffer_paddr + rx_avail_off) & 0xFFFFFFFF;
-    uart_regs->QueueDriverHigh = (hw_ring_buffer_paddr + rx_avail_off) >> 32;
-    uart_regs->QueueDeviceLow = (hw_ring_buffer_paddr + rx_used_off) & 0xFFFFFFFF;
-    uart_regs->QueueDeviceHigh = (hw_ring_buffer_paddr + rx_used_off) >> 32;
-    uart_regs->QueueReady = 1;
+    assert(virtio_transport_queue_setup(&dev, VIRTIO_SERIAL_RX_QUEUE, RX_COUNT, hw_ring_buffer_paddr + rx_desc_off,
+                                        hw_ring_buffer_paddr + rx_avail_off, hw_ring_buffer_paddr + rx_used_off));
 
     // Setup TX queue
-    assert(uart_regs->QueueNumMax >= TX_COUNT);
-    uart_regs->QueueSel = VIRTIO_SERIAL_TX_QUEUE;
-    uart_regs->QueueNum = TX_COUNT;
-    uart_regs->QueueDescLow = (hw_ring_buffer_paddr + tx_desc_off) & 0xFFFFFFFF;
-    uart_regs->QueueDescHigh = (hw_ring_buffer_paddr + tx_desc_off) >> 32;
-    uart_regs->QueueDriverLow = (hw_ring_buffer_paddr + tx_avail_off) & 0xFFFFFFFF;
-    uart_regs->QueueDriverHigh = (hw_ring_buffer_paddr + tx_avail_off) >> 32;
-    uart_regs->QueueDeviceLow = (hw_ring_buffer_paddr + tx_used_off) & 0xFFFFFFFF;
-    uart_regs->QueueDeviceHigh = (hw_ring_buffer_paddr + tx_used_off) >> 32;
-    uart_regs->QueueReady = 1;
+    assert(virtio_transport_queue_setup(&dev, VIRTIO_SERIAL_TX_QUEUE, TX_COUNT, hw_ring_buffer_paddr + tx_desc_off,
+                                        hw_ring_buffer_paddr + tx_avail_off, hw_ring_buffer_paddr + tx_used_off));
 
     // Set the DRIVER_OK status bit
-    uart_regs->Status = VIRTIO_DEVICE_STATUS_DRIVER_OK;
-    uart_regs->InterruptACK = VIRTIO_MMIO_IRQ_VQUEUE;
+    virtio_transport_set_status(&dev, VIRTIO_DEVICE_STATUS_DRIVER_OK);
+    virtio_transport_write_isr(&dev, VIRTIO_IRQ_VQUEUE);
 }
 
 static void handle_irq()
 {
-    uint32_t irq_status = uart_regs->InterruptStatus;
-    if (irq_status & VIRTIO_MMIO_IRQ_VQUEUE) {
+    uint32_t irq_status = virtio_transport_read_isr(&dev);
+    if (irq_status & VIRTIO_IRQ_VQUEUE) {
         // ACK the interrupt first before handling responses
-        uart_regs->InterruptACK = VIRTIO_MMIO_IRQ_VQUEUE;
+        virtio_transport_write_isr(&dev, VIRTIO_IRQ_VQUEUE);
+        // uart_regs->InterruptACK = VIRTIO_IRQ_VQUEUE;
 
         // We don't know whether the IRQ is related to a change to the RX queue
         // or TX queue, so we check both.
@@ -381,7 +355,7 @@ static void handle_irq()
         tx_provide();
     }
 
-    if (irq_status & VIRTIO_MMIO_IRQ_CONFIG) {
+    if (irq_status & VIRTIO_IRQ_CONFIG) {
         LOG_DRIVER_ERR("unexpected change in configuration %u\n", irq_status);
     }
 }
@@ -393,7 +367,7 @@ void init()
     assert(device_resources.num_irqs == 1);
     assert(device_resources.num_regions == 4);
 
-    uart_regs = (volatile virtio_mmio_regs_t *)device_resources.regions[0].region.vaddr;
+    // uart_regs = (volatile virtio_mmio_regs_t *)device_resources.regions[0].region.vaddr;
     hw_ring_buffer_vaddr = (uintptr_t)device_resources.regions[1].region.vaddr;
     hw_ring_buffer_paddr = device_resources.regions[1].io_addr;
     virtio_rx_char = device_resources.regions[2].region.vaddr;

--- a/drivers/serial/virtio/console.c
+++ b/drivers/serial/virtio/console.c
@@ -134,7 +134,6 @@ static void tx_provide(void)
         /* Finally, need to notify the queue if we have transferred data */
         /* This assumes VIRTIO_F_NOTIFICATION_DATA has not been negotiated */
         virtio_transport_queue_notify(&dev, VIRTIO_SERIAL_TX_QUEUE);
-        // uart_regs->QueueNotify = VIRTIO_SERIAL_TX_QUEUE;
         if (serial_require_consumer_signal(&tx_queue_handle)) {
             serial_cancel_consumer_signal(&tx_queue_handle);
             sddf_notify(config.tx.id);
@@ -207,7 +206,6 @@ static void rx_provide(void)
     if (transferred) {
         /* We have added more avail buffers, so notify the device */
         virtio_transport_queue_notify(&dev, VIRTIO_SERIAL_RX_QUEUE);
-        // uart_regs->QueueNotify = VIRTIO_SERIAL_RX_QUEUE;
     }
 }
 
@@ -276,7 +274,7 @@ void console_setup()
     // Set the ACKNOWLEDGE bit to say we have noticed the device
     virtio_transport_set_status(&dev, VIRTIO_DEVICE_STATUS_ACKNOWLEDGE);
 
-        // Set the DRIVER bit to say we know how to drive the device
+    // Set the DRIVER bit to say we know how to drive the device
     virtio_transport_set_status(&dev, VIRTIO_DEVICE_STATUS_DRIVER);
 
 #ifdef DEBUG_DRIVER
@@ -343,7 +341,6 @@ static void handle_irq()
     if (irq_status & VIRTIO_IRQ_VQUEUE) {
         // ACK the interrupt first before handling responses
         virtio_transport_write_isr(&dev, VIRTIO_IRQ_VQUEUE);
-        // uart_regs->InterruptACK = VIRTIO_IRQ_VQUEUE;
 
         // We don't know whether the IRQ is related to a change to the RX queue
         // or TX queue, so we check both.
@@ -367,7 +364,6 @@ void init()
     assert(device_resources.num_irqs == 1);
     assert(device_resources.num_regions == 4);
 
-    // uart_regs = (volatile virtio_mmio_regs_t *)device_resources.regions[0].region.vaddr;
     hw_ring_buffer_vaddr = (uintptr_t)device_resources.regions[1].region.vaddr;
     hw_ring_buffer_paddr = device_resources.regions[1].io_addr;
     virtio_rx_char = device_resources.regions[2].region.vaddr;

--- a/drivers/serial/virtio/serial_driver.mk
+++ b/drivers/serial/virtio/serial_driver.mk
@@ -7,8 +7,13 @@
 # the virtio console driver.
 
 SERIAL_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+VIRTIO_TRANSPORT_DIR := $(SDDF)/virtio/transport/
 
-serial_driver.elf: serial/virtio/serial_driver.o libsddf_util_debug.a
+serial/virtio/mmio/transport.o: ${VIRTIO_TRANSPORT_DIR}/mmio.c ${CHECK_NETDRV_FLAGS} | $(SDDF_LIBC_INCLUDE)
+	mkdir -p serial/virtio/mmio
+	${CC} -c ${CFLAGS} -o $@ $<
+
+serial_driver.elf: serial/virtio/serial_driver.o libsddf_util_debug.a serial/virtio/mmio/transport.o
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 serial/virtio/serial_driver.o: ${SERIAL_DRIVER_DIR}/console.c |serial/virtio $(SDDF_LIBC_INCLUDE)
@@ -17,7 +22,7 @@ serial/virtio/serial_driver.o: ${SERIAL_DRIVER_DIR}/console.c |serial/virtio $(S
 serial/virtio:
 	mkdir -p $@
 
--include serial/virtio/serial_driver.d
+-include serial/virtio/serial_driver.d serial/virtio/mmio/transport.d
 
 clean::
 	rm -f serial/virtio/serial_driver.[do]

--- a/drivers/serial/virtio/serial_driver.mk
+++ b/drivers/serial/virtio/serial_driver.mk
@@ -9,7 +9,7 @@
 SERIAL_DRIVER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 VIRTIO_TRANSPORT_DIR := $(SDDF)/virtio/transport/
 
-serial/virtio/mmio/transport.o: ${VIRTIO_TRANSPORT_DIR}/mmio.c ${CHECK_NETDRV_FLAGS} | $(SDDF_LIBC_INCLUDE)
+serial/virtio/mmio/transport.o: ${VIRTIO_TRANSPORT_DIR}/mmio.c | $(SDDF_LIBC_INCLUDE)
 	mkdir -p serial/virtio/mmio
 	${CC} -c ${CFLAGS} -o $@ $<
 

--- a/tools/make/board/qemu_virt_aarch64.mk
+++ b/tools/make/board/qemu_virt_aarch64.mk
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
-PLATFORM := arm
+PLATFORM ?= arm
 
 BLK_DRIV_DIR ?= virtio/mmio
 GPU_DRIV_DIR ?= virtio
@@ -11,8 +11,8 @@ NET_DRIV_DIR ?= virtio/mmio
 ETH_DRIV ?= eth_driver_virtio.elf
 ETH_DRIV_DIR1 := ${NET_DRIV_DIR}
 ETH_DRIV_1 := ${ETH_DRIV}
-TIMER_DRIV_DIR := ${PLATFORM}
-UART_DRIV_DIR := ${PLATFORM}
+TIMER_DRIV_DIR ?= ${PLATFORM}
+UART_DRIV_DIR ?= ${PLATFORM}
 
 CPU := cortex-a53
 QEMU := qemu-system-aarch64


### PR DESCRIPTION
virtio-serial was neglected and was using the old registers API. This PR updates it to use the new virtio-transport API.