### PR TITLE
Add base components for Acacia

### DIFF
--- a/acacia_sddf/__init__.py
+++ b/acacia_sddf/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+
+from .sddf import sDDFDriverClass, sDDFDriverConfig, sDDFDriverManifest
+from .board import BOARDS, Board

--- a/acacia_sddf/board.py
+++ b/acacia_sddf/board.py
@@ -1,0 +1,133 @@
+# Copyright 2025, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+from acacia import System, ProtectionDomain, aarch64, riscv64, x86_64, Arch
+from importlib.metadata import version
+
+
+@dataclass(frozen=True)
+class DriverDouble:
+    compatible: str
+    node_path: str
+
+
+@dataclass
+class Board:
+    name: str
+    arch: Arch
+    paddr_top: int
+    # Driver mappings -> (compatible, preferred_node) tuples
+    serial: DriverDouble = DriverDouble(None, None)
+    ethernet: DriverDouble = DriverDouble(None, None)
+    timer: DriverDouble = DriverDouble(None, None)
+    i2c: DriverDouble = DriverDouble(None, None)
+    blk: DriverDouble = DriverDouble(None, None)
+    partition: int = 0
+    baud_rate: Optional[int] = None
+
+
+# Keep this list in alphabetical order by board name
+# TODO: convert to Dictionary
+BOARDS: List[Board] = [
+    Board(
+        name="cheshire",
+        arch=riscv64,
+        paddr_top=0x90000000,
+    ),
+    Board(
+        name="hifive_p550",
+        arch=riscv64,
+        paddr_top=0xA0000000,
+    ),
+    Board(
+        name="imx8mm_evk",
+        arch=aarch64,
+        paddr_top=0x70000000,
+    ),
+    Board(
+        name="imx8mp_evk",
+        arch=aarch64,
+        paddr_top=0x70000000,
+    ),
+    Board(
+        name="imx8mp_iotgate",
+        arch=aarch64,
+        paddr_top=0x70000000,
+    ),
+    Board(
+        name="imx8mq_evk",
+        arch=aarch64,
+        paddr_top=0x70000000,
+    ),
+    Board(
+        name="kria_k26",
+        arch=aarch64,
+        paddr_top=0x70000000,
+    ),
+    Board(
+        name="maaxboard",
+        arch=aarch64,
+        paddr_top=0x70000000,
+        partition=2,
+    ),
+    Board(
+        name="odroidc2",
+        arch=aarch64,
+        paddr_top=0x60000000,
+        baud_rate=115200,
+    ),
+    Board(
+        name="odroidc4",
+        arch=aarch64,
+        paddr_top=0x60000000,
+        baud_rate=115200,
+    ),
+    Board(
+        name="qemu_virt_aarch64",
+        arch=aarch64,
+        paddr_top=0x6_0000_000,
+    ),
+    Board(
+        name="qemu_virt_riscv64",
+        arch=riscv64,
+        paddr_top=0xA_0000_000,
+        partition=0,
+    ),
+    Board(
+        name="rock3b",
+        arch=aarch64,
+        paddr_top=0xEC000000,
+        baud_rate=1500000,
+    ),
+    Board(
+        name="rpi4b_1gb",
+        arch=aarch64,
+        paddr_top=0x2_000_000,
+    ),
+    Board(
+        name="serengeti",
+        arch=riscv64,
+        paddr_top=0x90000000,
+    ),
+    Board(
+        name="star64",
+        arch=riscv64,
+        paddr_top=0x100000000,
+    ),
+    Board(
+        name="zcu102",
+        arch=aarch64,
+        paddr_top=0x80000000,
+    ),
+    Board(
+        name="x86_64_generic",
+        arch=x86_64,
+        paddr_top=0x7FFDF000,
+    ),
+    Board(
+        name="x86_64_generic_vtx",
+        arch=x86_64,
+        paddr_top=0x7FFDF000,
+    ),
+]

--- a/acacia_sddf/driver_manifest.py
+++ b/acacia_sddf/driver_manifest.py
@@ -1,0 +1,92 @@
+# Copyright 2026, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+
+from dataclasses import dataclass
+from typing import List, Dict, Type, Union, Optional
+from collections import defaultdict
+
+
+@dataclass
+class DTSRegion:
+    name: str
+    perms: str = None
+    size: int = None
+    dt_idx: int = None
+
+
+@dataclass
+class DTSIRQ:
+    dt_index: int
+
+
+@dataclass
+class sDDFDriverConfig:
+    """
+    Encapsulation of device tree fields describing an instance
+    of a driver.
+
+    WARNING: the order of regions and irqs affects the order they are
+    mapped into the driver in config structs! We REALLY shouldn't have
+    this be the case. This is a hangover from `config.json` and sdfgen.
+
+    TODO: make this better in future
+    """
+
+    compatible: Union[List[str], str]
+    regions: List[DTSRegion]
+    irqs: List[DTSIRQ]
+
+    def __post_init__(self):
+        if isinstance(self.compatible, str):
+            self.compatible = [self.compatible]
+        assert type(self.regions) is list
+        assert type(self.irqs) is list
+
+
+class __sDDFDriverManifest:
+    """
+    Wrapper class encapsulating sDDF driver manifest. This is a
+    mapping of driver subsystem type -> list of driver names ->
+    DTS fields. I.e. this encodes:
+        * Which drivers are compatible with what devices, according to the
+          device tree,
+        * What drivers are available in each driver class,
+        * Which driver subsystem types in sdfgen map to which drivers.
+
+    You should NOT make a new instance of this class! Use the
+    `sDDFDriverManifest()` function to get the global instance.
+    """
+
+    def __init__(self):
+        self.map: Dict[Type[sDDFDeviceClass], Dict[str, sDDFDriverConfig]] = (
+            defaultdict(dict)
+        )
+
+    def add_driver_config(
+        self,
+        subsystem_type: Type[sDDFDriverConfig],
+        driver_name: str,
+        config: sDDFDriverConfig,
+    ):
+        # Refuse namespace collisions
+        if driver_name in self.map[subsystem_type]:
+            raise ValueError(
+                f"Driver named {driver_name} already exists for " f"{subsystem_type}!"
+            )
+        self.map[subsystem_type][driver_name] = config
+
+    def __getitem__(self, item):
+        # Allow array syntax for indexing into dict of driver names per class type
+        return self.map[item]
+
+    def get_configs_matching_compatible(
+        self, subsystem_type: Type[sDDFDriverConfig], compat: str
+    ) -> List[sDDFDriverConfig]:
+        return [c for c in self.map[subsystem_type].values() if compat in c.compatible]
+
+
+module_manifest = __sDDFDriverManifest()
+
+
+def sDDFDriverManifest():
+    return module_manifest

--- a/acacia_sddf/sddf.py
+++ b/acacia_sddf/sddf.py
@@ -1,0 +1,244 @@
+# Copyright 2026, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+import sys, os
+from typing import List, Optional, Tuple
+from abc import abstractmethod
+from acacia import (
+    Subsystem,
+    ProtectionDomain,
+    Channel,
+    Map,
+    MemoryRegion,
+    DTBNode,
+    DeviceTreeBlob,
+    SchedulingProperties,
+    ConfigStruct,
+    IRQ,
+    System,
+)
+from .driver_manifest import sDDFDriverManifest, sDDFDriverConfig, DTSIRQ, DTSRegion
+
+
+class sDDFDriverClass(Subsystem):
+    """
+    This abstract class is inherited by all sDDF driver class implementations.
+    It handles:
+        a) Mapping of sDDF drivers to their corresponding device tree blobs
+        b) Parsing the device tree to set up device resources
+        c) Providing some common utility functions for generating config structs, etc.
+    """
+
+    def __init__(
+        self,
+        system: System,
+        driver_pd: ProtectionDomain,
+        class_name: str,
+        dev_compatible: str,
+        dev_dt_path: str,
+        magic: str,
+    ):
+        super().__init__(system, class_name)
+        self.driver = driver_pd
+        self.sdf = system
+        self.dtb = system.dtb
+        self.driver_magic = magic
+        if system.dtb is None:
+            print(
+                f"Initialising {class_name} driver with no DTB. Assuming this is x86 and no DTB is needed"
+            )
+            self.create_dtb_resources()
+            return
+
+        # Find real DTB node
+        print(
+            f"Finding {class_name} compatible for {dev_compatible} -- {dev_dt_path} from {self.dtb.file_path}"
+        )
+        target_node = self.dtb.get_node_by_path(dev_dt_path)
+
+        # make sure compatible matches!
+        if dev_compatible not in (a_c := self.dtb.get_compatible(target_node)):
+            raise IOError(
+                f"Target node {dev_dt_path} has compatible {a_c}... "
+                f"doesn't match expected {dev_compatible}!"
+            )
+
+        # check if DTB node is "okay" if it has a status
+        ok = self.dtb.get_node_prop(target_node, "status")
+        if ok is not None and ok.as_str() != "okay":
+            raise RuntimeError(f"{target_node} has bad status {ok.as_str()}!")
+
+        self.dtb_node = target_node
+
+        # Find sDDF driver matching this node
+        matching_configs = sDDFDriverManifest().get_configs_matching_compatible(
+            type(self), dev_compatible
+        )
+
+        if len(matching_configs) == 0:
+            raise RuntimeError(
+                f"No driver config matches {dev_compatible} -> {dev_dt_path}!"
+            )
+        elif len(matching_configs) != 1:
+            raise RuntimeError(
+                f"Multiple sDDF drivers satisfy {dev_compatible}! "
+                f"There should be only one.\n{matching_configs}"
+            )
+        self.sddf_driver_config = matching_configs[0]
+        self.create_dtb_resources()
+
+    def create_dtb_resources(self) -> ConfigStruct:
+        """
+        Given the driver PD and the DTB+driver_config we were initialised with,
+        create all regions, maps, and IRQs required. Creates a DeviceResources ConfigStruct
+        for the subsystem to use upon calling `create_config_structs`.
+        """
+        # track fields to store in DeviceResources. tuples of vaddr, offset
+        self.__region_maps = []
+        self.__irq_ids = []
+        if self.dtb is None:
+            print("sddf.py: no DTB! Creating dummy device resources.")
+            # x86 or otherwise no DTB!
+            print("sddf.py: no DTB! Assuming x86")
+            self.x86_resources()
+            return
+
+        for region in self.sddf_driver_config.regions:
+            mr = None
+            # We name regions as [region_name]_[node_path] to avoid collisions with
+            # duplicate driver classes on different nodes
+            region_name = region.name + "_" + self.dtb_node.path
+
+            # First: create or find matching MR
+            if region.dt_idx is not None:
+                # First: find reg property
+                regs = self.dtb.get_node_regs(self.dtb_node)
+                r_addr, r_sz = regs[region.dt_idx]
+                r_sz = self.sdf.arch.roundup_to_page(r_sz)
+
+                # Check we can turn this into a region
+                if region.size is not None:
+                    if r_sz < region.size:
+                        raise RuntimeError()  # todo
+
+                    if (region.size & (self.sdf.arch.default_page_size() - 1)) != 0:
+                        raise RuntimeError(
+                            f"Region {region} with size={region.size} is not aligned to"
+                            f"system page size!"
+                        )
+                mr_sz = region.size if region.size is not None else r_sz
+                d_paddr = self.dtb.get_reg_paddr(self.sdf.arch, self.dtb_node, r_addr)
+                d_reg_offset = r_addr % self.sdf.arch.default_page_size()
+
+                # Check if this page is shared (i.e. a matching region is already existing).
+                # If regions overlap but don't have the same start, we do nothing and let microkit
+                # reject this. Should we reject here? TODO
+                existing_mr = [mr for mr in self.sdf.mrs if mr.paddr == d_paddr]
+                if len(existing_mr) == 1:
+                    mr = existing_mr[0]
+                elif len(existing_mr) > 1:
+                    raise RuntimeError(
+                        f"Multiple MRs with paddr={d_paddr}! -> {existing_mr}"
+                    )
+                else:
+                    # This is new (or overlapping with a different start)
+                    mr = MemoryRegion(
+                        self.sdf, region_name, mr_sz, paddr=d_paddr, cached=False
+                    )
+            else:
+                # This is a physical region that needs an arbitrary paddr. We make it now
+                # and acacia assigns a paddr upon calling `System.assemble`. We make the
+                # config structs in `generate_config_structs` - Acacia only calls it AFTER
+                # assembling, ensuring that our MRs have a paddr in the config struct.
+                mr = MemoryRegion(self.sdf, region_name, region.size, physical=True)
+                d_reg_offset = 0
+
+            # Second: set up map
+            d_map = self.driver.create_automap(
+                mr, region.perms if region.perms else "rw"
+            )
+            self.__region_maps.append((d_map, d_reg_offset))
+
+        # Next: set up IRQs
+        irqs_from_prop = self.dtb.get_parsed_irqs(self.dtb_node, self.sdf.arch)
+        if len(irqs_from_prop) == 0 and (t := len(self.sddf_driver_config.irqs)) != 0:
+            raise RuntimeError(
+                f"Driver config expects {t} irqs but none found in node!"
+            )
+
+        for irq in self.sddf_driver_config.irqs:
+            if irq.dt_index >= len(irqs_from_prop):
+                raise IndexError(
+                    f"Config {self.sddf_driver_config} refers to more IRQs than present in DTB (n={len(irqs_from_prop)})!"
+                )
+            dt_irq = irqs_from_prop[irq.dt_index]
+            self.__irq_ids.append(self.driver.add_irq(dt_irq))
+
+    def generate_config_structs(self):
+        """
+        Returns config structs as specified by DTB and driver config. We need to make
+        MRs before Acacia calls `generate_config_structs` on each subsystem to ensure
+        physical MRs without an explicit paddr get assigned an address in time.
+        """
+        return [
+            DeviceResourcesFactory(
+                self.driver_magic,
+                self.__region_maps,
+                self.__irq_ids,
+                target_file=self.driver.prog_image,
+            )
+        ]
+
+    def x86_resources(self):
+        """
+        Create any resources needed if running on an x86 platform. Automatically
+        called in the event that no DTB is present. Subclasses should override this
+        method to do whatever they might need.
+
+        By default nothing will happen.
+        """
+        ...
+
+
+def RegionResourceFactory(map: Map, section_name: Optional[str] = None, offset=0):
+    fields = {"vaddr": map.vaddr + offset, "size": map.mr.size}
+    return ConfigStruct(
+        fields, type_name="region_resource_t", section_name=section_name
+    )
+
+
+def DeviceRegionResourceFactory(region: ConfigStruct, io_addr: int):
+    assert io_addr is not None
+    fields = {"region": region, "io_addr": io_addr}
+    return ConfigStruct(fields, type_name="device_region_resource_t")
+
+
+def DeviceIRQResourceFactory(id: int):
+    fields = {"id": id}
+    return ConfigStruct(fields, type_name="device_irq_resource_t")
+
+
+def DeviceResourcesFactory(
+    magic_str: str,
+    maps_offsets: List[Tuple[Map, int]],
+    irq_ids: List[int],
+    target_file: str,
+    section_name="device_resources",
+):
+    region_structs = [
+        DeviceRegionResourceFactory(RegionResourceFactory(m, offset=o), m.mr.paddr)
+        for m, o in maps_offsets
+    ]
+    irq_structs = [DeviceIRQResourceFactory(i) for i in irq_ids]
+    fields = {
+        "magic": magic_str,
+        "num_regions": len(region_structs),
+        "num_irqs": len(irq_structs),
+        "regions": region_structs,
+        "irqs": irq_structs,
+    }
+    return ConfigStruct(
+        fields,
+        type_name="device_resources_t",
+        section_name=section_name,
+        target_file=target_file,
+    )

--- a/include/sddf/resources/device.h
+++ b/include/sddf/resources/device.h
@@ -26,7 +26,7 @@ typedef struct device_irq_resource {
 } device_irq_resource_t;
 
 typedef struct device_resources {
-    char magic[5];
+    char magic[DEVICE_MAGIC_LEN];
     uint8_t num_regions;
     uint8_t num_irqs;
     device_region_resource_t regions[DEVICE_MAX_REGIONS];

--- a/include/sddf/resources/device.h
+++ b/include/sddf/resources/device.h
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include <sddf/resources/common.h>
 
-#define DEVICE_MAGIC_LEN 5
+#define DEVICE_MAGIC_LEN 6
 static char DEVICE_MAGIC[DEVICE_MAGIC_LEN] = { 's', 'D', 'D', 'F', 0x1 };
 
 #define DEVICE_MAX_REGIONS 64


### PR DESCRIPTION
This pull request adds a python module which hosts Acacia subsystems to generate sDDF classes.
* sddf.py implements the same functionality as sddf.zig in sdf_gen, with only a few deviations to enable nicer OO implementation of subclasses (e.g. x86 hook)
* driver_manifest.py replaces the sdf_gen driver probing process. This is a temporary measure: we need to rework how we parameterise drivers in the near future. We will need a manifest, it should just work a bit differently (i.e. better DTS support to handle platform-specific driver dependencies such as I2C needing a timer on some boards)
* board.py is minorly restructured and moved here. I have not removed the old board.py here to prevent breaking the existing metaprograms. We will need to remove the old one after merging all the device class PRs. The only real change here is to add compatible strings to each board peripheral definition, instead of only node paths. It also removes some misplaced code such as the function to add the TSC to x86 systems. Similarly to the above re: driver_manifest.py, I think we should nuke board.py altogether in the near future since device tree blobs theoretically encode all information we require.

This is the base PR for each new Acacia driver class. 

This extracts the base changes from https://github.com/au-ts/sddf/pull/751 with fixes applied for the discussion that reached resolutions.