### PR TITLE
docs: declare minimum supported python version as 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ website [here](https://trustworthy.systems/projects/drivers/).
 * GNU Make
 * Clang and LLVM bintools
 * Device Tree Compiler
-* Python (3.9 or higher)
+* Python (3.10 or higher)
 
 See the instructions below for installing the rest of the dependencies based on
 your machine:


### PR DESCRIPTION
As discussed as part of Microkit Acacia (sdfgen rewrite) work https://github.com/au-ts/microkit_acacia/pull/22#discussion_r3732719950.

Python 3.9 was EOL 2025-10-31, as per https://www.python.org/downloads/release/python-3925/.