### PR TITLE
virtio: add option to skip PCI bus probing

### DIFF
--- a/virtio/transport/pci.c
+++ b/virtio/transport/pci.c
@@ -19,8 +19,9 @@
 #define PCI_DATA_PORT_ID 2
 #define PCI_DATA_PORT_ADDR 0xCFC
 
-/* Multiplier for virtIO queue kick mechanism. */
-uint32_t nftn_multiplier;
+/* Multiplier for virtIO queue kick mechanism.
+ * See https://github.com/qemu/qemu/blob/4ee536fac748b70e6f3d8568ddd20cfbaa9cf7bf/hw/virtio/virtio-pci.c#L365 */
+uint32_t nftn_multiplier = 4;
 
 uint32_t pci_compute_port_address(uint8_t bus, uint8_t dev, uint8_t func, uint8_t off)
 {
@@ -168,6 +169,7 @@ bool virtio_transport_probe(device_resources_t *device_resources, virtio_device_
 {
     assert(device_resources_check_magic(device_resources));
 
+#ifndef SDDF_VIRTIO_PCI_TRANSPORT_SKIP_BUS_CHECK
     uint8_t bus = device_handle_ret->pci_bus;
     uint8_t dev = device_handle_ret->pci_dev;
     uint8_t func = device_handle_ret->pci_func;
@@ -202,6 +204,7 @@ bool virtio_transport_probe(device_resources_t *device_resources, virtio_device_
     }
 
     pci_debug_print_header(bus, dev, func, &pci_device_header);
+#endif
 
     return true;
 }


### PR DESCRIPTION
In virtIO PCI transport, we need to probe the PCI bus for two reasons:
1. To check that the device at Bus:Dev.Func geographic location is the correct type (block/network).
2. To grab the virtqueue notification multiplier, which is used to compute the doorbell address to kick the device.

This is problematic if you want to use two virtio drivers in a system. For example, using both the block and network drivers. Since the kernel will only grant access to the PCI root complex I/O Ports to one PD at any given time.

This commit adds a preprocessor flag that allow you to skip this bus check so that you can run multiple virtio drivers in one system. The device type check will be skipped, and the multiplier hardcoded to QEMU's value.

I intend for this to be a temporary workaround to unblock Windows VM upstreaming activities in libvmm while the PCI driver is being merged.