### PR TITLE
vSwitch: dynamic ACL rule

### DIFF
--- a/examples/vswitch/README.md
+++ b/examples/vswitch/README.md
@@ -11,10 +11,17 @@ The example has a similar set up to the [echo
 server](/examples/echo_server/README.md) example, however has four network
 clients which are all clients of the vswitch.
 
-The example also contains a separate `vswitch_orchestrator` PD. It connects
-to the vSwitch and toggles the bidirectional ACL between ports 0 and 1 every 5 seconds.
-Client 0 sends an ICMP probe to client 1 once per second.
-Replies appear in the serial output only while the runtime ACL permits the packets to pass.
+The demo has two parts:
+
+1. All four clients obtain an IP address with DHCP, discover their reachable
+   neighbours, and send each neighbour one ICMP request.
+2. An orchestrator PD (`vswitch_orchestrator`) toggles the port forwarding ACL
+   rules between Client 0 and Client 1, but it will wait until the first part
+   of the demo completes.
+   Clients 0 and 1 notify orchestrator PD after they have completed neighbour
+   discovery. The orchestrator then toggles the ACL between ports 0 and 1 every
+   five seconds. Client 0 sends an ICMP probe to client 1 once per second,
+   so replies appear only while the runtime ACL permits this traffic.
 
 The system architecture of a vswitch client system is described
 [here](/docs/network/vswitch.md).
@@ -38,7 +45,8 @@ DHCP request finished, IP address for netif client0 is: 10.0.2.18
 This indicates that each client has successfully completed DHCP and printed its
 IP address. Clients will then register their IP addresses with the vswitch,
 request their reachable neighbours, request the IP address of each reachable
-neighbour then try to ping each neighbour once.
+neighbour, then try to ping each neighbour once. Once clients 0 and 1 have
+both completed this process, the ACL test begins.
 
 The orchestrator also reports each runtime ACL update, for example:
 

--- a/examples/vswitch/README.md
+++ b/examples/vswitch/README.md
@@ -11,6 +11,11 @@ The example has a similar set up to the [echo
 server](/examples/echo_server/README.md) example, however has four network
 clients which are all clients of the vswitch.
 
+The example also contains a separate `vswitch_orchestrator` PD. It connects
+to the vSwitch and toggles the bidirectional ACL between ports 0 and 1 every 5 seconds.
+Client 0 sends an ICMP probe to client 1 once per second.
+Replies appear in the serial output only while the runtime ACL permits the packets to pass.
+
 The system architecture of a vswitch client system is described
 [here](/docs/network/vswitch.md).
 
@@ -34,6 +39,14 @@ This indicates that each client has successfully completed DHCP and printed its
 IP address. Clients will then register their IP addresses with the vswitch,
 request their reachable neighbours, request the IP address of each reachable
 neighbour then try to ping each neighbour once.
+
+The orchestrator also reports each runtime ACL update, for example:
+
+```
+vSwitch ACL: port 0 <-> port 1 is disabled
+vSwitch ACL: port 0 <-> port 1 is enabled
+ICMP reply matched on netif client0 peer=1 seq=18 from 10.0.2.17
+```
 
 Here is the output from client 0, which has permissions to contact each of it's
 three neighbours:

--- a/examples/vswitch/client.c
+++ b/examples/vswitch/client.c
@@ -48,6 +48,10 @@ static neighbors_t neighbors[SDDF_NET_MAX_CLIENTS];
 #define ACL_TEST_PORT1 1
 #define ACL_TEST_INTERVAL_TICKS (NS_IN_S / (LWIP_TICK_MS * NS_IN_MS))
 
+#define ORCHESTRATOR_CHANNEL 60
+
+static bool orchestrator_notified;
+
 static uint8_t vswitch_client_id = SDDF_NET_MAX_CLIENTS;
 static uint8_t acl_test_tick_count;
 
@@ -109,6 +113,25 @@ static void query_ips()
 
         neighbors[i].icmp_ctx.ip_addr = sddf_get_mr(VSWITCH_REQ_RET_IP_ADDR);
     }
+}
+
+static void notify_orchestrator_when_ready()
+{
+    /* We use Client 0/1 as the demonstrator for the ACL test */
+    if (orchestrator_notified || vswitch_client_id > ACL_TEST_PORT1) {
+        return;
+    }
+
+    for (uint8_t i = 0; i < SDDF_NET_MAX_CLIENTS; i++) {
+        if (neighbors[i].pingable && !neighbors[i].icmp_ctx.ip_addr) {
+            return;
+        }
+    }
+
+    sddf_notify(ORCHESTRATOR_CHANNEL);
+
+    orchestrator_notified = true;
+    sddf_printf("Client %s completed neighbour discovery\n", sddf_get_pd_name());
 }
 
 /**
@@ -187,6 +210,7 @@ void notified(sddf_channel ch)
         if (tick_count == 50) {
             query_ips();
             ping_neighbors();
+            notify_orchestrator_when_ready();
             tick_count = 0;
         }
         send_acl_test_probe();

--- a/examples/vswitch/client.c
+++ b/examples/vswitch/client.c
@@ -44,6 +44,12 @@ typedef struct neighbors {
 static neighbors_t neighbors[SDDF_NET_MAX_CLIENTS];
 
 #define LWIP_TICK_MS 100
+#define ACL_TEST_PORT0 0
+#define ACL_TEST_PORT1 1
+#define ACL_TEST_INTERVAL_TICKS (NS_IN_S / (LWIP_TICK_MS * NS_IN_MS))
+
+static uint8_t vswitch_client_id = SDDF_NET_MAX_CLIENTS;
+static uint8_t acl_test_tick_count;
 
 /**
  * Pings all other reachable vswitch clients exactly once, after their IP
@@ -58,6 +64,27 @@ static void ping_neighbors()
         send_icmp_request(&neighbors[i].icmp_ctx, i);
         neighbors[i].icmp_ctx.pinged = true;
     }
+}
+
+/* Client 0 probes client 1 once per second as an ACL data-plane test. */
+static void send_acl_test_probe()
+{
+    /* Only Client 0 can begin the test */
+    if (vswitch_client_id != ACL_TEST_PORT0) {
+        return;
+    }
+
+    if (++acl_test_tick_count < ACL_TEST_INTERVAL_TICKS) {
+        return;
+    }
+    acl_test_tick_count = 0;
+
+    icmp_context_t *ctx = &neighbors[ACL_TEST_PORT1].icmp_ctx;
+    if (!neighbors[ACL_TEST_PORT1].pingable || !ctx->ip_addr) {
+        return;
+    }
+    /* Replies are logged by the ICMP receive callback when the ACL permits them. */
+    send_icmp_request(ctx, ACL_TEST_PORT1);
 }
 
 /**
@@ -140,6 +167,7 @@ void init(void)
         sddf_printf("Client %s could not query vswitch state!\n", sddf_get_pd_name());
     }
 
+    vswitch_client_id = sddf_get_mr(VSWITCH_QUERY_RET_CLIENT_ID);
     uint64_t reachable_neighbours = sddf_get_mr(VSWITCH_QUERY_RET_REACHABLE_BITMAP);
     for (uint8_t i = 0; i < SDDF_NET_MAX_CLIENTS; i++) {
         neighbors[i].pingable = reachable_neighbours & ((uint64_t)1 << i);
@@ -161,6 +189,7 @@ void notified(sddf_channel ch)
             ping_neighbors();
             tick_count = 0;
         }
+        send_acl_test_probe();
     } else if (ch == serial_config.tx.id || ch == net_config.tx.id) {
         // Nothing to do
     } else {

--- a/examples/vswitch/meta.py
+++ b/examples/vswitch/meta.py
@@ -194,6 +194,10 @@ def generate(
 
     lwip_clients = [Sddf.Lwip(sdf, net_system, client) for client, _ in clients]
 
+    # We use Client 0/1 to demonstrate how orchestrator toggles ACL rules
+    sdf.add_channel(Channel(clients[0][0], vswitch_orchestrator, a_id=60, b_id=60))
+    sdf.add_channel(Channel(clients[1][0], vswitch_orchestrator, a_id=60, b_id=61))
+
     # Echo server protection domains
     pds = [
         uart_driver,

--- a/examples/vswitch/meta.py
+++ b/examples/vswitch/meta.py
@@ -152,9 +152,18 @@ def generate(
     net_virt_rx = ProtectionDomain("net_virt_rx", "network_virt_rx.elf", priority=99)
 
     vswitch = ProtectionDomain("net_vswitch", "network_vswitch.elf", priority=97)
+    vswitch_orchestrator = ProtectionDomain(
+        "vswitch_orchestrator", "vswitch_orchestrator.elf", priority=96
+    )
 
     net_system = Sddf.Net(
-        sdf, ethernet_node, ethernet_driver, net_virt_tx, net_virt_rx, vswitch=vswitch
+        sdf,
+        ethernet_node,
+        ethernet_driver,
+        net_virt_tx,
+        net_virt_rx,
+        vswitch=vswitch,
+        vswitch_orchestrator=vswitch_orchestrator,
     )
 
     client0_elf = copy_elf("client", "client", 0)
@@ -188,10 +197,12 @@ def generate(
     serial_system.add_client(client1)
     serial_system.add_client(client2)
     serial_system.add_client(client3)
+    serial_system.add_client(vswitch_orchestrator)
     timer_system.add_client(client0)
     timer_system.add_client(client1)
     timer_system.add_client(client2)
     timer_system.add_client(client3)
+    timer_system.add_client(vswitch_orchestrator)
     net_system.add_client_with_copier(client0, client0_net_copier, vswitch=True)
     net_system.add_client_with_copier(client1, client1_net_copier, vswitch=True)
     net_system.add_client_with_copier(client2, client2_net_copier, vswitch=True)
@@ -210,6 +221,7 @@ def generate(
         net_virt_tx,
         net_virt_rx,
         vswitch,
+        vswitch_orchestrator,
         client0,
         client0_net_copier,
         client1,

--- a/examples/vswitch/meta.py
+++ b/examples/vswitch/meta.py
@@ -49,6 +49,21 @@ def update_elf_section(elf_name: str, section_name: str, data_name: str):
     )
 
 
+def create_client(client_number: int):
+    client_elf = copy_elf("client", "client", client_number)
+    client = ProtectionDomain(
+        f"client{client_number}", client_elf, priority=96, budget=20000
+    )
+    net_copier = ProtectionDomain(
+        f"client{client_number}_net_copier",
+        f"network_copy{client_number}.elf",
+        priority=98,
+        budget=20000,
+    )
+
+    return client, net_copier
+
+
 def generate(
     sdf_file: str,
     output_dir: str,
@@ -165,53 +180,19 @@ def generate(
         vswitch=vswitch,
         vswitch_orchestrator=vswitch_orchestrator,
     )
-
-    client0_elf = copy_elf("client", "client", 0)
-    client0 = ProtectionDomain("client0", client0_elf, priority=96, budget=20000)
-    client0_net_copier = ProtectionDomain(
-        "client0_net_copier", "network_copy0.elf", priority=98, budget=20000
-    )
-
-    client1_elf = copy_elf("client", "client", 1)
-    client1 = ProtectionDomain("client1", client1_elf, priority=96, budget=20000)
-    client1_net_copier = ProtectionDomain(
-        "client1_net_copier",
-        "network_copy1.elf",
-        priority=98,
-        budget=20000,
-    )
-
-    client2_elf = copy_elf("client", "client", 2)
-    client2 = ProtectionDomain("client2", client2_elf, priority=96, budget=20000)
-    client2_net_copier = ProtectionDomain(
-        "client2_net_copier", "network_copy2.elf", priority=98, budget=20000
-    )
-
-    client3_elf = copy_elf("client", "client", 3)
-    client3 = ProtectionDomain("client3", client3_elf, priority=96, budget=20000)
-    client3_net_copier = ProtectionDomain(
-        "client3_net_copier", "network_copy3.elf", priority=98, budget=20000
-    )
-
-    serial_system.add_client(client0)
-    serial_system.add_client(client1)
-    serial_system.add_client(client2)
-    serial_system.add_client(client3)
     serial_system.add_client(vswitch_orchestrator)
-    timer_system.add_client(client0)
-    timer_system.add_client(client1)
-    timer_system.add_client(client2)
-    timer_system.add_client(client3)
     timer_system.add_client(vswitch_orchestrator)
-    net_system.add_client_with_copier(client0, client0_net_copier, vswitch=True)
-    net_system.add_client_with_copier(client1, client1_net_copier, vswitch=True)
-    net_system.add_client_with_copier(client2, client2_net_copier, vswitch=True)
-    net_system.add_client_with_copier(client3, client3_net_copier, vswitch=True)
 
-    client0_lib_sddf_lwip = Sddf.Lwip(sdf, net_system, client0)
-    client1_lib_sddf_lwip = Sddf.Lwip(sdf, net_system, client1)
-    client2_lib_sddf_lwip = Sddf.Lwip(sdf, net_system, client2)
-    client3_lib_sddf_lwip = Sddf.Lwip(sdf, net_system, client3)
+    clients = [create_client(client_number) for client_number in range(4)]
+
+    for client, _ in clients:
+        serial_system.add_client(client)
+    for client, _ in clients:
+        timer_system.add_client(client)
+    for client, net_copier in clients:
+        net_system.add_client_with_copier(client, net_copier, vswitch=True)
+
+    lwip_clients = [Sddf.Lwip(sdf, net_system, client) for client, _ in clients]
 
     # Echo server protection domains
     pds = [
@@ -222,14 +203,7 @@ def generate(
         net_virt_rx,
         vswitch,
         vswitch_orchestrator,
-        client0,
-        client0_net_copier,
-        client1,
-        client1_net_copier,
-        client2,
-        client2_net_copier,
-        client3,
-        client3_net_copier,
+        *(pd for client, net_copier in clients for pd in (client, net_copier)),
         timer_driver,
     ]
     for pd in pds:
@@ -244,26 +218,21 @@ def generate(
     # 1 -> 0, 2, V
     # 2 -> 0, 1, V
     # 3 -> 0, V
-    net_system.add_acl_rule(client0, client1, True, True)
-    net_system.add_acl_rule(client0, client2, True, True)
-    net_system.add_acl_rule(client0, client3, True, True)
-    net_system.add_acl_rule(client0, net_virt_tx, True, True)
-    net_system.add_acl_rule(client1, client2, True, True)
-    net_system.add_acl_rule(client1, net_virt_tx, True, True)
-    net_system.add_acl_rule(client2, net_virt_tx, True, True)
-    net_system.add_acl_rule(client3, net_virt_tx, True, True)
+    net_system.add_acl_rule(clients[0][0], clients[1][0], True, True)
+    net_system.add_acl_rule(clients[0][0], clients[2][0], True, True)
+    net_system.add_acl_rule(clients[0][0], clients[3][0], True, True)
+    net_system.add_acl_rule(clients[0][0], net_virt_tx, True, True)
+    net_system.add_acl_rule(clients[1][0], clients[2][0], True, True)
+    net_system.add_acl_rule(clients[1][0], net_virt_tx, True, True)
+    net_system.add_acl_rule(clients[2][0], net_virt_tx, True, True)
+    net_system.add_acl_rule(clients[3][0], net_virt_tx, True, True)
 
     assert net_system.serialise_config(output_dir)
     assert timer_system.connect()
     assert timer_system.serialise_config(output_dir)
-    assert client0_lib_sddf_lwip.connect()
-    assert client0_lib_sddf_lwip.serialise_config(output_dir)
-    assert client1_lib_sddf_lwip.connect()
-    assert client1_lib_sddf_lwip.serialise_config(output_dir)
-    assert client2_lib_sddf_lwip.connect()
-    assert client2_lib_sddf_lwip.serialise_config(output_dir)
-    assert client3_lib_sddf_lwip.connect()
-    assert client3_lib_sddf_lwip.serialise_config(output_dir)
+    for lwip in lwip_clients:
+        assert lwip.connect()
+        assert lwip.serialise_config(output_dir)
 
     if board.name == "rpi4b_1gb":
         update_elf_section(

--- a/examples/vswitch/orchestrator.c
+++ b/examples/vswitch/orchestrator.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <os/sddf.h>
+#include <sddf/network/config.h>
+#include <sddf/network/vswitch.h>
+#include <sddf/serial/config.h>
+#include <sddf/serial/queue.h>
+#include <sddf/timer/client.h>
+#include <sddf/timer/config.h>
+#include <sddf/util/printf.h>
+
+/* Allow DHCP and client IP discovery to complete before the first ACL change. */
+#define ACL_UPDATE_INTERVAL_NS (5 * NS_IN_S)
+
+__attribute__((__section__(".net_vswitch_orchestrator_config"))) net_vswitch_orchestrator_config_t vswitch_config;
+__attribute__((__section__(".serial_client_config"))) serial_client_config_t serial_config;
+__attribute__((__section__(".timer_client_config"))) timer_client_config_t timer_config;
+
+static serial_queue_handle_t serial_tx_queue_handle;
+static bool acl_enabled = true;
+
+/* Update both directions of the ACL between two vSwitch ports. */
+static void set_acl(uint8_t port0, uint8_t port1, bool enabled)
+{
+    sddf_set_mr(VSWITCH_ACL_PORT0, port0);
+    sddf_set_mr(VSWITCH_ACL_PORT1, port1);
+    sddf_set_mr(VSWITCH_ACL_VALUE, enabled);
+    sddf_ppcall(vswitch_config.vswitch_id, seL4_MessageInfo_new(VSWITCH_SET_ACL, 0, 0, VSWITCH_ACL_NUM_ARGS));
+
+    vswitch_err_t err = sddf_get_mr(VSWITCH_ACL_RET_ERR);
+    if (err == VSWITCH_ERR_OKAY) {
+        sddf_printf("vSwitch ACL: port %u <-> port %u is %s\n", port0, port1, enabled ? "enabled" : "disabled");
+    } else {
+        sddf_printf("vSwitch ACL update failed: %u\n", err);
+    }
+}
+
+void init(void)
+{
+    assert(net_config_check_magic(&vswitch_config));
+    assert(serial_config_check_magic(&serial_config));
+    assert(timer_config_check_magic(&timer_config));
+
+    serial_queue_init(&serial_tx_queue_handle, serial_config.tx.queue.vaddr, serial_config.tx.data.size,
+                      serial_config.tx.data.vaddr);
+    serial_putchar_init(serial_config.tx.id, &serial_tx_queue_handle);
+
+    sddf_printf("vSwitch orchestrator: toggling ACL 0 <-> 1 every 5 seconds\n");
+    sddf_timer_set_timeout(timer_config.driver_id, ACL_UPDATE_INTERVAL_NS);
+}
+
+void notified(sddf_channel ch)
+{
+    if (ch == timer_config.driver_id) {
+        acl_enabled = !acl_enabled;
+        set_acl(0, 1, acl_enabled);
+        sddf_timer_set_timeout(timer_config.driver_id, ACL_UPDATE_INTERVAL_NS);
+    } else if (ch != serial_config.tx.id) {
+        sddf_dprintf("vSwitch orchestrator: unexpected notification %u\n", ch);
+    }
+}

--- a/examples/vswitch/orchestrator.c
+++ b/examples/vswitch/orchestrator.c
@@ -15,6 +15,9 @@
 
 /* Allow DHCP and client IP discovery to complete before the first ACL change. */
 #define ACL_UPDATE_INTERVAL_NS (5 * NS_IN_S)
+#define ACL_TEST_NUM_CLIENTS 2
+#define CLIENT0_CHANNEL 60
+#define CLIENT1_CHANNEL 61
 
 __attribute__((__section__(".net_vswitch_orchestrator_config"))) net_vswitch_orchestrator_config_t vswitch_config;
 __attribute__((__section__(".serial_client_config"))) serial_client_config_t serial_config;
@@ -22,6 +25,35 @@ __attribute__((__section__(".timer_client_config"))) timer_client_config_t timer
 
 static serial_queue_handle_t serial_tx_queue_handle;
 static bool acl_enabled = true;
+static bool clients_ready[ACL_TEST_NUM_CLIENTS];
+
+static bool all_clients_ready()
+{
+    for (uint8_t i = 0; i < ACL_TEST_NUM_CLIENTS; i++) {
+        if (!clients_ready[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/* Wait for Client 0 and 1 to claim ready for ACL tests */
+static bool handle_client_ready(sddf_channel ch)
+{
+    if (ch == CLIENT0_CHANNEL) {
+        clients_ready[0] = true;
+        sddf_printf("vSwitch orchestrator: client 0 completed neighbour discovery\n");
+        return true;
+    }
+    if (ch == CLIENT1_CHANNEL) {
+        clients_ready[1] = true;
+        sddf_printf("vSwitch orchestrator: client 1 completed neighbour discovery\n");
+        return true;
+    }
+
+    return false;
+}
 
 /* Update both directions of the ACL between two vSwitch ports. */
 static void set_acl(uint8_t port0, uint8_t port1, bool enabled)
@@ -56,10 +88,14 @@ void init(void)
 void notified(sddf_channel ch)
 {
     if (ch == timer_config.driver_id) {
-        acl_enabled = !acl_enabled;
-        set_acl(0, 1, acl_enabled);
+        if (all_clients_ready()) {
+            acl_enabled = !acl_enabled;
+            set_acl(0, 1, acl_enabled);
+        }
         sddf_timer_set_timeout(timer_config.driver_id, ACL_UPDATE_INTERVAL_NS);
-    } else if (ch != serial_config.tx.id) {
+    } else if (ch == serial_config.tx.id) {
+        // Nothing to do
+    } else if (!handle_client_ready(ch)) {
         sddf_dprintf("vSwitch orchestrator: unexpected notification %u\n", ch);
     }
 }

--- a/examples/vswitch/vswitch.mk
+++ b/examples/vswitch/vswitch.mk
@@ -49,7 +49,8 @@ vpath %.c ${SDDF} ${VSWITCH}
 
 IMAGES := eth_driver.elf client.elf network_virt_rx.elf \
 	  network_virt_tx.elf network_copy.elf timer_driver.elf \
-	  serial_driver.elf serial_virt_tx.elf network_vswitch.elf
+	  serial_driver.elf serial_virt_tx.elf network_vswitch.elf \
+	  vswitch_orchestrator.elf
 
 
 CFLAGS += \
@@ -72,12 +73,16 @@ LIBS := --start-group -lmicrokit -Tmicrokit.ld libsddf_util_debug.a \
 	--end-group
 
 VSWITCH_OBJS := client.o icmp.o
+ORCHESTRATOR_OBJS := orchestrator.o
 
-DEPS := $(VSWITCH_OBJS:.o=.d)
+DEPS := $(VSWITCH_OBJS:.o=.d) $(ORCHESTRATOR_OBJS:.o=.d)
 
 all: loader.img
 
 client.elf: $(VSWITCH_OBJS) libsddf_util.a lib_sddf_lwip_client.a
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+vswitch_orchestrator.elf: $(ORCHESTRATOR_OBJS) libsddf_util.a
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 # Need to build libsddf_util_debug.a because it's included in LIBS
@@ -127,6 +132,9 @@ endif
 	$(OBJCOPY) --update-section .lib_sddf_lwip_config=lib_sddf_lwip_config_client2.data client2.elf
 	$(OBJCOPY) --update-section .lib_sddf_lwip_config=lib_sddf_lwip_config_client3.data client3.elf
 	$(OBJCOPY) --update-section .net_vswitch_config=net_vswitch.data network_vswitch.elf
+	$(OBJCOPY) --update-section .net_vswitch_orchestrator_config=net_vswitch_orchestrator.data vswitch_orchestrator.elf
+	$(OBJCOPY) --update-section .serial_client_config=serial_client_vswitch_orchestrator.data vswitch_orchestrator.elf
+	$(OBJCOPY) --update-section .timer_client_config=timer_client_vswitch_orchestrator.data vswitch_orchestrator.elf
 	touch $@
 
 ${IMAGE_FILE} $(REPORT_FILE): $(IMAGES) $(SYSTEM_FILE)

--- a/include/sddf/network/config.h
+++ b/include/sddf/network/config.h
@@ -135,6 +135,12 @@ typedef struct net_vswitch_config {
      * (ports[0].tx.num_buffers + ... + ports[num_ports].tx.num_buffers) * sizeof(uin8_t) bytes
      */
     region_resource_t buffer_metadata;
+
+    /**
+     * Optional protected-procedure-call channel used by a vSwitch
+     * orchestrator. Zero when no orchestrator is connected.
+     */
+    uint8_t orchestrator_id;
 } net_vswitch_config_t;
 
 static inline bool net_config_check_magic(void *config)

--- a/include/sddf/network/config.h
+++ b/include/sddf/network/config.h
@@ -143,6 +143,11 @@ typedef struct net_vswitch_config {
     uint8_t orchestrator_id;
 } net_vswitch_config_t;
 
+typedef struct net_vswitch_orchestrator_config {
+    char magic[SDDF_NET_MAGIC_LEN];
+    uint8_t vswitch_id;
+} net_vswitch_orchestrator_config_t;
+
 static inline bool net_config_check_magic(void *config)
 {
     char *magic = (char *)config;

--- a/include/sddf/network/vswitch.h
+++ b/include/sddf/network/vswitch.h
@@ -19,6 +19,10 @@ typedef enum {
     VSWITCH_ERR_VIRT_PORT,
     /* Unsupported operation */
     VSWITCH_ERR_INVALID_OPERATION,
+    /* Port ID is outside the configured port range */
+    VSWITCH_ERR_INVALID_PORT,
+    /* ACL value must be either zero or one */
+    VSWITCH_ERR_INVALID_ACL_VALUE,
 } vswitch_err_t;
 
 /**
@@ -81,3 +85,27 @@ typedef enum {
     /* Number of return arguments */
     VSWITCH_REQ_RET_NUM_ARGS,
 } vswitch_req_ret_args_t;
+
+/**
+ * Enable or disable bidirectional traffic between two vSwitch ports.
+ * This operation is only available to the configured vSwitch orchestrator.
+ */
+#define VSWITCH_SET_ACL 3
+
+typedef enum {
+    /* First vSwitch port whose ACL entry will be updated */
+    VSWITCH_ACL_PORT0 = 0,
+    /* Second vSwitch port whose ACL entry will be updated */
+    VSWITCH_ACL_PORT1,
+    /* Whether traffic is allowed (0 to deny, 1 to allow) */
+    VSWITCH_ACL_VALUE,
+    /* Number of arguments */
+    VSWITCH_ACL_NUM_ARGS,
+} vswitch_acl_args_t;
+
+typedef enum {
+    /* Success or failure of the operation */
+    VSWITCH_ACL_RET_ERR = 0,
+    /* Number of return arguments */
+    VSWITCH_ACL_RET_NUM_ARGS,
+} vswitch_acl_ret_args_t;

--- a/network/components/vswitch.c
+++ b/network/components/vswitch.c
@@ -187,6 +187,20 @@ static bool vswitch_can_send_to(uint8_t src_id, uint8_t dst_id)
     return state.allow_list[src_id] & ((uint64_t)1 << dst_id);
 }
 
+static void vswitch_set_acl(uint8_t port0, uint8_t port1, bool allow)
+{
+    uint64_t port0_bit = (uint64_t)1 << port0;
+    uint64_t port1_bit = (uint64_t)1 << port1;
+
+    if (allow) {
+        state.allow_list[port0] |= port1_bit;
+        state.allow_list[port1] |= port0_bit;
+    } else {
+        state.allow_list[port0] &= ~port1_bit;
+        state.allow_list[port1] &= ~port0_bit;
+    }
+}
+
 static uint8_t mac_addr_find(const mac_addr_t *dest_macaddr)
 {
     mac_addr_t *mac;
@@ -404,6 +418,32 @@ void init(void)
 
 seL4_MessageInfo_t protected(sddf_channel ch, seL4_MessageInfo_t msginfo)
 {
+    if (ch == config.orchestrator_id) {
+        if (microkit_msginfo_get_label(msginfo) != VSWITCH_SET_ACL) {
+            LOG_VSWITCH_ERR("Received invalid orchestrator operation\n");
+            sddf_set_mr(VSWITCH_ACL_RET_ERR, VSWITCH_ERR_INVALID_OPERATION);
+            return seL4_MessageInfo_new(0, 0, 0, VSWITCH_ACL_RET_NUM_ARGS);
+        }
+
+        seL4_Word port0 = sddf_get_mr(VSWITCH_ACL_PORT0);
+        seL4_Word port1 = sddf_get_mr(VSWITCH_ACL_PORT1);
+        seL4_Word allow = sddf_get_mr(VSWITCH_ACL_VALUE);
+
+        if (port0 >= config.num_ports || port1 >= config.num_ports || port0 == port1) {
+            sddf_set_mr(VSWITCH_ACL_RET_ERR, VSWITCH_ERR_INVALID_PORT);
+            return seL4_MessageInfo_new(0, 0, 0, VSWITCH_ACL_RET_NUM_ARGS);
+        }
+        if (allow > 1) {
+            sddf_set_mr(VSWITCH_ACL_RET_ERR, VSWITCH_ERR_INVALID_ACL_VALUE);
+            return seL4_MessageInfo_new(0, 0, 0, VSWITCH_ACL_RET_NUM_ARGS);
+        }
+
+        vswitch_set_acl((uint8_t)port0, (uint8_t)port1, allow != 0);
+        LOG_VSWITCH("Orchestrator set ports %u and %u to %u\n", port0, port1, allow);
+        sddf_set_mr(VSWITCH_ACL_RET_ERR, VSWITCH_ERR_OKAY);
+        return seL4_MessageInfo_new(0, 0, 0, VSWITCH_ACL_RET_NUM_ARGS);
+    }
+
     uint8_t ppc_client = 0;
     while (ppc_client < config.num_ports) {
         if (ch == config.ports[ppc_client].tx.id) {


### PR DESCRIPTION
This commit enables the vSwitch to adjust ACL rules for port forwarding dynamically.

What's new:
+ A new vSwitch operation `VSWITCH_SET_ACL` which set the port connection state `y|n` between `port(x)` and `port(y)`
+ An example orchestrator PD that changes the ACL rules dynamically by PPC-ing the vSwitch at the system's runtime
+ The example of how the network subsystem reacts when the orchestrator PD triggers ACL rule changes by invoking the vSwitch periodically.

Deps:
+ sdfgen with orchestrator connection support (https://github.com/au-ts/microkit_sdf_gen/pull/37)