### PR TITLE
virtualisers: ensure that the cache is clean prior to DMA into buffers

### DIFF
--- a/blk/components/virt.c
+++ b/blk/components/virt.c
@@ -86,7 +86,10 @@ static void handle_driver()
         switch (reqbk.code) {
         case BLK_REQ_READ:
             if (drv_status == BLK_RESP_OK) {
-                /* Invalidate cache */
+                /* Invalidate the cache following the DMA write to memory.
+                 * This relies on the cache already being clean for correctness,
+                 * which we ensure by performing a cache_clean() in handle_client().
+                 */
                 cache_clean_and_invalidate(reqbk.vaddr, reqbk.vaddr + (BLK_TRANSFER_SIZE * reqbk.count));
             }
             break;
@@ -178,6 +181,19 @@ static bool handle_client(int cli_id)
                 resp_status = BLK_RESP_ERR_INVALID_PARAM;
                 goto req_fail;
             }
+
+            /* Perform a cache_clean operation.
+             * - For BLK_REQ_READ (i.e. DMA writes happen), we need to ensure that
+             *   the cache is clean prior to DMA, as we perform cache_clean_and_invalidate()
+             *   in handle_driver(); if the cache was dirty that post-DMA clean
+             *   could overwrite DMA'd data.
+             * - For BLK_REQ_WRITE (i.e. DMA reads happen), we need to ensure that
+             *   the data in the cache is written out to memory, so clean
+             *   forces that flush.
+             */
+            cache_clean(cli_data_base_vaddr + cli_offset,
+                        cli_data_base_vaddr + cli_offset + (BLK_TRANSFER_SIZE * cli_count));
+
             break;
         }
         case BLK_REQ_FLUSH:
@@ -188,11 +204,6 @@ static bool handle_client(int cli_id)
             LOG_BLK_VIRT_ERR("client %d gave an invalid request code %d\n", cli_id, cli_code);
             resp_status = BLK_RESP_ERR_INVALID_PARAM;
             goto req_fail;
-        }
-
-        if (cli_code == BLK_REQ_WRITE) {
-            cache_clean(cli_data_base_vaddr + cli_offset,
-                        cli_data_base_vaddr + cli_offset + (BLK_TRANSFER_SIZE * cli_count));
         }
 
         /* Bookkeep client request and generate driver req id */

--- a/network/components/virt_rx.c
+++ b/network/components/virt_rx.c
@@ -77,6 +77,9 @@ void rx_return(void)
             // We would invalidate if it worked in usermode. Alas, it
             // does not -- see [1]. The fastest operation that works is a
             // usermode CleanInvalidate (faster than a Invalidate via syscall).
+            // This relies on the fact that we map the RX buffers in RO, so
+            // it is not possible to have dirty cache lines that will be written
+            // out with the clean.
             //
             // [1]: https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Instructions/DC-IVAC--Data-or-unified-Cache-line-Invalidate-by-VA-to-PoC
             cache_clean_and_invalidate(buffer_vaddr, buffer_vaddr + buffer.len);
@@ -148,9 +151,12 @@ void rx_provide(void)
                 }
 
                 // To avoid having to perform a cache clean here we ensure that
-                // the DMA region is only mapped in read only. This avoids the
-                // case where pending writes are only written to the buffer
-                // memory after DMA has occured.
+                // the DMA region is only mapped in read only in both the
+                // virtualiser and rx copier. This avoids the case where
+                // pending writes from dirty cache lines are only written to
+                // the buffer memory after DMA has occurred.
+                // i.e. the correctness of this assumes read-only access to
+                // RX buffers.
                 buffer.io_or_offset = buffer.io_or_offset + config.data.io_addr;
                 err = net_enqueue_free(&state.rx_queue_drv, buffer);
                 assert(!err);


### PR DESCRIPTION
The block virtualiser was previously only performing a cache_clean() if a write request (which performs a DMA read) was happening; but it needs to also perform it for the read request as we use a cache_clean_and_invaliate() to invalidate the DMA after the device writes into the buffer; which relies on the fact that the buffer caches are clean.

The net virtualiser avoids this problem by having the RX buffers mapped in RO and uses an RX copier, so it can omit the cache_clean().

Note that this is not a security issue; it only affects the one client, and could have been mitigated by a client performing cache clean on its own buffers; it will only cause data corruption.