### PR TITLE
Fix virtio-net driver on KVM virtual machines.

### DIFF
--- a/drivers/network/virtio/mmio/config.json
+++ b/drivers/network/virtio/mmio/config.json
@@ -12,7 +12,8 @@
             },
             {
                 "name": "hw_ring_buffer",
-                "size": 65536
+                "size": 65536,
+                "cached": true
             }
         ],
         "irqs": [


### PR DESCRIPTION
Related to #740.

The fixes are mainly cleaning and invalidating the cache when notifying the device or device writes in main memory. When accessing the used buffers, we first clean and invalidate the cache so that we are guaranteed that we are accessing main memory. When writing to available and descriptor buffers, we simply flush the cache related to the rings.

This patch only works on commits before https://github.com/au-ts/sddf/commit/92301f7d3f2415eec61709e0cb3c66563beb2016.