### PR TITLE
Acacia serial

### DIFF
--- a/acacia_sddf/__init__.py
+++ b/acacia_sddf/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+
+from .sddf import sDDFDriverClass, sDDFDriverConfig, sDDFDriverManifest
+from .board import BOARDS, Board

--- a/acacia_sddf/__init__.py
+++ b/acacia_sddf/__init__.py
@@ -3,3 +3,4 @@
 
 from .sddf import sDDFDriverClass, sDDFDriverConfig, sDDFDriverManifest
 from .board import BOARDS, Board
+from .serial import sDDFSerial

--- a/acacia_sddf/board.py
+++ b/acacia_sddf/board.py
@@ -1,0 +1,133 @@
+# Copyright 2025, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+from acacia import System, ProtectionDomain, aarch64, riscv64, x86_64, Arch
+from importlib.metadata import version
+
+
+@dataclass(frozen=True)
+class DriverDouble:
+    compatible: str
+    node_path: str
+
+
+@dataclass
+class Board:
+    name: str
+    arch: Arch
+    paddr_top: int
+    # Driver mappings -> (compatible, preferred_node) tuples
+    serial: DriverDouble = DriverDouble(None, None)
+    ethernet: DriverDouble = DriverDouble(None, None)
+    timer: DriverDouble = DriverDouble(None, None)
+    i2c: DriverDouble = DriverDouble(None, None)
+    blk: DriverDouble = DriverDouble(None, None)
+    partition: int = 0
+    baud_rate: Optional[int] = None
+
+
+# Keep this list in alphabetical order by board name
+# TODO: convert to Dictionary
+BOARDS: List[Board] = [
+    Board(
+        name="cheshire",
+        arch=riscv64,
+        paddr_top=0x90000000,
+    ),
+    Board(
+        name="hifive_p550",
+        arch=riscv64,
+        paddr_top=0xA0000000,
+    ),
+    Board(
+        name="imx8mm_evk",
+        arch=aarch64,
+        paddr_top=0x70000000,
+    ),
+    Board(
+        name="imx8mp_evk",
+        arch=aarch64,
+        paddr_top=0x70000000,
+    ),
+    Board(
+        name="imx8mp_iotgate",
+        arch=aarch64,
+        paddr_top=0x70000000,
+    ),
+    Board(
+        name="imx8mq_evk",
+        arch=aarch64,
+        paddr_top=0x70000000,
+    ),
+    Board(
+        name="kria_k26",
+        arch=aarch64,
+        paddr_top=0x70000000,
+    ),
+    Board(
+        name="maaxboard",
+        arch=aarch64,
+        paddr_top=0x70000000,
+        partition=2,
+    ),
+    Board(
+        name="odroidc2",
+        arch=aarch64,
+        paddr_top=0x60000000,
+        baud_rate=115200,
+    ),
+    Board(
+        name="odroidc4",
+        arch=aarch64,
+        paddr_top=0x60000000,
+        baud_rate=115200,
+    ),
+    Board(
+        name="qemu_virt_aarch64",
+        arch=aarch64,
+        paddr_top=0x6_0000_000,
+    ),
+    Board(
+        name="qemu_virt_riscv64",
+        arch=riscv64,
+        paddr_top=0xA_0000_000,
+        partition=0,
+    ),
+    Board(
+        name="rock3b",
+        arch=aarch64,
+        paddr_top=0xEC000000,
+        baud_rate=1500000,
+    ),
+    Board(
+        name="rpi4b_1gb",
+        arch=aarch64,
+        paddr_top=0x2_000_000,
+    ),
+    Board(
+        name="serengeti",
+        arch=riscv64,
+        paddr_top=0x90000000,
+    ),
+    Board(
+        name="star64",
+        arch=riscv64,
+        paddr_top=0x100000000,
+    ),
+    Board(
+        name="zcu102",
+        arch=aarch64,
+        paddr_top=0x80000000,
+    ),
+    Board(
+        name="x86_64_generic",
+        arch=x86_64,
+        paddr_top=0x7FFDF000,
+    ),
+    Board(
+        name="x86_64_generic_vtx",
+        arch=x86_64,
+        paddr_top=0x7FFDF000,
+    ),
+]

--- a/acacia_sddf/board.py
+++ b/acacia_sddf/board.py
@@ -18,11 +18,11 @@ class Board:
     arch: Arch
     paddr_top: int
     # Driver mappings -> (compatible, preferred_node) tuples
-    serial: DriverDouble = DriverDouble(None, None)
-    ethernet: DriverDouble = DriverDouble(None, None)
-    timer: DriverDouble = DriverDouble(None, None)
-    i2c: DriverDouble = DriverDouble(None, None)
-    blk: DriverDouble = DriverDouble(None, None)
+    serial: Optional[DriverDouble] = DriverDouble(None, None)
+    ethernet: Optional[DriverDouble] = DriverDouble(None, None)
+    timer: Optional[DriverDouble] = DriverDouble(None, None)
+    i2c: Optional[DriverDouble] = DriverDouble(None, None)
+    blk: Optional[DriverDouble] = DriverDouble(None, None)
     partition: int = 0
     baud_rate: Optional[int] = None
 
@@ -34,91 +34,112 @@ BOARDS: List[Board] = [
         name="cheshire",
         arch=riscv64,
         paddr_top=0x90000000,
+        serial=DriverDouble("ns16550a", "soc/serial@3002000"),
     ),
     Board(
         name="hifive_p550",
         arch=riscv64,
         paddr_top=0xA0000000,
+        serial=DriverDouble("snps,dw-apb-uart", "soc/serial@0x50900000"),
     ),
     Board(
         name="imx8mm_evk",
         arch=aarch64,
         paddr_top=0x70000000,
+        serial=DriverDouble(
+            "fsl,imx8mm-uart", "soc@0/bus@30800000/spba-bus@30800000/serial@30890000"
+        ),
     ),
     Board(
         name="imx8mp_evk",
         arch=aarch64,
         paddr_top=0x70000000,
+        serial=DriverDouble(
+            "fsl,imx8mp-uart", "soc@0/bus@30800000/spba-bus@30800000/serial@30890000"
+        ),
     ),
     Board(
         name="imx8mp_iotgate",
         arch=aarch64,
         paddr_top=0x70000000,
+        serial=DriverDouble("fsl,imx8mp-uart", "soc@0/bus@30800000/serial@30890000"),
     ),
     Board(
         name="imx8mq_evk",
         arch=aarch64,
         paddr_top=0x70000000,
+        serial=DriverDouble("fsl,imx8mq-uart", "soc@0/bus@30800000/serial@30860000"),
     ),
     Board(
         name="kria_k26",
         arch=aarch64,
         paddr_top=0x70000000,
+        serial=DriverDouble("xlnx,zynqmp-uart", "axi/serial@ff010000"),
     ),
     Board(
         name="maaxboard",
         arch=aarch64,
         paddr_top=0x70000000,
+        serial=DriverDouble("fsl,imx8mq-uart", "soc@0/bus@30800000/serial@30860000"),
         partition=2,
     ),
     Board(
         name="odroidc2",
         arch=aarch64,
         paddr_top=0x60000000,
+        serial=DriverDouble("amlogic,meson-gx-uart", "soc/bus@c8100000/serial@4c0"),
         baud_rate=115200,
     ),
     Board(
         name="odroidc4",
         arch=aarch64,
         paddr_top=0x60000000,
+        serial=DriverDouble("amlogic,meson-gx-uart", "soc/bus@ff800000/serial@3000"),
         baud_rate=115200,
     ),
     Board(
         name="qemu_virt_aarch64",
         arch=aarch64,
         paddr_top=0x6_0000_000,
+        serial=DriverDouble("arm,pl011", "pl011@9000000"),
     ),
     Board(
         name="qemu_virt_riscv64",
         arch=riscv64,
         paddr_top=0xA_0000_000,
+        serial=DriverDouble("ns16550a", "soc/serial@10000000"),
         partition=0,
     ),
     Board(
         name="rock3b",
         arch=aarch64,
         paddr_top=0xEC000000,
+        serial=DriverDouble("snps,dw-apb-uart", "serial@fe660000"),
         baud_rate=1500000,
     ),
     Board(
         name="rpi4b_1gb",
         arch=aarch64,
         paddr_top=0x2_000_000,
+        serial=DriverDouble("brcm,bcm2835-aux-uart", "soc/serial@7e215040"),
     ),
     Board(
         name="serengeti",
         arch=riscv64,
         paddr_top=0x90000000,
+        serial=DriverDouble("ns16550a", "soc/serial@3002000"),
     ),
     Board(
         name="star64",
         arch=riscv64,
         paddr_top=0x100000000,
+        serial=DriverDouble("starfive,jh7110-uart", "soc/serial@10000000"),
     ),
     Board(
         name="zcu102",
         arch=aarch64,
         paddr_top=0x80000000,
+        serial=DriverDouble("xlnx,zynqmp-uart", "axi/serial@ff000000"),
     ),
     Board(
         name="x86_64_generic",

--- a/acacia_sddf/driver_manifest.py
+++ b/acacia_sddf/driver_manifest.py
@@ -1,0 +1,92 @@
+# Copyright 2026, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+
+from dataclasses import dataclass
+from typing import List, Dict, Type, Union, Optional
+from collections import defaultdict
+
+
+@dataclass
+class DTSRegion:
+    name: str
+    perms: str = None
+    size: int = None
+    dt_idx: int = None
+
+
+@dataclass
+class DTSIRQ:
+    dt_index: int
+
+
+@dataclass
+class sDDFDriverConfig:
+    """
+    Encapsulation of device tree fields describing an instance
+    of a driver.
+
+    WARNING: the order of regions and irqs affects the order they are
+    mapped into the driver in config structs! We REALLY shouldn't have
+    this be the case. This is a hangover from `config.json` and sdfgen.
+
+    TODO: make this better in future
+    """
+
+    compatible: Union[List[str], str]
+    regions: List[DTSRegion]
+    irqs: List[DTSIRQ]
+
+    def __post_init__(self):
+        if isinstance(self.compatible, str):
+            self.compatible = [self.compatible]
+        assert type(self.regions) is list
+        assert type(self.irqs) is list
+
+
+class __sDDFDriverManifest:
+    """
+    Wrapper class encapsulating sDDF driver manifest. This is a
+    mapping of driver subsystem type -> list of driver names ->
+    DTS fields. I.e. this encodes:
+        * Which drivers are compatible with what devices, according to the
+          device tree,
+        * What drivers are available in each driver class,
+        * Which driver subsystem types in sdfgen map to which drivers.
+
+    You should NOT make a new instance of this class! Use the
+    `sDDFDriverManifest()` function to get the global instance.
+    """
+
+    def __init__(self):
+        self.map: Dict[Type[sDDFDeviceClass], Dict[str, sDDFDriverConfig]] = (
+            defaultdict(dict)
+        )
+
+    def add_driver_config(
+        self,
+        subsystem_type: Type[sDDFDriverConfig],
+        driver_name: str,
+        config: sDDFDriverConfig,
+    ):
+        # Refuse namespace collisions
+        if driver_name in self.map[subsystem_type]:
+            raise ValueError(
+                f"Driver named {driver_name} already exists for " f"{subsystem_type}!"
+            )
+        self.map[subsystem_type][driver_name] = config
+
+    def __getitem__(self, item):
+        # Allow array syntax for indexing into dict of driver names per class type
+        return self.map[item]
+
+    def get_configs_matching_compatible(
+        self, subsystem_type: Type[sDDFDriverConfig], compat: str
+    ) -> List[sDDFDriverConfig]:
+        return [c for c in self.map[subsystem_type].values() if compat in c.compatible]
+
+
+module_manifest = __sDDFDriverManifest()
+
+
+def sDDFDriverManifest():
+    return module_manifest

--- a/acacia_sddf/sddf.py
+++ b/acacia_sddf/sddf.py
@@ -1,0 +1,244 @@
+# Copyright 2026, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+import sys, os
+from typing import List, Optional, Tuple
+from abc import abstractmethod
+from acacia import (
+    Subsystem,
+    ProtectionDomain,
+    Channel,
+    Map,
+    MemoryRegion,
+    DTBNode,
+    DeviceTreeBlob,
+    SchedulingProperties,
+    ConfigStruct,
+    IRQ,
+    System,
+)
+from .driver_manifest import sDDFDriverManifest, sDDFDriverConfig, DTSIRQ, DTSRegion
+
+
+class sDDFDriverClass(Subsystem):
+    """
+    This abstract class is inherited by all sDDF driver class implementations.
+    It handles:
+        a) Mapping of sDDF drivers to their corresponding device tree blobs
+        b) Parsing the device tree to set up device resources
+        c) Providing some common utility functions for generating config structs, etc.
+    """
+
+    def __init__(
+        self,
+        system: System,
+        driver_pd: ProtectionDomain,
+        class_name: str,
+        dev_compatible: str,
+        dev_dt_path: str,
+        magic: str,
+    ):
+        super().__init__(system, class_name)
+        self.driver = driver_pd
+        self.sdf = system
+        self.dtb = system.dtb
+        self.driver_magic = magic
+        if system.dtb is None:
+            print(
+                f"Initialising {class_name} driver with no DTB. Assuming this is x86 and no DTB is needed"
+            )
+            self.create_dtb_resources()
+            return
+
+        # Find real DTB node
+        print(
+            f"Finding {class_name} compatible for {dev_compatible} -- {dev_dt_path} from {self.dtb.file_path}"
+        )
+        target_node = self.dtb.get_node_by_path(dev_dt_path)
+
+        # make sure compatible matches!
+        if dev_compatible not in (a_c := self.dtb.get_compatible(target_node)):
+            raise IOError(
+                f"Target node {dev_dt_path} has compatible {a_c}... "
+                f"doesn't match expected {dev_compatible}!"
+            )
+
+        # check if DTB node is "okay" if it has a status
+        ok = self.dtb.get_node_prop(target_node, "status")
+        if ok is not None and ok.as_str() != "okay":
+            raise RuntimeError(f"{target_node} has bad status {ok.as_str()}!")
+
+        self.dtb_node = target_node
+
+        # Find sDDF driver matching this node
+        matching_configs = sDDFDriverManifest().get_configs_matching_compatible(
+            type(self), dev_compatible
+        )
+
+        if len(matching_configs) == 0:
+            raise RuntimeError(
+                f"No driver config matches {dev_compatible} -> {dev_dt_path}!"
+            )
+        elif len(matching_configs) != 1:
+            raise RuntimeError(
+                f"Multiple sDDF drivers satisfy {dev_compatible}! "
+                f"There should be only one.\n{matching_configs}"
+            )
+        self.sddf_driver_config = matching_configs[0]
+        self.create_dtb_resources()
+
+    def create_dtb_resources(self) -> ConfigStruct:
+        """
+        Given the driver PD and the DTB+driver_config we were initialised with,
+        create all regions, maps, and IRQs required. Creates a DeviceResources ConfigStruct
+        for the subsystem to use upon calling `create_config_structs`.
+        """
+        # track fields to store in DeviceResources. tuples of vaddr, offset
+        self.__region_maps = []
+        self.__irq_ids = []
+        if self.dtb is None:
+            print("sddf.py: no DTB! Creating dummy device resources.")
+            # x86 or otherwise no DTB!
+            print("sddf.py: no DTB! Assuming x86")
+            self.x86_resources()
+            return
+
+        for region in self.sddf_driver_config.regions:
+            mr = None
+            # We name regions as [region_name]_[node_path] to avoid collisions with
+            # duplicate driver classes on different nodes
+            region_name = region.name + "_" + self.dtb_node.path
+
+            # First: create or find matching MR
+            if region.dt_idx is not None:
+                # First: find reg property
+                regs = self.dtb.get_node_regs(self.dtb_node)
+                r_addr, r_sz = regs[region.dt_idx]
+                r_sz = self.sdf.arch.roundup_to_page(r_sz)
+
+                # Check we can turn this into a region
+                if region.size is not None:
+                    if r_sz < region.size:
+                        raise RuntimeError()  # todo
+
+                    if (region.size & (self.sdf.arch.default_page_size() - 1)) != 0:
+                        raise RuntimeError(
+                            f"Region {region} with size={region.size} is not aligned to"
+                            f"system page size!"
+                        )
+                mr_sz = region.size if region.size is not None else r_sz
+                d_paddr = self.dtb.get_reg_paddr(self.sdf.arch, self.dtb_node, r_addr)
+                d_reg_offset = r_addr % self.sdf.arch.default_page_size()
+
+                # Check if this page is shared (i.e. a matching region is already existing).
+                # If regions overlap but don't have the same start, we do nothing and let microkit
+                # reject this. Should we reject here? TODO
+                existing_mr = [mr for mr in self.sdf.mrs if mr.paddr == d_paddr]
+                if len(existing_mr) == 1:
+                    mr = existing_mr[0]
+                elif len(existing_mr) > 1:
+                    raise RuntimeError(
+                        f"Multiple MRs with paddr={d_paddr}! -> {existing_mr}"
+                    )
+                else:
+                    # This is new (or overlapping with a different start)
+                    mr = MemoryRegion(
+                        self.sdf, region_name, mr_sz, paddr=d_paddr, cached=False
+                    )
+            else:
+                # This is a physical region that needs an arbitrary paddr. We make it now
+                # and acacia assigns a paddr upon calling `System.assemble`. We make the
+                # config structs in `generate_config_structs` - Acacia only calls it AFTER
+                # assembling, ensuring that our MRs have a paddr in the config struct.
+                mr = MemoryRegion(self.sdf, region_name, region.size, physical=True)
+                d_reg_offset = 0
+
+            # Second: set up map
+            d_map = self.driver.create_automap(
+                mr, region.perms if region.perms else "rw"
+            )
+            self.__region_maps.append((d_map, d_reg_offset))
+
+        # Next: set up IRQs
+        irqs_from_prop = self.dtb.get_parsed_irqs(self.dtb_node, self.sdf.arch)
+        if len(irqs_from_prop) == 0 and (t := len(self.sddf_driver_config.irqs)) != 0:
+            raise RuntimeError(
+                f"Driver config expects {t} irqs but none found in node!"
+            )
+
+        for irq in self.sddf_driver_config.irqs:
+            if irq.dt_index >= len(irqs_from_prop):
+                raise IndexError(
+                    f"Config {self.sddf_driver_config} refers to more IRQs than present in DTB (n={len(irqs_from_prop)})!"
+                )
+            dt_irq = irqs_from_prop[irq.dt_index]
+            self.__irq_ids.append(self.driver.add_irq(dt_irq))
+
+    def generate_config_structs(self):
+        """
+        Returns config structs as specified by DTB and driver config. We need to make
+        MRs before Acacia calls `generate_config_structs` on each subsystem to ensure
+        physical MRs without an explicit paddr get assigned an address in time.
+        """
+        return [
+            DeviceResourcesFactory(
+                self.driver_magic,
+                self.__region_maps,
+                self.__irq_ids,
+                target_file=self.driver.prog_image,
+            )
+        ]
+
+    def x86_resources(self):
+        """
+        Create any resources needed if running on an x86 platform. Automatically
+        called in the event that no DTB is present. Subclasses should override this
+        method to do whatever they might need.
+
+        By default nothing will happen.
+        """
+        ...
+
+
+def RegionResourceFactory(map: Map, section_name: Optional[str] = None, offset=0):
+    fields = {"vaddr": map.vaddr + offset, "size": map.mr.size}
+    return ConfigStruct(
+        fields, type_name="region_resource_t", section_name=section_name
+    )
+
+
+def DeviceRegionResourceFactory(region: ConfigStruct, io_addr: int):
+    assert io_addr is not None
+    fields = {"region": region, "io_addr": io_addr}
+    return ConfigStruct(fields, type_name="device_region_resource_t")
+
+
+def DeviceIRQResourceFactory(id: int):
+    fields = {"id": id}
+    return ConfigStruct(fields, type_name="device_irq_resource_t")
+
+
+def DeviceResourcesFactory(
+    magic_str: str,
+    maps_offsets: List[Tuple[Map, int]],
+    irq_ids: List[int],
+    target_file: str,
+    section_name="device_resources",
+):
+    region_structs = [
+        DeviceRegionResourceFactory(RegionResourceFactory(m, offset=o), m.mr.paddr)
+        for m, o in maps_offsets
+    ]
+    irq_structs = [DeviceIRQResourceFactory(i) for i in irq_ids]
+    fields = {
+        "magic": magic_str,
+        "num_regions": len(region_structs),
+        "num_irqs": len(irq_structs),
+        "regions": region_structs,
+        "irqs": irq_structs,
+    }
+    return ConfigStruct(
+        fields,
+        type_name="device_resources_t",
+        section_name=section_name,
+        target_file=target_file,
+    )

--- a/acacia_sddf/serial.py
+++ b/acacia_sddf/serial.py
@@ -1,0 +1,538 @@
+# Copyright 2026, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+
+from acacia import (
+    System,
+    Subsystem,
+    ProtectionDomain,
+    Channel,
+    Map,
+    MemoryRegion,
+    DTBNode,
+    DeviceTreeBlob,
+    SchedulingProperties,
+    ConfigStruct,
+    SubsystemBuildError,
+)
+from acacia.x86 import IOPort
+from acacia.irq import IrqIoapic
+import sys, os
+from .driver_manifest import sDDFDriverManifest, sDDFDriverConfig, DTSIRQ, DTSRegion
+from .sddf import sDDFDriverClass, DeviceResourcesFactory, RegionResourceFactory
+from collections import defaultdict
+from typing import List, Dict, Type, Union, Optional
+
+SERIAL_DEFAULT_BEGIN_STR = "Begin input\r\n"
+SERIAL_MAX_BEGIN_STR_LEN = 128
+SERIAL_PROTOCOL_MAGIC = "sDDF" + chr(0x3)
+
+
+class sDDFSerial(sDDFDriverClass):
+    def __init__(
+        self,
+        sdf: System,
+        dev_compatible: str,
+        dev_dt_path: str,
+        driver_prio: int,
+        virt_tx_prio: int,
+        allow_rx: bool = False,
+        virt_rx_prio: Optional[int] = None,
+        cpu: Optional[int] = None,
+        enable_color: bool = True,
+        baud_rate: int = 115200,
+        begin_str: str = SERIAL_DEFAULT_BEGIN_STR,
+        # We leave this as configurable just in case...
+        data_size: int = 0x10000,
+        queue_size: int = 0x1000,
+        virt_rx_elf: str = "serial_virt_rx.elf",
+        virt_tx_elf: str = "serial_virt_tx.elf",
+        driver_elf: str = "serial_driver.elf",
+    ):
+        assert driver_prio > virt_tx_prio > 0
+        if allow_rx:
+            # Default RX prio == TX prio
+            if virt_rx_prio is None:
+                virt_rx_prio = virt_tx_prio
+            assert driver_prio > virt_rx_prio > 0
+
+        self.cpu = cpu
+        driver = ProtectionDomain(
+            sdf,
+            "serial_driver",
+            driver_elf,
+            scheduling=SchedulingProperties(driver_prio),
+            cpu=self.cpu,
+        )
+        super().__init__(
+            sdf, driver, "serial", dev_compatible, dev_dt_path, magic="sDDF" + chr(0x1)
+        )
+        self.allow_rx = allow_rx
+        self.data_size = data_size
+        self.queue_size = queue_size
+        self.enable_color = enable_color
+        self.baud_rate = baud_rate
+        if len(begin_str) > SERIAL_MAX_BEGIN_STR_LEN:
+            raise SubsystemBuildError(
+                f"begin_str length {len(begin_str)} exceeds max {SERIAL_MAX_BEGIN_STR_LEN}"
+            )
+        self.begin_str = begin_str
+        self.virt_tx = None
+        self.virt_rx = None
+        self.virt_rx_elf = virt_rx_elf
+        self.virt_tx_elf = virt_tx_elf
+
+        # Stubs of config structs that we need to collect in construct_infrastructure and connect_clients
+        self.virt_tx_config = None
+        self.virt_rx_config = None
+        self.driver_config = None
+        self.virt_tx_driver_conn = None
+        self.virt_rx_driver_conn = None
+        self.client_configs = []
+        self.construct_infrastructure(
+            virt_rx_prio if virt_rx_prio else -1, virt_tx_prio
+        )
+
+    def construct_infrastructure(self, virt_rx_prio: int, virt_tx_prio: int):
+        self.virt_tx = ProtectionDomain(
+            self.sdf,
+            "serial_virt_tx",
+            self.virt_tx_elf,
+            scheduling=SchedulingProperties(virt_tx_prio),
+            cpu=self.cpu,
+        )
+        if self.allow_rx and virt_rx_prio > 0:
+            self.virt_rx = ProtectionDomain(
+                self.sdf,
+                "serial_virt_rx",
+                self.virt_rx_elf,
+                scheduling=SchedulingProperties(virt_rx_prio),
+                cpu=self.cpu,
+            )
+
+        driver_tx_queue_mr = MemoryRegion(
+            self.sdf, "serial_driver_tx_queue", self.queue_size
+        )
+        driver_tx_data_mr = MemoryRegion(
+            self.sdf,
+            "serial_driver_tx_data",
+            self.data_size * 2 if self.enable_color else self.data_size,
+            cached=True,
+        )
+
+        driver_tx_queue_map = self.driver.create_automap(
+            driver_tx_queue_mr, Map.Permissions(r=True, w=True)
+        )
+        driver_tx_data_map = self.driver.create_automap(
+            driver_tx_data_mr, Map.Permissions(r=True, w=True)
+        )
+        virt_tx_queue_map = self.virt_tx.create_automap(
+            driver_tx_queue_mr, Map.Permissions(r=True, w=True)
+        )
+        virt_tx_data_map = self.virt_tx.create_automap(
+            driver_tx_data_mr, Map.Permissions(r=True, w=True)
+        )
+
+        driver_virt_tx_ch = Channel(
+            self.sdf,
+            Channel.End(self.driver, can_notify=True, can_pp=False),
+            Channel.End(self.virt_tx, can_notify=True, can_pp=False),
+        )
+
+        driver_tx_conn = self.serial_connection_resource_factory(
+            driver_tx_queue_map,
+            driver_tx_data_map,
+            driver_virt_tx_ch.id_for_pd(self.driver),
+        )
+        self.virt_tx_driver_conn = self.serial_connection_resource_factory(
+            virt_tx_queue_map,
+            virt_tx_data_map,
+            driver_virt_tx_ch.id_for_pd(self.virt_tx),
+        )
+
+        driver_rx_conn = None
+        if self.virt_rx:
+            driver_rx_queue_mr = MemoryRegion(
+                self.sdf, "serial_driver_rx_queue", self.queue_size
+            )
+            driver_rx_data_mr = MemoryRegion(
+                self.sdf, "serial_driver_rx_data", self.data_size
+            )
+
+            driver_rx_queue_map = self.driver.create_automap(
+                driver_rx_queue_mr, Map.Permissions(r=True, w=True)
+            )
+            driver_rx_data_map = self.driver.create_automap(
+                driver_rx_data_mr, Map.Permissions(r=True, w=True)
+            )
+            virt_rx_queue_map = self.virt_rx.create_automap(
+                driver_rx_queue_mr, Map.Permissions(r=True, w=True)
+            )
+            virt_rx_data_map = self.virt_rx.create_automap(
+                driver_rx_data_mr, Map.Permissions(r=True, w=True)
+            )
+
+            driver_virt_rx_ch = Channel(
+                self.sdf,
+                Channel.End(self.driver, can_notify=True, can_pp=False),
+                Channel.End(self.virt_rx, can_notify=True, can_pp=False),
+            )
+
+            driver_rx_conn = self.serial_connection_resource_factory(
+                driver_rx_queue_map,
+                driver_rx_data_map,
+                driver_virt_rx_ch.id_for_pd(self.driver),
+            )
+            self.virt_rx_driver_conn = self.serial_connection_resource_factory(
+                virt_rx_queue_map,
+                virt_rx_data_map,
+                driver_virt_rx_ch.id_for_pd(self.virt_rx),
+            )
+
+        self.driver_config = self.serial_driver_config_factory(
+            self.driver,
+            SERIAL_PROTOCOL_MAGIC,
+            self.baud_rate,
+            1 if self.virt_rx else 0,
+            driver_tx_conn,
+            driver_rx_conn,
+        )
+
+    def connect_clients(self):
+        assert self.virt_tx is not None
+        assert self.driver is not None
+
+        virt_tx_client_structs = []
+        virt_rx_client_conns = []
+        client_configs = []
+
+        for c in self.clients:
+            if c.priority >= self.virt_tx.priority:
+                raise SubsystemBuildError(
+                    f"Client {c} has a priority higher than virt_tx's "
+                    f"({self.virt_tx.priority})!"
+                )
+            if self.virt_rx and c.priority >= self.virt_rx.priority:
+                raise SubsystemBuildError(
+                    f"Client {c} has a priority higher than virt_rx's "
+                    f"({self.virt_rx.priority})!"
+                )
+
+            # TX connection: virt_tx -> client
+            tx_queue_mr = MemoryRegion(
+                self.sdf, f"serial_tx_queue_{c.name}", self.queue_size
+            )
+            tx_data_mr = MemoryRegion(
+                self.sdf, f"serial_tx_data_{c.name}", self.data_size
+            )
+
+            virt_tx_tx_queue_map = self.virt_tx.create_automap(
+                tx_queue_mr, Map.Permissions(r=True, w=True)
+            )
+            virt_tx_tx_data_map = self.virt_tx.create_automap(
+                tx_data_mr, Map.Permissions(r=True, w=True)
+            )
+            c_tx_queue_map = c.create_automap(
+                tx_queue_mr, Map.Permissions(r=True, w=True)
+            )
+            c_tx_data_map = c.create_automap(
+                tx_data_mr, Map.Permissions(r=True, w=True)
+            )
+
+            tx_ch = Channel(
+                self.sdf,
+                Channel.End(self.virt_tx, can_notify=True, can_pp=False),
+                Channel.End(c, can_notify=True, can_pp=False),
+            )
+
+            virt_tx_conn = self.serial_connection_resource_factory(
+                virt_tx_tx_queue_map, virt_tx_tx_data_map, tx_ch.id_for_pd(self.virt_tx)
+            )
+            client_tx_conn = self.serial_connection_resource_factory(
+                c_tx_queue_map, c_tx_data_map, tx_ch.id_for_pd(c)
+            )
+
+            virt_tx_client_structs.append(
+                self.serial_virt_tx_client_config_factory(c.name, virt_tx_conn)
+            )
+
+            # RX connection (if enabled): virt_rx -> client
+            client_rx_conn = None
+            if self.virt_rx:
+                rx_queue_mr = MemoryRegion(
+                    self.sdf, f"serial_rx_queue_{c.name}", self.queue_size
+                )
+                rx_data_mr = MemoryRegion(
+                    self.sdf, f"serial_rx_data_{c.name}", self.data_size
+                )
+
+                virt_rx_rx_queue_map = self.virt_rx.create_automap(
+                    rx_queue_mr, Map.Permissions(r=True, w=True)
+                )
+                virt_rx_rx_data_map = self.virt_rx.create_automap(
+                    rx_data_mr, Map.Permissions(r=True, w=True)
+                )
+                c_rx_queue_map = c.create_automap(
+                    rx_queue_mr, Map.Permissions(r=True, w=True)
+                )
+                c_rx_data_map = c.create_automap(
+                    rx_data_mr, Map.Permissions(r=True, w=True)
+                )
+
+                rx_ch = Channel(
+                    self.sdf,
+                    Channel.End(self.virt_rx, can_notify=True, can_pp=False),
+                    Channel.End(c, can_notify=True, can_pp=False),
+                )
+
+                virt_rx_conn = self.serial_connection_resource_factory(
+                    virt_rx_rx_queue_map,
+                    virt_rx_rx_data_map,
+                    rx_ch.id_for_pd(self.virt_rx),
+                )
+                client_rx_conn = self.serial_connection_resource_factory(
+                    c_rx_queue_map, c_rx_data_map, rx_ch.id_for_pd(c)
+                )
+                virt_rx_client_conns.append(virt_rx_conn)
+
+            client_configs.append(
+                self.serial_client_config_factory(
+                    c, SERIAL_PROTOCOL_MAGIC, client_tx_conn, client_rx_conn
+                )
+            )
+
+        self.virt_tx_config = self.serial_virt_tx_config_factory(
+            self.virt_tx,
+            SERIAL_PROTOCOL_MAGIC,
+            len(self.clients),
+            self.virt_tx_driver_conn,
+            virt_tx_client_structs,
+            1 if self.enable_color else 0,
+            1 if self.virt_rx else 0,
+            self.begin_str,
+        )
+
+        if self.virt_rx:
+            self.virt_rx_config = self.serial_virt_rx_config_factory(
+                self.virt_rx,
+                SERIAL_PROTOCOL_MAGIC,
+                len(self.clients),
+                self.virt_rx_driver_conn,
+                virt_rx_client_conns,
+            )
+
+        self.client_configs = client_configs
+
+    def x86_resources(self):
+        self.add_x86_serial_port()
+
+    def generate_config_structs(self):
+        # We've already made our structs, just return them as a list for the serialiser
+        driver_resources = [self.driver_config]
+        virt_resources = []
+        if self.virt_tx_config:
+            virt_resources.append(self.virt_tx_config)
+        if self.virt_rx_config:
+            virt_resources.append(self.virt_rx_config)
+        return (
+            super().generate_config_structs()
+            + [self.driver_config]
+            + virt_resources
+            + self.client_configs
+        )
+
+    # ### connection config struct factory functions ###
+
+    def serial_connection_resource_factory(
+        self, queue_map: Map, data_map: Map, ch_id: int
+    ) -> ConfigStruct:
+        fields = {
+            "queue": RegionResourceFactory(queue_map),
+            "data": RegionResourceFactory(data_map),
+            "id": ch_id,
+        }
+        return ConfigStruct(fields, type_name="serial_connection_resource_t")
+
+    def serial_driver_config_factory(
+        self,
+        driver_pd: ProtectionDomain,
+        magic: str,
+        baud_rate: int,
+        rx_enabled: int,
+        tx_connection: ConfigStruct,
+        rx_connection: Optional[ConfigStruct] = None,
+    ) -> ConfigStruct:
+        fields = {
+            "magic": magic,
+            "default_baud": baud_rate,
+            "rx_enabled": rx_enabled,
+            "tx": tx_connection,
+            "rx": rx_connection if rx_connection else ConfigStruct({}, empty=True),
+        }
+        return ConfigStruct(
+            fields,
+            type_name="serial_driver_config_t",
+            target_file=driver_pd.prog_image,
+            section_name="serial_driver_config",
+        )
+
+    def serial_virt_rx_config_factory(
+        self,
+        virt_rx_pd: ProtectionDomain,
+        magic: str,
+        num_clients: int,
+        driver_connection: ConfigStruct,
+        client_connections: List[ConfigStruct],
+    ) -> ConfigStruct:
+        fields = {
+            "magic": magic,
+            "num_clients": num_clients,
+            "driver": driver_connection,
+            "clients": client_connections,
+            "switch_char": chr(28),
+            "terminate_num_char": "\r",
+        }
+        return ConfigStruct(
+            fields,
+            type_name="serial_virt_rx_config_t",
+            target_file=virt_rx_pd.prog_image,
+            section_name="serial_virt_rx_config",
+        )
+
+    def serial_virt_tx_client_config_factory(
+        self, name: str, conn: ConfigStruct
+    ) -> ConfigStruct:
+        fields = {
+            "conn": conn,
+            "name": name,
+        }
+        return ConfigStruct(fields, type_name="serial_virt_tx_client_t")
+
+    def serial_virt_tx_config_factory(
+        self,
+        virt_tx_pd: ProtectionDomain,
+        magic: str,
+        num_clients: int,
+        driver_connection: ConfigStruct,
+        client_connections: List[ConfigStruct],
+        enable_colour: int,
+        enable_rx: int,
+        begin_str: str,
+    ) -> ConfigStruct:
+        fields = {
+            "magic": magic,
+            "driver": driver_connection,
+            "clients": client_connections,
+            "num_clients": num_clients,
+            "begin_str": begin_str,
+            "enable_colour": enable_colour,
+            "enable_rx": enable_rx,
+        }
+        return ConfigStruct(
+            fields,
+            type_name="serial_virt_tx_config_t",
+            target_file=virt_tx_pd.prog_image,
+            section_name="serial_virt_tx_config",
+        )
+
+    def serial_client_config_factory(
+        self,
+        client_pd: ProtectionDomain,
+        magic,
+        tx_connection: ConfigStruct,
+        rx_connection: Optional[ConfigStruct] = None,
+    ) -> ConfigStruct:
+        fields = {
+            "magic": magic,
+            "tx": tx_connection,
+            "rx": rx_connection if rx_connection else ConfigStruct({}, empty=True),
+        }
+        return ConfigStruct(
+            fields,
+            type_name="serial_client_config_t",
+            target_file=client_pd.prog_image,
+            section_name="serial_client_config",
+        )
+
+    # x86 Util
+    def add_x86_serial_port(self):
+        # The serial device does not located on PCIe and the interrupts are
+        # conventionally configured by BIOS. The IRQ number can be read from
+        # Linux or APCI tables.
+        self.driver.add_ioport(IOPort(0x3F8, 8, 0))
+        self.driver.add_irq(IrqIoapic(0, 4, 0, id=1))
+
+
+# Driver configs
+serial_driver_configs: Dict[str, List[sDDFDriverConfig]] = defaultdict(list)
+
+
+def add_driver_config(driver_name: str, config: sDDFDriverConfig):
+    sDDFDriverManifest().add_driver_config(sDDFSerial, driver_name, config)
+
+
+add_driver_config(
+    "meson",
+    sDDFDriverConfig(
+        ["amlogic,meson-gx-uart", "amlogic,meson-ao-uart"],
+        [DTSRegion("regs", "rw", 4096, 0)],
+        [DTSIRQ(0)],
+    ),
+)
+
+add_driver_config(
+    "pl011",
+    sDDFDriverConfig(
+        compatible="arm,pl011",
+        regions=[DTSRegion("regs", "rw", 4096, 0)],
+        irqs=[DTSIRQ(0)],
+    ),
+)
+
+add_driver_config(
+    "imx",
+    sDDFDriverConfig(
+        compatible=["fsl,imx8mq-uart", "fsl,imx8mm-uart", "fsl,imx8mp-uart"],
+        regions=[DTSRegion("regs", "rw", 4096, 0)],
+        irqs=[DTSIRQ(0)],
+    ),
+)
+
+# ns16550a
+add_driver_config(
+    "ns16550a",
+    sDDFDriverConfig(
+        compatible=[
+            "starfive,jh7110-uart",
+            "ns16550a",
+            "brcm,bcm2835-aux-uart",
+            "snps,dw-apb-uart",
+        ],
+        regions=[DTSRegion("regs", "rw", 4096, 0)],
+        irqs=[DTSIRQ(0)],
+    ),
+)
+
+# virtio
+add_driver_config(
+    "virtio",
+    sDDFDriverConfig(
+        compatible="virtio,mmio",
+        regions=[
+            DTSRegion("regs", "rw", 4096, 0),
+            DTSRegion("hw_ring_buffer", size=65536),
+            DTSRegion("virtio_rx_buf", size=4096),
+            DTSRegion("virtio_tx_buf", size=4096),
+        ],
+        irqs=[DTSIRQ(0)],
+    ),
+)
+
+# xlnx
+add_driver_config(
+    "xlnx",
+    sDDFDriverConfig(
+        compatible="xlnx,zynqmp-uart",
+        regions=[DTSRegion("regs", dt_idx=0)],
+        irqs=[DTSIRQ(0)],
+    ),
+)

--- a/examples/serial/meta.py
+++ b/examples/serial/meta.py
@@ -4,72 +4,35 @@ import sys, os
 import argparse
 from typing import List
 from dataclasses import dataclass
-from sdfgen import SystemDescription, Sddf, DeviceTree
+from acacia import System, ProtectionDomain, MemoryRegion, Channel, DeviceTreeBlob
+from acacia.arch import x86_64
 
-sys.path.append(
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../tools/meta")
-)
-from board import BOARDS
-
-ProtectionDomain = SystemDescription.ProtectionDomain
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../"))
+from acacia_sddf import sDDFSerial, BOARDS
 
 
-def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
-    serial_driver = ProtectionDomain("serial_driver", "serial_driver.elf", priority=200)
-    serial_virt_tx = ProtectionDomain(
-        "serial_virt_tx", "serial_virt_tx.elf", priority=199
-    )
-    serial_virt_rx = ProtectionDomain(
-        "serial_virt_rx", "serial_virt_rx.elf", priority=199
-    )
+def generate(sdf_file: str, output_dir: str):
+    client0 = ProtectionDomain(sdf, "client0", "client0.elf", priority=1)
+    client1 = ProtectionDomain(sdf, "client1", "client1.elf", priority=1)
 
-    if board.arch == SystemDescription.Arch.X86_64:
-        serial_port = SystemDescription.IoPort(0x3F8, 8, 0)
-        serial_driver.add_ioport(serial_port)
-
-        # The serial device does not located on PCIe and the interrupts are
-        # conventionally configured by BIOS. The IRQ number can be read from
-        # Linux or APCI tables.
-        serial_irq = SystemDescription.IrqIoapic(0, 4, 0, id=1)
-        serial_driver.add_irq(serial_irq)
-
-    client0 = ProtectionDomain("client0", "client0.elf", priority=1)
-    client1 = ProtectionDomain("client1", "client1.elf", priority=1)
-
-    serial_node = None
-    if dtb is not None:
-        serial_node = dtb.node(board.serial)
-        assert serial_node is not None
-
-    baud_rate = board.baud_rate
-
-    serial_system = Sddf.Serial(
+    serial = sDDFSerial(
         sdf,
-        serial_node,
-        serial_driver,
-        serial_virt_tx,
-        virt_rx=serial_virt_rx,
+        board.serial.compatible,
+        board.serial.node_path,
+        driver_prio=200,
+        virt_tx_prio=199,
+        allow_rx=True,
         enable_color=True,
-        baud_rate=baud_rate,
+        baud_rate=board.baud_rate if board.baud_rate else 115200,
     )
-    serial_system.add_client(client0)
-    serial_system.add_client(client1)
 
-    pds = [
-        serial_driver,
-        serial_virt_tx,
-        serial_virt_rx,
-        client0,
-        client1,
-    ]
-    for pd in pds:
-        sdf.add_pd(pd)
+    for pd in [client0, client1]:
+        serial.add_client(pd)
 
-    assert serial_system.connect()
-    assert serial_system.serialise_config(output_dir)
-
-    with open(f"{output_dir}/{sdf_file}", "w+") as f:
-        f.write(sdf.render())
+    sdf.make_config_structs()
+    out_file = f"{output_dir}/{sdf_file}"
+    print(f"Saving to {out_file}")
+    sdf.write_xml_file(out_file)
 
 
 if __name__ == "__main__":
@@ -83,13 +46,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     board = next(filter(lambda b: b.name == args.board, BOARDS))
+    if board.arch != x86_64:
+        dtb = DeviceTreeBlob(args.dtb)
+    else:
+        dtb = None
+    sdf = System(board.arch, board.paddr_top, dtb)
 
-    sdf = SystemDescription(board.arch, board.paddr_top)
-    sddf = Sddf(args.sddf)
-
-    dtb = None
-    if board.arch != SystemDescription.Arch.X86_64:
-        with open(args.dtb, "rb") as f:
-            dtb = DeviceTree(f.read())
-
-    generate(args.sdf, args.output, dtb)
+    generate(args.sdf, args.output)

--- a/examples/serial/serial.mk
+++ b/examples/serial/serial.mk
@@ -85,11 +85,11 @@ else
 	$(PYTHON) $(METAPROGRAM) --sddf $(SDDF) --board $(MICROKIT_BOARD) --output . --sdf $(SYSTEM_FILE)
 endif
 	$(OBJCOPY) --update-section .device_resources=serial_driver_device_resources.data serial_driver.elf
-	$(OBJCOPY) --update-section .serial_driver_config=serial_driver_config.data serial_driver.elf
-	$(OBJCOPY) --update-section .serial_virt_rx_config=serial_virt_rx.data serial_virt_rx.elf
-	$(OBJCOPY) --update-section .serial_virt_tx_config=serial_virt_tx.data serial_virt_tx.elf
-	$(OBJCOPY) --update-section .serial_client_config=serial_client_client0.data client0.elf
-	$(OBJCOPY) --update-section .serial_client_config=serial_client_client1.data client1.elf
+	$(OBJCOPY) --update-section .serial_driver_config=serial_driver_serial_driver_config.data serial_driver.elf
+	$(OBJCOPY) --update-section .serial_virt_rx_config=serial_virt_rx_serial_virt_rx_config.data serial_virt_rx.elf
+	$(OBJCOPY) --update-section .serial_virt_tx_config=serial_virt_tx_serial_virt_tx_config.data serial_virt_tx.elf
+	$(OBJCOPY) --update-section .serial_client_config=client0_serial_client_config.data client0.elf
+	$(OBJCOPY) --update-section .serial_client_config=client1_serial_client_config.data client1.elf
 	touch $@
 
 $(IMAGE_FILE) $(REPORT_FILE): $(IMAGES) $(SYSTEM_FILE)

--- a/include/sddf/resources/device.h
+++ b/include/sddf/resources/device.h
@@ -26,7 +26,7 @@ typedef struct device_irq_resource {
 } device_irq_resource_t;
 
 typedef struct device_resources {
-    char magic[5];
+    char magic[DEVICE_MAGIC_LEN];
     uint8_t num_regions;
     uint8_t num_irqs;
     device_region_resource_t regions[DEVICE_MAX_REGIONS];

--- a/include/sddf/resources/device.h
+++ b/include/sddf/resources/device.h
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include <sddf/resources/common.h>
 
-#define DEVICE_MAGIC_LEN 5
+#define DEVICE_MAGIC_LEN 6
 static char DEVICE_MAGIC[DEVICE_MAGIC_LEN] = { 's', 'D', 'D', 'F', 0x1 };
 
 #define DEVICE_MAX_REGIONS 64

--- a/include/sddf/serial/config.h
+++ b/include/sddf/serial/config.h
@@ -13,7 +13,7 @@
 #define SDDF_SERIAL_MAX_CLIENTS 64
 #define SDDF_SERIAL_BEGIN_STR_MAX_LEN 128
 
-#define SDDF_SERIAL_MAGIC_LEN 5
+#define SDDF_SERIAL_MAGIC_LEN 6
 static char SDDF_SERIAL_MAGIC[SDDF_SERIAL_MAGIC_LEN] = { 's', 'D', 'D', 'F', 0x3 };
 
 typedef struct serial_connection_resource {


### PR DESCRIPTION
Based on https://github.com/au-ts/sddf/pull/775, this PR adds the Acacia serial module and updates the example to use it. We also change the magic field length to have a zero terminator since this is required with Acacia.