### PR TITLE
virtio: setup virtqueues based on host capability

### DIFF
--- a/drivers/blk/virtio/block.c
+++ b/drivers/blk/virtio/block.c
@@ -31,8 +31,7 @@
 
 virtio_device_handle_t dev;
 
-#define QUEUE_SIZE 1024
-#define VIRTQ_NUM_REQUESTS QUEUE_SIZE
+#define QUEUE_SIZE_MAX 1024
 
 uintptr_t requests_paddr;
 uintptr_t requests_vaddr;
@@ -47,14 +46,14 @@ static struct virtio_blk_req *virtio_headers;
  * A mapping from virtIO header index in the descriptor virtq ring, to the sDDF ID given
  * in the request. We need this mapping due to out of order operations.
  */
-uint32_t virtio_header_to_id[QUEUE_SIZE];
+uint32_t virtio_header_to_id[QUEUE_SIZE_MAX];
 
 /*
  * Due to the out-of-order nature of virtIO, we need a way of allocating indexes in a
  * non-linear way.
  */
 ialloc_t ialloc_desc;
-uint32_t descriptors[QUEUE_SIZE];
+uint32_t descriptors[QUEUE_SIZE_MAX];
 
 uint16_t last_seen_used = 0;
 
@@ -271,7 +270,6 @@ void handle_irq(void)
 void virtio_blk_init(void)
 {
     assert(virtio_transport_probe(&device_resources, &dev, VIRTIO_DEVICE_ID_BLK));
-    ialloc_init(&ialloc_desc, descriptors, QUEUE_SIZE);
 
     /* First reset the device */
     virtio_transport_set_status(&dev, 0);
@@ -302,9 +300,6 @@ void virtio_blk_init(void)
     storage_info->block_size = 1;
     storage_info->sector_size = VIRTIO_BLK_SECTOR_SIZE;
 
-    /* Finished populating configuration */
-    blk_storage_set_ready(storage_info, true);
-
 #ifdef DEBUG_DRIVER
     uint32_t features_low = virtio_transport_get_driver_features(&dev, 0);
     uint32_t features_high = virtio_transport_get_driver_features(&dev, 1);
@@ -321,11 +316,15 @@ void virtio_blk_init(void)
         return;
     }
 
+    uint16_t host_q_capacity = virtio_transport_queue_get_capacity(&dev, 0);
+    uint16_t driver_q_capacity = MIN(host_q_capacity, QUEUE_SIZE_MAX);
+    ialloc_init(&ialloc_desc, descriptors, driver_q_capacity);
+
     /* Add virtqueues */
     size_t desc_off = 0;
-    size_t avail_off = ALIGN(desc_off + (16 * VIRTQ_NUM_REQUESTS), 2);
-    size_t used_off = ALIGN(avail_off + (6 + 2 * VIRTQ_NUM_REQUESTS), 4);
-    size_t size = used_off + (6 + 8 * VIRTQ_NUM_REQUESTS);
+    size_t avail_off = ALIGN(desc_off + (16 * driver_q_capacity), 2);
+    size_t used_off = ALIGN(avail_off + (6 + 2 * driver_q_capacity), 4);
+    size_t size = used_off + (6 + 8 * driver_q_capacity);
 
     // Make sure that the metadata region is able to fit all the virtIO specific
     // extra data.
@@ -337,12 +336,12 @@ void virtio_blk_init(void)
     assert(size <= device_resources.regions[2].region.size);
 #endif
 
-    virtq.num = VIRTQ_NUM_REQUESTS;
+    virtq.num = driver_q_capacity;
     virtq.desc = (struct virtq_desc *)(requests_vaddr + desc_off);
     virtq.avail = (struct virtq_avail *)(requests_vaddr + avail_off);
     virtq.used = (struct virtq_used *)(requests_vaddr + used_off);
 
-    virtio_transport_queue_setup(&dev, 0, VIRTQ_NUM_REQUESTS, requests_paddr + desc_off, requests_paddr + avail_off,
+    virtio_transport_queue_setup(&dev, 0, driver_q_capacity, requests_paddr + desc_off, requests_paddr + avail_off,
                                  requests_paddr + used_off);
 
     /* Finish initialisation */
@@ -390,6 +389,10 @@ void init(void)
     virtio_blk_init();
 
     blk_queue_init(&blk_queue, config.virt.req_queue.vaddr, config.virt.resp_queue.vaddr, config.virt.num_buffers);
+
+    /* Driver ready */
+    blk_storage_info_t *storage_info = config.virt.storage_info.vaddr;
+    blk_storage_set_ready(storage_info, true);
 }
 
 void notified(sddf_channel ch)

--- a/drivers/network/virtio/common/ethernet.c
+++ b/drivers/network/virtio/common/ethernet.c
@@ -43,9 +43,8 @@ __attribute__((__section__(".net_driver_config"))) net_driver_config_t config;
 uintptr_t hw_ring_buffer_vaddr;
 uintptr_t hw_ring_buffer_paddr;
 
-#define RX_COUNT 512
-#define TX_COUNT 512
-#define MAX_COUNT MAX(RX_COUNT, TX_COUNT)
+#define RX_COUNT_MAX 512
+#define TX_COUNT_MAX 512
 
 #define HW_RING_SIZE (0x10000)
 
@@ -69,9 +68,9 @@ virtio_net_hdr_t *virtio_net_tx_headers;
 virtio_device_handle_t dev;
 
 ialloc_t rx_ialloc_desc;
-uint32_t rx_descriptors[RX_COUNT];
+uint32_t rx_descriptors[RX_COUNT_MAX];
 ialloc_t tx_ialloc_desc;
-uint32_t tx_descriptors[TX_COUNT];
+uint32_t tx_descriptors[TX_COUNT_MAX];
 
 static inline bool virtio_avail_full(struct virtq *virtq, ialloc_t *ialloc)
 {
@@ -330,16 +329,21 @@ static void eth_setup(void)
 #endif
 
     // Setup the virtqueues
+    uint16_t rx_q_host_capacity = virtio_transport_queue_get_capacity(&dev, VIRTIO_NET_RX_QUEUE);
+    uint16_t tx_q_host_capacity = virtio_transport_queue_get_capacity(&dev, VIRTIO_NET_TX_QUEUE);
+
+    uint16_t rx_q_driver_capacity = MIN(rx_q_host_capacity, RX_COUNT_MAX);
+    uint16_t tx_q_driver_capacity = MIN(tx_q_host_capacity, TX_COUNT_MAX);
 
     size_t rx_desc_off = 0;
-    size_t rx_avail_off = ALIGN(rx_desc_off + (16 * RX_COUNT), 2);
-    size_t rx_used_off = ALIGN(rx_avail_off + (6 + 2 * RX_COUNT), 4);
-    size_t tx_desc_off = ALIGN(rx_used_off + (6 + 8 * RX_COUNT), 16);
-    size_t tx_avail_off = ALIGN(tx_desc_off + (16 * TX_COUNT), 2);
-    size_t tx_used_off = ALIGN(tx_avail_off + (6 + 2 * TX_COUNT), 4);
-    size_t virtq_size = tx_used_off + (6 + 8 * TX_COUNT);
+    size_t rx_avail_off = ALIGN(rx_desc_off + (16 * rx_q_driver_capacity), 2);
+    size_t rx_used_off = ALIGN(rx_avail_off + (6 + 2 * rx_q_driver_capacity), 4);
+    size_t tx_desc_off = ALIGN(rx_used_off + (6 + 8 * rx_q_driver_capacity), 16);
+    size_t tx_avail_off = ALIGN(tx_desc_off + (16 * tx_q_driver_capacity), 2);
+    size_t tx_used_off = ALIGN(tx_avail_off + (6 + 2 * tx_q_driver_capacity), 4);
+    size_t virtq_size = tx_used_off + (6 + 8 * tx_q_driver_capacity);
 
-    rx_virtq.num = RX_COUNT;
+    rx_virtq.num = rx_q_driver_capacity;
     rx_virtq.desc = (struct virtq_desc *)(hw_ring_buffer_vaddr + rx_desc_off);
     rx_virtq.avail = (struct virtq_avail *)(hw_ring_buffer_vaddr + rx_avail_off);
     rx_virtq.used = (struct virtq_used *)(hw_ring_buffer_vaddr + rx_used_off);
@@ -348,7 +352,7 @@ static void eth_setup(void)
     assert((uintptr_t)rx_virtq.avail % 2 == 0);
     assert((uintptr_t)rx_virtq.used % 4 == 0);
 
-    tx_virtq.num = TX_COUNT;
+    tx_virtq.num = tx_q_driver_capacity;
     tx_virtq.desc = (struct virtq_desc *)(hw_ring_buffer_vaddr + tx_desc_off);
     tx_virtq.avail = (struct virtq_avail *)(hw_ring_buffer_vaddr + tx_avail_off);
     tx_virtq.used = (struct virtq_used *)(hw_ring_buffer_vaddr + tx_used_off);
@@ -361,22 +365,27 @@ static void eth_setup(void)
     virtio_net_tx_headers_vaddr = hw_ring_buffer_vaddr + virtq_size;
     virtio_net_tx_headers_paddr = hw_ring_buffer_paddr + virtq_size;
     virtio_net_tx_headers = (virtio_net_hdr_t *)virtio_net_tx_headers_vaddr;
-    size_t tx_headers_size = ((TX_COUNT / 2) * sizeof(virtio_net_hdr_t));
+    size_t tx_headers_size = ((tx_q_driver_capacity / 2) * sizeof(virtio_net_hdr_t));
     virtio_net_rx_headers_paddr = virtio_net_tx_headers_paddr + tx_headers_size;
-    size_t rx_headers_size = ((RX_COUNT / 2) * sizeof(virtio_net_hdr_t));
+    size_t rx_headers_size = ((rx_q_driver_capacity / 2) * sizeof(virtio_net_hdr_t));
 
     assert(virtq_size + tx_headers_size + rx_headers_size <= HW_RING_SIZE);
+
+    ialloc_init(&rx_ialloc_desc, rx_descriptors, rx_q_driver_capacity);
+    ialloc_init(&tx_ialloc_desc, tx_descriptors, tx_q_driver_capacity);
 
     rx_provide();
     tx_provide();
 
     // Setup RX queue first
-    assert(virtio_transport_queue_setup(&dev, VIRTIO_NET_RX_QUEUE, RX_COUNT, hw_ring_buffer_paddr + rx_desc_off,
-                                        hw_ring_buffer_paddr + rx_avail_off, hw_ring_buffer_paddr + rx_used_off));
+    assert(virtio_transport_queue_setup(&dev, VIRTIO_NET_RX_QUEUE, rx_q_driver_capacity,
+                                        hw_ring_buffer_paddr + rx_desc_off, hw_ring_buffer_paddr + rx_avail_off,
+                                        hw_ring_buffer_paddr + rx_used_off));
 
     // Setup TX queue
-    assert(virtio_transport_queue_setup(&dev, VIRTIO_NET_TX_QUEUE, TX_COUNT, hw_ring_buffer_paddr + tx_desc_off,
-                                        hw_ring_buffer_paddr + tx_avail_off, hw_ring_buffer_paddr + tx_used_off));
+    assert(virtio_transport_queue_setup(&dev, VIRTIO_NET_TX_QUEUE, tx_q_driver_capacity,
+                                        hw_ring_buffer_paddr + tx_desc_off, hw_ring_buffer_paddr + tx_avail_off,
+                                        hw_ring_buffer_paddr + tx_used_off));
 
     // Set the MAC address
     config->mac[0] = 0x52;
@@ -410,9 +419,6 @@ void init(void)
     hw_ring_buffer_vaddr = (uintptr_t)device_resources.regions[1].region.vaddr;
     hw_ring_buffer_paddr = device_resources.regions[1].io_addr;
 #endif
-
-    ialloc_init(&rx_ialloc_desc, rx_descriptors, RX_COUNT);
-    ialloc_init(&tx_ialloc_desc, tx_descriptors, TX_COUNT);
 
     net_queue_init(&rx_queue, config.virt_rx.free_queue.vaddr, config.virt_rx.active_queue.vaddr,
                    config.virt_rx.num_buffers);

--- a/include/sddf/virtio/transport/common.h
+++ b/include/sddf/virtio/transport/common.h
@@ -57,6 +57,7 @@ uint32_t virtio_transport_get_device_features(virtio_device_handle_t *device_han
 uint32_t virtio_transport_get_driver_features(virtio_device_handle_t *device_handle, uint32_t select);
 void virtio_transport_set_driver_features(virtio_device_handle_t *device_handle, uint32_t select,
                                           uint32_t driver_features);
+uint16_t virtio_transport_queue_get_capacity(virtio_device_handle_t *device_handle, uint32_t select);
 bool virtio_transport_queue_setup(virtio_device_handle_t *device_handle, uint32_t select, uint16_t size, uint64_t desc,
                                   uint64_t driver, uint64_t device);
 void virtio_transport_queue_notify(virtio_device_handle_t *device_handle, uint32_t select);

--- a/virtio/transport/mmio.c
+++ b/virtio/transport/mmio.c
@@ -95,19 +95,25 @@ void virtio_transport_set_driver_features(virtio_device_handle_t *device_handle,
     regs->DriverFeatures = driver_features;
 }
 
+uint16_t virtio_transport_queue_get_capacity(virtio_device_handle_t *device_handle, uint32_t select)
+{
+    volatile virtio_mmio_regs_t *regs = get_regs(device_handle->device_resources);
+    regs->QueueSel = select;
+    return regs->QueueNumMax;
+}
+
 bool virtio_transport_queue_setup(virtio_device_handle_t *device_handle, uint32_t select, uint16_t size, uint64_t desc,
                                   uint64_t driver, uint64_t device)
 {
-    volatile virtio_mmio_regs_t *regs = get_regs(device_handle->device_resources);
-
-    regs->QueueSel = select;
-
-    if (regs->QueueNumMax < size) {
-        LOG_VIRTIO_TRANSPORT("virtio queue is smaller than virtqueue!\n");
+    uint16_t hw_max_capacity = virtio_transport_queue_get_capacity(device_handle, select);
+    if (size > hw_max_capacity) {
+        LOG_VIRTIO_ERR("Requested queue size %u is larger than host's max %u!\n", size, hw_max_capacity);
         return false;
     }
 
-    regs->QueueNum = (uint32_t)size;
+    volatile virtio_mmio_regs_t *regs = get_regs(device_handle->device_resources);
+    regs->QueueSel = select;
+    regs->QueueNum = size;
     regs->QueueDescLow = desc & 0xffffffff;
     regs->QueueDescHigh = desc >> 32;
     regs->QueueDriverLow = driver & 0xffffffff;

--- a/virtio/transport/pci.c
+++ b/virtio/transport/pci.c
@@ -246,11 +246,23 @@ void virtio_transport_set_driver_features(virtio_device_handle_t *device_handle,
     cfg->driver_feature = driver_features;
 }
 
+uint16_t virtio_transport_queue_get_capacity(virtio_device_handle_t *device_handle, uint32_t select)
+{
+    virtio_pci_common_cfg_t *cfg = get_cfg(device_handle->device_resources);
+    cfg->queue_select = select;
+    return cfg->queue_size;
+}
+
 bool virtio_transport_queue_setup(virtio_device_handle_t *device_handle, uint32_t select, uint16_t size, uint64_t desc,
                                   uint64_t driver, uint64_t device)
 {
-    virtio_pci_common_cfg_t *cfg = get_cfg(device_handle->device_resources);
+    uint16_t hw_max_capacity = virtio_transport_queue_get_capacity(device_handle, select);
+    if (size > hw_max_capacity) {
+        LOG_VIRTIO_ERR("Requested queue size %u is larger than host's max %u!\n", size, hw_max_capacity);
+        return false;
+    }
 
+    virtio_pci_common_cfg_t *cfg = get_cfg(device_handle->device_resources);
     cfg->queue_select = select;
     cfg->queue_size = size;
     cfg->queue_desc = desc;


### PR DESCRIPTION
Previously we ignored the host's maximum virtqueues size and just
blasted our own value into the device. QEMU handled this gracefully
because it actually didn't check that what we wrote is under the limit,
but as of 11.1.0 this is no longer the case and our drivers broke. See:

https://freenode.net/article/qemu-fixes-virtio-mmio-queue-size-oob-cve-2026-50626

To fix this we must read what the host's maximum value is and clamp
the virtqueue size accordingly. We also need to initialise the index
allocator in the virtIO drivers with the corresponding range too,
otherwise we will get an out of bound index from the allocator.